### PR TITLE
Removed useless code.

### DIFF
--- a/examples/Obj-C SDK/Obj-C SDK/ViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/ViewController.m
@@ -90,9 +90,4 @@
     [view addConstraints:[NSArray arrayWithObjects:horizontalConstraint, verticalConstraint, nil]];
 };
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
-}
-
 @end


### PR DESCRIPTION
There is no need to have: <b>- (void)didReceiveMemoryWarning </b> implemented since we are not doing anything inside. Simply removing the code is equivalent to current implementation.