### PR TITLE
Add: Pods to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ xcuserdata/
 *.xccheckout
 DerivedData/
 *~
+Pods/


### PR DESCRIPTION
In case you use Pods, and do not store them in git, there is a point to add them ti .gitignore