### PR TITLE
Add ObjectMapper as a linked library instead of copy framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.5.1] 2016-06-14
+### Fixed
+
+- [Issue #47](https://github.com/uber/rides-ios-sdk/issues/47) SSO fails for correctly configured China apps. SDK now sends the correct Region string for SSO 
+
 ## [0.5.0] 2016-06-2
 ### Added
 

--- a/UberRides.podspec
+++ b/UberRides.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "UberRides"
-  s.version      = "0.5.0"
+  s.version      = "0.5.1"
   s.summary      = "The Official Uber Rides iOS SDK."
   s.description  = <<-DESC
     This Swift library allows you to integrate Uber into your iOS app. It is designed to make it quick and easy to add a 'Request a Ride' button in your application, seamlessly connecting your users with Uber.

--- a/source/UberRides.xcodeproj/project.pbxproj
+++ b/source/UberRides.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3A66B4721D1F38D600B4F181 /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCA459AF1D000813003CBA3D /* ObjectMapper.framework */; };
 		AC0404791BFACD1D00AC1501 /* UberRides.h in Headers */ = {isa = PBXBuildFile; fileRef = AC0404781BFACD1D00AC1501 /* UberRides.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AC0404801BFACD1D00AC1501 /* UberRides.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC0404751BFACD1D00AC1501 /* UberRides.framework */; };
 		AC0404851BFACD1D00AC1501 /* UberRidesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0404841BFACD1D00AC1501 /* UberRidesTests.swift */; };
@@ -296,6 +297,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3A66B4721D1F38D600B4F181 /* ObjectMapper.framework in Frameworks */,
 				AC0404801BFACD1D00AC1501 /* UberRides.framework in Frameworks */,
 				DCA459D41D003EFC003CBA3D /* OHHTTPStubs.framework in Frameworks */,
 			);
@@ -546,7 +548,6 @@
 				AC0404711BFACD1D00AC1501 /* Frameworks */,
 				AC0404721BFACD1D00AC1501 /* Headers */,
 				AC0404731BFACD1D00AC1501 /* Resources */,
-				DCA459B11D000825003CBA3D /* Copy Carthage Frameworks */,
 			);
 			buildRules = (
 			);
@@ -656,21 +657,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		DCA459B11D000825003CBA3D /* Copy Carthage Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/../Carthage/Build/iOS/ObjectMapper.framework",
-			);
-			name = "Copy Carthage Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
 		DCA459D51D003F0F003CBA3D /* Copy Carthage Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/source/UberRides/Configuration.swift
+++ b/source/UberRides/Configuration.swift
@@ -120,9 +120,9 @@ import WebKit
     public static var regionString: String {
         switch region {
         case .China:
-            return "China"
+            return "china"
         case .Default:
-            return "Default"
+            return "default"
         }
     }
     

--- a/source/UberRides/Info.plist
+++ b/source/UberRides/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.0</string>
+	<string>0.5.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/source/UberRidesTests/AuthenticationURLUtilityTests.swift
+++ b/source/UberRidesTests/AuthenticationURLUtilityTests.swift
@@ -49,7 +49,7 @@ class AuthenticationURLUtilityTests: XCTestCase {
         let expectedClientID = "testClientID"
         let expectedAppName = "My Awesome App"
         let expectedCallbackURI = "testURI://uberConnectNative"
-        let expectedLoginType = "Default"
+        let expectedLoginType = "default"
         let expectedSDK = "ios"
         let expectedSDKVersion = versionNumber
         
@@ -78,7 +78,7 @@ class AuthenticationURLUtilityTests: XCTestCase {
         let expectedClientID = "testClientID"
         let expectedAppName = "My Awesome App"
         let expectedCallbackURI = "testURI://uberConnectNative"
-        let expectedLoginType = "Default"
+        let expectedLoginType = "default"
         let expectedSDK = "ios"
         let expectedSDKVersion = versionNumber
         
@@ -109,7 +109,7 @@ class AuthenticationURLUtilityTests: XCTestCase {
         let expectedClientID = "testClientID"
         let expectedAppName = "My Awesome App"
         let expectedCallbackURI = "testURI://uberConnectNative"
-        let expectedLoginType = "China"
+        let expectedLoginType = "china"
         let expectedSDK = "ios"
         let expectedSDKVersion = versionNumber
         
@@ -140,7 +140,7 @@ class AuthenticationURLUtilityTests: XCTestCase {
         let expectedClientID = "testClientID"
         let expectedAppName = "My Awesome App"
         let expectedCallbackURI = "testURI://uberConnectNative"
-        let expectedLoginType = "China"
+        let expectedLoginType = "china"
         let expectedSDK = "ios"
         let expectedSDKVersion = versionNumber
         


### PR DESCRIPTION
Currently, using Carthage, it's not possible to upload an app to iTunesConnect. When uploading there are errors for invalid bundle.

http://stackoverflow.com/questions/25777958/validation-error-invalid-bundle-the-bundle-at-contains-disallowed-file-fr

Frameworks do not require Copy Carthage but require Linked Libraries. See the instructions from Carthage's Readme.

Closes #49 