### PR TITLE
Issue#101 Old User Data accessible

### DIFF
--- a/source/UberRides/TokenManager.swift
+++ b/source/UberRides/TokenManager.swift
@@ -97,7 +97,7 @@ import Foundation
         keychainWrapper.setAccessGroup(accessGroup)
         let success = keychainWrapper.setObject(accessToken, key: tokenIdentifier)
         if success {
-            NSUserDefaults.standardUserDefaults().setBool(YES, forKey: kCheckFirstRun)
+            NSUserDefaults.standardUserDefaults().setBool(true, forKey: kCheckFirstRun)
             NSUserDefaults.standardUserDefaults().synchronize()
             NSNotificationCenter.defaultCenter().postNotificationName(TokenManagerDidSaveTokenNotification, object: self)
         }

--- a/source/UberRidesTests/RidesClientTests.swift
+++ b/source/UberRidesTests/RidesClientTests.swift
@@ -923,6 +923,7 @@ class RidesClientTests: XCTestCase {
         
         keychainHelper.setAccessGroup(tokenGroup)
         keychainHelper.setObject(token, key: tokenKey)
+        saveFirstRunKey()
         defer {
             keychainHelper.deleteObjectForKey(tokenKey)
         }
@@ -962,6 +963,7 @@ class RidesClientTests: XCTestCase {
         
         keychainHelper.setAccessGroup(tokenGroup)
         keychainHelper.setObject(token, key: tokenKey)
+        saveFirstRunKey()
         defer {
             keychainHelper.deleteObjectForKey(tokenKey)
         }
@@ -991,6 +993,7 @@ class RidesClientTests: XCTestCase {
         
         keychainHelper.setAccessGroup(tokenGroup)
         keychainHelper.setObject(token, key: tokenKey)
+        saveFirstRunKey()
         defer {
             keychainHelper.deleteObjectForKey(tokenKey)
         }
@@ -1020,6 +1023,7 @@ class RidesClientTests: XCTestCase {
         
         keychainHelper.setAccessGroup(tokenGroup)
         keychainHelper.setObject(token, key: tokenKey)
+        saveFirstRunKey()
         defer {
             keychainHelper.deleteObjectForKey(tokenKey)
         }
@@ -1082,5 +1086,12 @@ class RidesClientTests: XCTestCase {
         let ridesClient = RidesClient(accessTokenIdentifier: tokenKey)
         let accessToken = ridesClient.fetchAccessToken()
         XCTAssertNil(accessToken)
+    }
+    
+    //MARK: Helper
+    func saveFirstRunKey() {
+        let kCheckFirstRun = "com.uber.checkFirstRun"
+        NSUserDefaults.standardUserDefaults().setBool(true, forKey: kCheckFirstRun)
+        NSUserDefaults.standardUserDefaults().synchronize()
     }
 }


### PR DESCRIPTION
User auth token stored in the keychain, when app deleted and reinstall this data won’t remove and previous user auth token accessed, if it expires it auto refresh the auth token.

Fixes: Store a bool value to user default and check it is first run then remove auth token else previous behaviour.
