### PR TITLE
Swift 3/Xcode 8 conversion

### DIFF
--- a/UberRides.podspec
+++ b/UberRides.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.source_files = ["source/UberRides/*.swift", "source/UberRides/Model/*.swift", "source/UberRides/OAuth/*.swift", "source/UberRides/Utilities/*.swift"]
   s.resource     = "source/UberRides/Resources/**"
   s.requires_arc = true
-  s.dependency 'ObjectMapper', '~> 1.0'
+  s.dependency 'ObjectMapper', '~> 2.0'
 
 end

--- a/source/UberRides.xcodeproj/project.pbxproj
+++ b/source/UberRides.xcodeproj/project.pbxproj
@@ -589,10 +589,12 @@
 				TargetAttributes = {
 					AC0404741BFACD1D00AC1501 = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 					AC04047E1BFACD1D00AC1501 = {
 						CreatedOnToolsVersion = 7.1;
 						DevelopmentTeam = 36UPBWHAQE;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -919,6 +921,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -938,6 +941,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.uber.sdk.UberRides;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -949,6 +953,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.uber.sdk.UberRidesTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -960,6 +965,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.uber.sdk.UberRidesTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/source/UberRides/AppStoreDeeplink.swift
+++ b/source/UberRides/AppStoreDeeplink.swift
@@ -27,7 +27,7 @@ import Foundation
 /**
  *  A Deeplinking object for authenticating a user via the native Uber app
  */
-@objc(UBSDKAppStoreDeeplink) public class AppStoreDeeplink: BaseDeeplink {
+@objc(UBSDKAppStoreDeeplink) open class AppStoreDeeplink: BaseDeeplink {
     
     /**
      Initializes an App Store Deeplink to bring the user to the appstore
@@ -39,11 +39,11 @@ import Foundation
         let domain = "m.uber.com"
         let path = "/sign-up"
         
-        let clientIDQueryItem = NSURLQueryItem(name: "client_id", value: Configuration.getClientID())
+        let clientIDQueryItem = URLQueryItem(name: "client_id", value: Configuration.getClientID())
         
         let userAgent = userAgent ?? "rides-ios-v\(Configuration.sdkVersion)"
         
-        let userAgentQueryItem = NSURLQueryItem(name: "user-agent", value: userAgent)
+        let userAgentQueryItem = URLQueryItem(name: "user-agent", value: userAgent)
         
         let queryItems = [clientIDQueryItem, userAgentQueryItem]
         

--- a/source/UberRides/AuthenticationDeeplink.swift
+++ b/source/UberRides/AuthenticationDeeplink.swift
@@ -27,7 +27,7 @@ import Foundation
 /**
  *  A Deeplinking object for authenticating a user via the native Uber app
  */
-@objc(UBSDKAuthenticationDeeplink) public class AuthenticationDeeplink: BaseDeeplink {
+@objc(UBSDKAuthenticationDeeplink) open class AuthenticationDeeplink: BaseDeeplink {
 
     /**
      Initializes an Authentication Deeplink to request the provided scopes

--- a/source/UberRides/BaseDeeplink.swift
+++ b/source/UberRides/BaseDeeplink.swift
@@ -27,39 +27,39 @@ import Foundation
 /**
  *  A Deeplinking object for authenticating a user via the native Uber app
  */
-@objc(UBSDKBaseDeeplink) public class BaseDeeplink: NSObject, Deeplinking {
+@objc(UBSDKBaseDeeplink) open class BaseDeeplink: NSObject, Deeplinking {
     
     /// The scheme for the auth deeplink
-    public var scheme: String
+    open var scheme: String
     
     /// The domain for the auth deeplink
-    public var domain: String
+    open var domain: String
     
     /// The path for the auth deeplink
-    public var path: String?
+    open var path: String?
     
     /// The array of query items the deeplink will include
-    public var queryItems: [NSURLQueryItem]?
+    open var queryItems: [URLQueryItem]?
     
-    public let deeplinkURL: NSURL
+    open let deeplinkURL: URL
     
-    private var waitingOnSystemPromptResponse = false
-    private var checkingSystemPromptResponse = false
-    private var promptTimer: NSTimer?
-    private var completionWrapper: ((NSError?) -> ()) = { _ in }
+    fileprivate var waitingOnSystemPromptResponse = false
+    fileprivate var checkingSystemPromptResponse = false
+    fileprivate var promptTimer: Timer?
+    fileprivate var completionWrapper: ((NSError?) -> ()) = { _ in }
     
-    @objc public init?(scheme: String, domain: String, path: String?, queryItems: [NSURLQueryItem]?) {
+    @objc public init?(scheme: String, domain: String, path: String?, queryItems: [URLQueryItem]?) {
         self.scheme = scheme
         self.domain = domain
         self.path = path
         self.queryItems = queryItems
         
-        let requestURLComponents = NSURLComponents()
+        var requestURLComponents = URLComponents()
         requestURLComponents.scheme = scheme
         requestURLComponents.host = domain
-        requestURLComponents.path = path
+        requestURLComponents.path = path ?? ""
         requestURLComponents.queryItems = queryItems
-        guard let deeplinkURL = requestURLComponents.URL else {
+        guard let deeplinkURL = requestURLComponents.url else {
             return nil
         }
         self.deeplinkURL = deeplinkURL
@@ -74,9 +74,9 @@ import Foundation
      - parameter completion: The completion block to execute once the deeplink has
      executed. Passes in True if the url was successfully opened, false otherwise.
      */
-    @objc public func execute(completion: ((NSError?) -> ())? = nil) {
+    @objc open func execute(_ completion: ((NSError?) -> ())? = nil) {
         
-        let usingIOS9 = NSProcessInfo().isOperatingSystemAtLeastVersion(NSOperatingSystemVersion(majorVersion: 9, minorVersion: 0, patchVersion: 0))
+        let usingIOS9 = ProcessInfo().isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 9, minorVersion: 0, patchVersion: 0))
         
         if usingIOS9 {
             executeOnIOS9(completion)
@@ -87,13 +87,13 @@ import Foundation
     
     //Mark: Internal Interface
     
-    func executeOnIOS9(completion: ((NSError?) -> ())?) {
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(appWillResignActiveHandler), name: UIApplicationWillResignActiveNotification, object: nil);
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(appDidBecomeActiveHandler), name: UIApplicationDidBecomeActiveNotification, object: nil);
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(appDidEnterBackgroundHandler), name: UIApplicationDidEnterBackgroundNotification, object: nil)
+    func executeOnIOS9(_ completion: ((NSError?) -> ())?) {
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActiveHandler), name: NSNotification.Name.UIApplicationWillResignActive, object: nil);
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActiveHandler), name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil);
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackgroundHandler), name: NSNotification.Name.UIApplicationDidEnterBackground, object: nil)
         
         completionWrapper = { handled in
-            NSNotificationCenter.defaultCenter().removeObserver(self)
+            NotificationCenter.default.removeObserver(self)
             self.promptTimer?.invalidate()
             self.promptTimer = nil
             self.checkingSystemPromptResponse = false
@@ -102,13 +102,13 @@ import Foundation
         }
         
         var error: NSError?
-        if UIApplication.sharedApplication().canOpenURL(deeplinkURL) {
-            let openedURL = UIApplication.sharedApplication().openURL(deeplinkURL)
+        if UIApplication.shared.canOpenURL(deeplinkURL) {
+            let openedURL = UIApplication.shared.openURL(deeplinkURL)
             if !openedURL {
-                error = DeeplinkErrorFactory.errorForType(.UnableToFollow)
+                error = DeeplinkErrorFactory.errorForType(.unableToFollow)
             }
         } else {
-            error = DeeplinkErrorFactory.errorForType(.UnableToOpen)
+            error = DeeplinkErrorFactory.errorForType(.unableToOpen)
         }
         
         if error != nil {
@@ -116,19 +116,19 @@ import Foundation
         }
     }
     
-    func executeOnBelowIOS9(completion: ((NSError?) -> ())?) {
+    func executeOnBelowIOS9(_ completion: ((NSError?) -> ())?) {
         completionWrapper = { handled in
             completion?(handled)
         }
         
         var error: NSError?
-        if UIApplication.sharedApplication().canOpenURL(deeplinkURL) {
-            let openedURL = UIApplication.sharedApplication().openURL(deeplinkURL)
+        if UIApplication.shared.canOpenURL(deeplinkURL) {
+            let openedURL = UIApplication.shared.openURL(deeplinkURL)
             if !openedURL {
-                error = DeeplinkErrorFactory.errorForType(.UnableToFollow)
+                error = DeeplinkErrorFactory.errorForType(.unableToFollow)
             }
         } else {
-            error = DeeplinkErrorFactory.errorForType(.UnableToOpen)
+            error = DeeplinkErrorFactory.errorForType(.unableToOpen)
         }
         
         completionWrapper(error)
@@ -136,7 +136,7 @@ import Foundation
     
     //Mark: App Lifecycle Notifications
     
-    @objc private func appWillResignActiveHandler(notification: NSNotification) {
+    @objc fileprivate func appWillResignActiveHandler(_ notification: Notification) {
         if !waitingOnSystemPromptResponse {
             waitingOnSystemPromptResponse = true
         } else if checkingSystemPromptResponse {
@@ -144,19 +144,19 @@ import Foundation
         }
     }
     
-    @objc private func appDidBecomeActiveHandler(notification: NSNotification) {
+    @objc fileprivate func appDidBecomeActiveHandler(_ notification: Notification) {
         if waitingOnSystemPromptResponse {
             checkingSystemPromptResponse = true
-            promptTimer = NSTimer.scheduledTimerWithTimeInterval(0.25, target: self, selector: #selector(deeplinkHelper), userInfo: nil, repeats: false)
+            promptTimer = Timer.scheduledTimer(timeInterval: 0.25, target: self, selector: #selector(deeplinkHelper), userInfo: nil, repeats: false)
         }
     }
     
-    @objc private func appDidEnterBackgroundHandler(notification: NSNotification) {
+    @objc fileprivate func appDidEnterBackgroundHandler(_ notification: Notification) {
         completionWrapper(nil)
     }
     
-    @objc private func deeplinkHelper() {
-        let error = DeeplinkErrorFactory.errorForType(.DeeplinkNotFollowed)
+    @objc fileprivate func deeplinkHelper() {
+        let error = DeeplinkErrorFactory.errorForType(.deeplinkNotFollowed)
         completionWrapper(error)
     }
 }

--- a/source/UberRides/Configuration.swift
+++ b/source/UberRides/Configuration.swift
@@ -32,8 +32,8 @@ import WebKit
  - China:   China, for apps that are based in China
  */
 @objc public enum Region : Int {
-    case Default
-    case China
+    case `default`
+    case china
 }
 
 /**
@@ -46,36 +46,36 @@ import WebKit
  - Native:            Callback URI to use for Native (SSO) flow
  */
 @objc public enum CallbackURIType : Int {
-    case AuthorizationCode
-    case General
-    case Implicit
-    case Native
+    case authorizationCode
+    case general
+    case implicit
+    case native
     
     func toString() -> String {
         switch self {
-        case .AuthorizationCode:
+        case .authorizationCode:
             return "AuthorizationCode"
-        case .General:
+        case .general:
             return "General"
-        case .Implicit:
+        case .implicit:
             return "Implicit"
-        case .Native:
+        case .native:
             return "Native"
         }
     }
     
-    static func fromString(string: String) -> CallbackURIType {
+    static func fromString(_ string: String) -> CallbackURIType {
         switch string {
-        case CallbackURIType.AuthorizationCode.toString():
-            return .AuthorizationCode
-        case CallbackURIType.Implicit.toString():
-            return .Implicit
-        case CallbackURIType.Native.toString():
-            return .Native
-        case CallbackURIType.General.toString():
+        case CallbackURIType.authorizationCode.toString():
+            return .authorizationCode
+        case CallbackURIType.implicit.toString():
+            return .implicit
+        case CallbackURIType.native.toString():
+            return .native
+        case CallbackURIType.general.toString():
             fallthrough
         default:
-            return .General
+            return .general
         }
     }
 }
@@ -85,50 +85,50 @@ import WebKit
  default values for Application-wide configuration properties. All properties are 
  configurable via the respective setter method
 */
-@objc(UBSDKConfiguration) public class Configuration : NSObject {
+@objc(UBSDKConfiguration) open class Configuration : NSObject {
     // MARK : Variables
     
     /// The .plist file to use, default is Info.plist
-    public static var plistName = "Info"
+    open static var plistName = "Info"
     
     /// The bundle that contains the .plist file. Default is the mainBundle()
-    public static var bundle = NSBundle.mainBundle()
+    open static var bundle = Bundle.main
     
     static var processPool = WKProcessPool()
     
-    private static let clientIDKey = "UberClientID"
-    private static let appNameKey = "UberDisplayName"
-    private static let serverTokenKey = "UberServerToken"
-    private static let callbackURIKey = "UberCallbackURI"
-    private static let callbackURIsKey = "UberCallbackURIs"
-    private static let callbackURIsTypeKey = "UberCallbackURIType"
-    private static let callbackURIStringKey = "URIString"
-    private static let accessTokenIdentifier = "RidesAccessTokenKey"
+    fileprivate static let clientIDKey = "UberClientID"
+    fileprivate static let appNameKey = "UberDisplayName"
+    fileprivate static let serverTokenKey = "UberServerToken"
+    fileprivate static let callbackURIKey = "UberCallbackURI"
+    fileprivate static let callbackURIsKey = "UberCallbackURIs"
+    fileprivate static let callbackURIsTypeKey = "UberCallbackURIType"
+    fileprivate static let callbackURIStringKey = "URIString"
+    fileprivate static let accessTokenIdentifier = "RidesAccessTokenKey"
     
-    private static var clientID : String?
-    private static var callbackURIString : String?
-    private static var callbackURIs = [CallbackURIType : String]()
-    private static var appDisplayName: String?
-    private static var serverToken: String?
-    private static var defaultKeychainAccessGroup: String?
-    private static var defaultAccessTokenIdentifier: String?
-    private static var region : Region = .Default
-    private static var isSandbox : Bool = false
-    private static var useFallback: Bool = true
+    fileprivate static var clientID : String?
+    fileprivate static var callbackURIString : String?
+    fileprivate static var callbackURIs = [CallbackURIType : String]()
+    fileprivate static var appDisplayName: String?
+    fileprivate static var serverToken: String?
+    fileprivate static var defaultKeychainAccessGroup: String?
+    fileprivate static var defaultAccessTokenIdentifier: String?
+    fileprivate static var region : Region = .default
+    fileprivate static var isSandbox : Bool = false
+    fileprivate static var useFallback: Bool = true
     
     /// The string value of the current region setting
-    public static var regionString: String {
+    open static var regionString: String {
         switch region {
-        case .China:
+        case .china:
             return "china"
-        case .Default:
+        case .default:
             return "default"
         }
     }
     
     /// The current version of the SDK as a string
-    public static var sdkVersion: String {
-        guard let version = NSBundle(forClass: self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String else {
+    open static var sdkVersion: String {
+        guard let version = Bundle(for: self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
             return "Unknown"
         }
         return version
@@ -137,9 +137,9 @@ import WebKit
     /**
      Resets all of the Configuration's values to default
      */
-    public static func restoreDefaults() {
+    open static func restoreDefaults() {
         plistName = "Info"
-        bundle = NSBundle.mainBundle()
+        bundle = Bundle.main
         setClientID(nil)
         setCallbackURIString(nil)
         callbackURIs = parseCallbackURIs()
@@ -147,7 +147,7 @@ import WebKit
         setServerToken(nil)
         setDefaultAccessTokenIdentifier(nil)
         setDefaultKeychainAccessGroup(nil)
-        setRegion(Region.Default)
+        setRegion(Region.default)
         setSandboxEnabled(false)
         setFallbackEnabled(true)
         resetProcessPool()
@@ -161,7 +161,7 @@ import WebKit
     
      - returns: The string to use for the Client ID
     */
-    public static func getClientID() -> String {
+    open static func getClientID() -> String {
         if clientID == nil {
             guard let defaultValue = getDefaultValue(clientIDKey) else {
                 fatalConfigurationError("ClientID", key: clientIDKey)
@@ -178,8 +178,8 @@ import WebKit
      
      - returns: The string to use for the Callback URI
     */
-    public static func getCallbackURIString() -> String {
-        return getCallbackURIString(.General)
+    open static func getCallbackURIString() -> String {
+        return getCallbackURIString(.general)
     }
     
     /**
@@ -193,11 +193,11 @@ import WebKit
      
      - returns: The callbackURIString for the the requested type
      */
-    public static func getCallbackURIString(type: CallbackURIType) -> String {
+    open static func getCallbackURIString(_ type: CallbackURIType) -> String {
         if callbackURIs[type] == nil {
             let defaultCallbacks = parseCallbackURIs()
-            var fallback = defaultCallbacks[type] ?? callbackURIs[.General]
-            fallback = fallback ?? defaultCallbacks[.General]
+            var fallback = defaultCallbacks[type] ?? callbackURIs[.general]
+            fallback = fallback ?? defaultCallbacks[.general]
             fallback = fallback ?? getDefaultValue(callbackURIKey)
             guard let fallbackCallback = fallback else {
                 fatalConfigurationError("CallbackURIStrings[\(type.toString())]", key: callbackURIsKey)
@@ -213,7 +213,7 @@ import WebKit
      
      - returns: The app's name
     */
-    public static func getAppDisplayName() -> String {
+    open static func getAppDisplayName() -> String {
         if appDisplayName == nil {
             guard let defaultValue = getDefaultValue(appNameKey) else {
                 fatalConfigurationError("appDisplayName", key: appNameKey)
@@ -232,7 +232,7 @@ import WebKit
      
      - returns: The string Representing your app's server token
     */
-    public static func getServerToken() -> String? {
+    open static func getServerToken() -> String? {
         if serverToken == nil {
             serverToken = getDefaultValue(serverTokenKey)
         }
@@ -246,7 +246,7 @@ import WebKit
      
      - returns: The default keychain access group to use
     */
-    public static func getDefaultKeychainAccessGroup() -> String {
+    open static func getDefaultKeychainAccessGroup() -> String {
         guard let defaultKeychainAccessGroup = defaultKeychainAccessGroup else {
             return ""
         }
@@ -260,7 +260,7 @@ import WebKit
      
      - returns: The default access token identifier to use
     */
-    public static func getDefaultAccessTokenIdentifier() -> String {
+    open static func getDefaultAccessTokenIdentifier() -> String {
         guard let defaultAccessTokenIdentifier = defaultAccessTokenIdentifier else {
             return accessTokenIdentifier
         }
@@ -273,7 +273,7 @@ import WebKit
      
      - returns: The Region the SDK is using
      */
-    public static func getRegion() -> Region {
+    open static func getRegion() -> Region {
         return region
     }
     
@@ -282,7 +282,7 @@ import WebKit
      
      - returns: true if Sandbox is enabled, false otherwise
      */
-    public static func getSandboxEnabled() -> Bool {
+    open static func getSandboxEnabled() -> Bool {
         return isSandbox
     }
     
@@ -293,7 +293,7 @@ import WebKit
      
      - returns: true if fallback enabled, false otherwise
      */
-    public static func getFallbackEnabled() -> Bool {
+    open static func getFallbackEnabled() -> Bool {
         return useFallback
     }
     
@@ -305,7 +305,7 @@ import WebKit
     
      - parameter clientID: The client ID String to use
     */
-    public static func setClientID(clientID: String?) {
+    open static func setClientID(_ clientID: String?) {
         self.clientID = clientID
     }
     
@@ -317,8 +317,8 @@ import WebKit
      
      - parameter callbackURIString: The callback URI String to use
     */
-    public static func setCallbackURIString(callbackURIString: String?) {
-        setCallbackURIString(callbackURIString, type: .General)
+    open static func setCallbackURIString(_ callbackURIString: String?) {
+        setCallbackURIString(callbackURIString, type: .general)
     }
     
     /**
@@ -331,7 +331,7 @@ import WebKit
      - parameter callbackURIString: The callback URI String to use
      - parameter type:              The Callback URI Type to use
      */
-    public static func setCallbackURIString(callbackURIString: String?, type: CallbackURIType) {
+    open static func setCallbackURIString(_ callbackURIString: String?, type: CallbackURIType) {
         var callbackURIs = self.callbackURIs ?? [CallbackURIType : String]()
         callbackURIs[type] = callbackURIString
         self.callbackURIs = callbackURIs
@@ -344,7 +344,7 @@ import WebKit
      
      - parameter appDisplayName: The display name String to use
     */
-    public static func setAppDisplayName(appDisplayName: String?) {
+    open static func setAppDisplayName(_ appDisplayName: String?) {
         self.appDisplayName = appDisplayName
     }
     
@@ -354,7 +354,7 @@ import WebKit
      
      - parameter serverToken: The Server Token String to use
     */
-    public static func setServerToken(serverToken: String?) {
+    open static func setServerToken(_ serverToken: String?) {
         self.serverToken = serverToken
     }
     
@@ -364,7 +364,7 @@ import WebKit
      
      - parameter keychainAccessGroup: The client ID String to use
     */
-    public static func setDefaultKeychainAccessGroup(keychainAccessGroup: String?) {
+    open static func setDefaultKeychainAccessGroup(_ keychainAccessGroup: String?) {
         self.defaultKeychainAccessGroup = keychainAccessGroup
     }
     
@@ -374,7 +374,7 @@ import WebKit
      
      - parameter accessTokenIdentifier: The access token identifier to use
      */
-    public static func setDefaultAccessTokenIdentifier(accessTokenIdentifier: String?) {
+    open static func setDefaultAccessTokenIdentifier(_ accessTokenIdentifier: String?) {
         self.defaultAccessTokenIdentifier = accessTokenIdentifier
     }
     
@@ -384,7 +384,7 @@ import WebKit
      
      - parameter region: The region the SDK should use
      */
-    public static func setRegion(region: Region) {
+    open static func setRegion(_ region: Region) {
         self.region = region
     }
     
@@ -394,7 +394,7 @@ import WebKit
      
      - parameter enabled: Whether or not sandbox should be enabled
      */
-    public static func setSandboxEnabled(enabled: Bool) {
+    open static func setSandboxEnabled(_ enabled: Bool) {
         isSandbox = enabled
     }
     
@@ -405,7 +405,7 @@ import WebKit
      
      - parameter enabled: Whether or not fallback should be enabled
      */
-    public static func setFallbackEnabled(enabled: Bool) {
+    open static func setFallbackEnabled(_ enabled: Bool) {
         useFallback = enabled
     }
     
@@ -417,15 +417,15 @@ import WebKit
     
     // MARK: Private
     
-    private static func getPlistDictionary() -> [String : AnyObject]? {
-        guard let path = bundle.pathForResource(plistName, ofType: "plist"),
+    fileprivate static func getPlistDictionary() -> [String : AnyObject]? {
+        guard let path = bundle.path(forResource: plistName, ofType: "plist"),
             let dictionary = NSDictionary(contentsOfFile: path) as? [String: AnyObject] else {
                 return nil
         }
         return dictionary
     }
     
-    private static func getDefaultValue(key: String) -> String? {
+    fileprivate static func getDefaultValue(_ key: String) -> String? {
         guard let dictionary = getPlistDictionary(),
             let defaultValue = dictionary[key] as? String else {
                 return nil
@@ -434,7 +434,7 @@ import WebKit
         return defaultValue
     }
     
-    private static func parseCallbackURIs() -> [CallbackURIType : String] {
+    fileprivate static func parseCallbackURIs() -> [CallbackURIType : String] {
         guard let plist = getPlistDictionary(), let callbacks = plist[callbackURIsKey] as? [[String : AnyObject]] else {
             return [CallbackURIType : String]()
         }
@@ -450,7 +450,7 @@ import WebKit
         return callbackURIs
     }
     
-    @noreturn private static func fatalConfigurationError(variableName: String, key: String ) {
+    fileprivate static func fatalConfigurationError(_ variableName: String, key: String ) -> Never  {
         fatalError("Unable to get your \(variableName). Did you forget to set it in your \(plistName).plist? (Should be under \(key) key)")
     }
     

--- a/source/UberRides/DeeplinkErrorFactory.swift
+++ b/source/UberRides/DeeplinkErrorFactory.swift
@@ -34,7 +34,7 @@ class DeeplinkErrorFactory {
      
      - returns: An initialized NSError
      */
-    static func errorForType(deeplinkErrorType: DeeplinkErrorType) -> NSError {
+    static func errorForType(_ deeplinkErrorType: DeeplinkErrorType) -> NSError {
         return NSError(domain: errorDomain, code: deeplinkErrorType.rawValue, userInfo: nil)
     }
 }

--- a/source/UberRides/DeeplinkErrorType.swift
+++ b/source/UberRides/DeeplinkErrorType.swift
@@ -30,7 +30,7 @@
  - UnableToOpen:        The application either is unable to open the URL or was unable to query for the provided deeplink scheme (iOS 9+ only). The latter requires you to add it to your application's plist file under LSQpplicationQueriesSchemes
  */
 @objc enum DeeplinkErrorType : Int {
-    case DeeplinkNotFollowed
-    case UnableToFollow
-    case UnableToOpen
+    case deeplinkNotFollowed
+    case unableToFollow
+    case unableToOpen
 }

--- a/source/UberRides/DeeplinkRequestingBehavior.swift
+++ b/source/UberRides/DeeplinkRequestingBehavior.swift
@@ -21,7 +21,7 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-@objc(UBSDKDeeplinkRequestingBehavior) public class DeeplinkRequestingBehavior : NSObject, RideRequesting {
+@objc(UBSDKDeeplinkRequestingBehavior) open class DeeplinkRequestingBehavior : NSObject, RideRequesting {
         
     /**
      Requests a ride using a RequestDeeplink that is constructed using the provided
@@ -30,14 +30,14 @@
      - parameter rideParameters: The RideParameters to use for building and executing 
      the deeplink
      */
-    @objc public func requestRide(rideParameters: RideParameters?) {
+    @objc open func requestRide(_ rideParameters: RideParameters?) {
         guard let rideParameters = rideParameters else {
             return
         }
         let deeplink = createDeeplink(rideParameters)
         
         let deeplinkCompletion: (NSError?) -> () = { error in
-            if let error = error where error.code != DeeplinkErrorType.DeeplinkNotFollowed.rawValue {
+            if let error = error , error.code != DeeplinkErrorType.deeplinkNotFollowed.rawValue {
                 self.createAppStoreDeeplink(rideParameters).execute(nil)
             }
         }
@@ -45,11 +45,11 @@
         deeplink.execute(deeplinkCompletion)
     }
     
-    func createDeeplink(rideParameters: RideParameters) -> RequestDeeplink {
+    func createDeeplink(_ rideParameters: RideParameters) -> RequestDeeplink {
         return RequestDeeplink(rideParameters: rideParameters)
     }
     
-    func createAppStoreDeeplink(rideParameters: RideParameters) -> Deeplinking {
+    func createAppStoreDeeplink(_ rideParameters: RideParameters) -> Deeplinking {
         return AppStoreDeeplink(userAgent: rideParameters.userAgent)
     }
 }

--- a/source/UberRides/DeeplinkingProtocol.swift
+++ b/source/UberRides/DeeplinkingProtocol.swift
@@ -37,10 +37,10 @@
     var path: String? { get }
     
     /// The query parameter items for the deeplink, where a deeplink takes the form scheme://domain/path?query
-    var queryItems: [NSURLQueryItem]? { get }
+    var queryItems: [URLQueryItem]? { get }
     
     /// The deeplink URL that the deeplink will execute
-    var deeplinkURL: NSURL { get }
+    var deeplinkURL: URL { get }
     
     /**
      Execute a deeplink to launch into an external app
@@ -54,5 +54,5 @@
      - parameter completion: The completion block to execute once the deeplink has
      executed. Passes in True if the url was successfully opened, false otherwise.
      */
-    @objc func execute(completion: ((NSError?) -> ())?)
+    @objc func execute(_ completion: ((NSError?) -> ())?)
 }

--- a/source/UberRides/EndpointsManager.swift
+++ b/source/UberRides/EndpointsManager.swift
@@ -28,16 +28,16 @@ import CoreLocation
  *  Protocol for all endpoints to conform to.
  */
 protocol UberAPI {
-    var body: NSData? { get }
+    var body: Data? { get }
     var headers: [String: String]? { get }
     var host: String { get}
     var method: Method { get }
     var path: String { get }
-    var query: [NSURLQueryItem] { get }
+    var query: [URLQueryItem] { get }
 }
 
 extension UberAPI {
-    var body: NSData? {
+    var body: Data? {
         return nil
     }
     
@@ -48,16 +48,16 @@ extension UberAPI {
     var host: String {
         if Configuration.getSandboxEnabled() {
             switch Configuration.getRegion() {
-            case .China:
+            case .china:
                 return "https://sandbox-api.uber.com.cn"
-            case .Default:
+            case .default:
                 return "https://sandbox-api.uber.com"
             }
         } else {
             switch Configuration.getRegion() {
-            case .China:
+            case .china:
                 return "https://api.uber.com.cn"
-            case .Default:
+            case .default:
                 return "https://api.uber.com"
             }
         }
@@ -82,7 +82,7 @@ private enum Resources: String {
     case Products = "products"
     case Request = "requests"
     
-    private var version: String {
+    fileprivate var version: String {
         switch self {
         case .Estimates: return "v1"
         case .History: return "v1.2"
@@ -94,7 +94,7 @@ private enum Resources: String {
         }
     }
     
-    private var basePath: String {
+    fileprivate var basePath: String {
         return "/\(version)/\(rawValue)"
     }
 }
@@ -116,13 +116,13 @@ enum Method: String {
  - parameter queries: tuples of key-value pairs
  - returns: an array of NSURLQueryItems
  */
-func queryBuilder(queries: (name: String, value: String)...) -> [NSURLQueryItem] {
-    var queryItems = [NSURLQueryItem]()
+func queryBuilder(_ queries: (name: String, value: String)...) -> [URLQueryItem] {
+    var queryItems = [URLQueryItem]()
     for query in queries {
         if query.name.isEmpty || query.value.isEmpty {
             continue
         }
-        queryItems.append(NSURLQueryItem(name: query.name, value: query.value))
+        queryItems.append(URLQueryItem(name: query.name, value: query.value))
     }
     return queryItems
 }
@@ -132,39 +132,39 @@ func queryBuilder(queries: (name: String, value: String)...) -> [NSURLQueryItem]
  - RideRequestWidget: Ride Request Widget endpoint.
  */
 enum Components: UberAPI {
-    case RideRequestWidget(rideParameters: RideParameters?)
+    case rideRequestWidget(rideParameters: RideParameters?)
     
     var method: Method {
         switch self {
-        case .RideRequestWidget:
+        case .rideRequestWidget:
             return .GET
         }
     }
     
     var host: String {
         switch Configuration.getRegion() {
-        case .China:
+        case .china:
             return "https://components.uber.com.cn"
-        case .Default:
+        case .default:
             return "https://components.uber.com"
         }
     }
     
     var path: String {
         switch self {
-        case .RideRequestWidget:
+        case .rideRequestWidget:
             return "/rides/"
         }
     }
     
-    var query: [NSURLQueryItem] {
+    var query: [URLQueryItem] {
         switch self {
-        case .RideRequestWidget(let rideParameters):
+        case .rideRequestWidget(let rideParameters):
             let environment = Configuration.getSandboxEnabled() ? "sandbox" : "production"
             var queryItems = queryBuilder( ("env", "\(environment)") )
             
             if let rideParameters = rideParameters {
-                queryItems.appendContentsOf(RequestURLUtil.buildRequestQueryParameters(rideParameters))
+                queryItems += RequestURLUtil.buildRequestQueryParameters(rideParameters)
             }
             
             return queryItems
@@ -180,17 +180,17 @@ enum Components: UberAPI {
  - Refresh: Used to refresh an access token that has been aquired via SSO
  */
 enum OAuth: UberAPI {
-    case ImplicitLogin(clientID: String, scopes: [RidesScope], redirect: String)
-    case AuthorizationCodeLogin(clientID: String, redirect: String, scopes: [RidesScope], state: String?)
-    case Refresh(clientID: String, refreshToken: String)
+    case implicitLogin(clientID: String, scopes: [RidesScope], redirect: String)
+    case authorizationCodeLogin(clientID: String, redirect: String, scopes: [RidesScope], state: String?)
+    case refresh(clientID: String, refreshToken: String)
     
     var method: Method {
         switch self {
-        case .ImplicitLogin:
+        case .implicitLogin:
             fallthrough
-        case .AuthorizationCodeLogin:
+        case .authorizationCodeLogin:
             return .GET
-        case .Refresh:
+        case .refresh:
             return .POST
         }
     }
@@ -199,61 +199,61 @@ enum OAuth: UberAPI {
         return OAuth.regionHostString()
     }
 
-    var body: NSData? {
+    var body: Data? {
         switch self {
-        case .Refresh(let clientID, let refreshToken):
+        case .refresh(let clientID, let refreshToken):
             let query = queryBuilder(
                 ("client_id", clientID),
                 ("refresh_token", refreshToken)
             )
-            let components = NSURLComponents()
+            var components = URLComponents()
             components.queryItems = query
-            return components.query?.dataUsingEncoding(NSUTF8StringEncoding)
+            return components.query?.data(using: String.Encoding.utf8)
         default:
             return nil
         }
     }
     
-    static func regionHostString(region: Region = Configuration.getRegion()) -> String {
+    static func regionHostString(_ region: Region = Configuration.getRegion()) -> String {
         switch region {
-        case .China:
+        case .china:
             return "https://login.uber.com.cn"
-        case .Default:
+        case .default:
             return "https://login.uber.com"
         }
     }
     
     var path: String {
         switch self {
-        case .ImplicitLogin:
+        case .implicitLogin:
             fallthrough
-        case .AuthorizationCodeLogin:
+        case .authorizationCodeLogin:
             return "/oauth/v2/authorize"
-        case .Refresh:
+        case .refresh:
             return "/oauth/v2/mobile/token"
         }
     }
     
-    var query: [NSURLQueryItem] {
+    var query: [URLQueryItem] {
         switch self {
-        case .ImplicitLogin(let clientID, let scopes, let redirect):
+        case .implicitLogin(let clientID, let scopes, let redirect):
             var loginQuery = baseLoginQuery(clientID, redirect: redirect, scopes: scopes)
             let additionalQueryItems = queryBuilder(("response_type", "token"))
             
-            loginQuery.appendContentsOf(additionalQueryItems)
+            loginQuery.append(contentsOf: additionalQueryItems)
             return loginQuery
-        case .AuthorizationCodeLogin(let clientID, let redirect, let scopes, let state):
+        case .authorizationCodeLogin(let clientID, let redirect, let scopes, let state):
             var loginQuery = baseLoginQuery(clientID, redirect: redirect, scopes: scopes)
             let additionalQueryItems = queryBuilder(("response_type", "code"),
                                           ("state", state ?? ""))
-            loginQuery.appendContentsOf(additionalQueryItems)
+            loginQuery.append(contentsOf: additionalQueryItems)
             return loginQuery
-        case .Refresh:
+        case .refresh:
             return queryBuilder()
         }
     }
     
-    func baseLoginQuery(clientID: String, redirect: String, scopes: [RidesScope]) -> [NSURLQueryItem] {
+    func baseLoginQuery(_ clientID: String, redirect: String, scopes: [RidesScope]) -> [URLQueryItem] {
         
         return queryBuilder(
             ("scope", scopes.toRidesScopeString()),
@@ -263,11 +263,11 @@ enum OAuth: UberAPI {
             ("signup_params", createSignupParameters()))
     }
     
-    private func createSignupParameters() -> String {
+    fileprivate func createSignupParameters() -> String {
         let signupParameters = [ "redirect_to_login" : true ]
         do {
-            let json = try NSJSONSerialization.dataWithJSONObject(signupParameters, options: NSJSONWritingOptions(rawValue: 0))
-            return json.base64EncodedStringWithOptions(NSDataBase64EncodingOptions.Encoding76CharacterLineLength)
+            let json = try JSONSerialization.data(withJSONObject: signupParameters, options: JSONSerialization.WritingOptions(rawValue: 0))
+            return json.base64EncodedString(options: NSData.Base64EncodingOptions.lineLength76Characters)
         } catch _ as NSError {
             return ""
         }
@@ -281,34 +281,34 @@ enum OAuth: UberAPI {
  - GetProduct: Returns information about the Uber product specified by product ID.
  */
 enum Products: UberAPI {
-    case GetAll(location: CLLocation)
-    case GetProduct(productID: String)
+    case getAll(location: CLLocation)
+    case getProduct(productID: String)
     
     var method: Method {
         switch self {
-        case .GetAll:
+        case .getAll:
             fallthrough
-        case .GetProduct:
+        case .getProduct:
             return .GET
         }
     }
     
     var path: String {
         switch self {
-        case .GetAll:
+        case .getAll:
             return Resources.Products.basePath
-        case .GetProduct(let productID):
+        case .getProduct(let productID):
             return "\(Resources.Products.basePath)/\(productID)"
         }
     }
     
-    var query: [NSURLQueryItem] {
+    var query: [URLQueryItem] {
         switch self {
-        case .GetAll(let location):
+        case .getAll(let location):
             return queryBuilder(
             ("latitude", "\(location.coordinate.latitude)"),
             ("longitude", "\(location.coordinate.longitude)"))
-        case .GetProduct:
+        case .getProduct:
             return queryBuilder()
         }
     }
@@ -321,36 +321,36 @@ enum Products: UberAPI {
  - Time:  Returns ETAs for all products offered at a given location (lat, long).
  */
 enum Estimates: UberAPI {
-    case Price(startLocation: CLLocation, endLocation: CLLocation)
-    case Time(location: CLLocation, productID: String?)
+    case price(startLocation: CLLocation, endLocation: CLLocation)
+    case time(location: CLLocation, productID: String?)
     
     var method: Method {
         switch self {
-        case .Price:
+        case .price:
             fallthrough
-        case .Time:
+        case .time:
             return .GET
         }
     }
     
     var path: String {
         switch self {
-        case .Price:
+        case .price:
             return "\(Resources.Estimates.basePath)/price"
-        case .Time:
+        case .time:
             return "\(Resources.Estimates.basePath)/time"
         }
     }
     
-    var query: [NSURLQueryItem] {
+    var query: [URLQueryItem] {
         switch self {
-        case .Price(let startLocation, let endLocation):
+        case .price(let startLocation, let endLocation):
             return queryBuilder(
             ("start_latitude", "\(startLocation.coordinate.latitude)"),
             ("start_longitude", "\(startLocation.coordinate.longitude)"),
             ("end_latitude", "\(endLocation.coordinate.latitude)"),
             ("end_longitude", "\(endLocation.coordinate.longitude)"))
-        case .Time(let location, let productID):
+        case .time(let location, let productID):
             return queryBuilder(
             ("start_latitude", "\(location.coordinate.latitude)"),
             ("start_longitude", "\(location.coordinate.longitude)"),
@@ -365,25 +365,25 @@ enum Estimates: UberAPI {
  - Get: Returns limited data about a user's lifetime activity with Uber.
  */
 enum History: UberAPI {
-    case Get(offset: Int?, limit: Int?)
+    case get(offset: Int?, limit: Int?)
     
     var method: Method {
         switch self {
-        case .Get:
+        case .get:
             return .GET
         }
     }
     
     var path: String {
         switch self {
-        case .Get:
+        case .get:
             return Resources.History.basePath
         }
     }
     
-    var query: [NSURLQueryItem] {
+    var query: [URLQueryItem] {
         switch self {
-        case .Get(let offset, let limit):
+        case .get(let offset, let limit):
             return queryBuilder(
             ("offset", offset == nil ? "" : "\(offset!)"),
             ("limit", limit == nil ? "" : "\(limit!)"))
@@ -397,25 +397,25 @@ enum History: UberAPI {
  - UserProfile: Returns information about the Uber user that has authorized the application.
  */
 enum Me: UberAPI {
-    case UserProfile
+    case userProfile
     
     var method: Method {
         switch self {
-        case .UserProfile:
+        case .userProfile:
             return .GET
         }
     }
     
     var path: String {
         switch self {
-        case .UserProfile:
+        case .userProfile:
             return Resources.Me.basePath
         }
     }
     
-    var query: [NSURLQueryItem] {
+    var query: [URLQueryItem] {
         switch self {
-        case .UserProfile:
+        case .userProfile:
             return queryBuilder()
         }
     }
@@ -430,38 +430,38 @@ enum Me: UberAPI {
  - Estimate:   Gets an estimate for a ride given the desired product, start, and end locations.
  */
 enum Requests: UberAPI {
-    case DeleteCurrent
-    case DeleteRequest(requestID: String)
-    case Estimate(rideParameters: RideParameters)
-    case GetCurrent
-    case GetRequest(requestID: String)
-    case Make(rideParameters: RideParameters)
-    case PatchCurrent(rideParameters: RideParameters)
-    case PatchRequest(requestID: String, rideParameters: RideParameters)
-    case RideMap(requestID: String)
-    case RideReceipt(requestID: String)
+    case deleteCurrent
+    case deleteRequest(requestID: String)
+    case estimate(rideParameters: RideParameters)
+    case getCurrent
+    case getRequest(requestID: String)
+    case make(rideParameters: RideParameters)
+    case patchCurrent(rideParameters: RideParameters)
+    case patchRequest(requestID: String, rideParameters: RideParameters)
+    case rideMap(requestID: String)
+    case rideReceipt(requestID: String)
     
-    var body: NSData? {
+    var body: Data? {
         switch self {
-        case DeleteCurrent:
+        case .deleteCurrent:
             fallthrough
-        case .DeleteRequest:
+        case .deleteRequest:
             return nil
-        case .Estimate(let rideParameters):
-            return RideRequestDataBuilder(rideParameters: rideParameters).build()
-        case .GetCurrent:
+        case .estimate(let rideParameters):
+            return RideRequestDataBuilder(rideParameters: rideParameters).build() as Data?
+        case .getCurrent:
             fallthrough
-        case .GetRequest:
+        case .getRequest:
             return nil
-        case .Make(let rideParameters):
-            return RideRequestDataBuilder(rideParameters: rideParameters).build()
-        case PatchCurrent(let rideParameters):
-            return RideRequestDataBuilder(rideParameters: rideParameters).build()
-        case .PatchRequest(_, let rideParameters):
-            return RideRequestDataBuilder(rideParameters: rideParameters).build()
-        case .RideMap:
+        case .make(let rideParameters):
+            return RideRequestDataBuilder(rideParameters: rideParameters).build() as Data?
+        case .patchCurrent(let rideParameters):
+            return RideRequestDataBuilder(rideParameters: rideParameters).build() as Data?
+        case .patchRequest(_, let rideParameters):
+            return RideRequestDataBuilder(rideParameters: rideParameters).build() as Data?
+        case .rideMap:
             return nil
-        case .RideReceipt:
+        case .rideReceipt:
             return nil
         }
     }
@@ -472,63 +472,63 @@ enum Requests: UberAPI {
     
     var method: Method {
         switch self {
-        case .DeleteCurrent:
+        case .deleteCurrent:
             fallthrough
-        case .DeleteRequest:
+        case .deleteRequest:
             return .DELETE
-        case .Estimate:
+        case .estimate:
             return .POST
-        case .GetCurrent:
+        case .getCurrent:
             fallthrough
-        case .GetRequest:
+        case .getRequest:
             return .GET
-        case .Make:
+        case .make:
             return .POST
-        case .PatchCurrent:
+        case .patchCurrent:
             fallthrough
-        case .PatchRequest:
+        case .patchRequest:
             return .PATCH
-        case .RideMap:
+        case .rideMap:
             return .GET
-        case .RideReceipt:
+        case .rideReceipt:
             return .GET
         }
     }
     
     var path: String {
         switch self {
-        case .DeleteCurrent:
+        case .deleteCurrent:
             return "\(Resources.Request.basePath)/current"
-        case .DeleteRequest(let requestID):
+        case .deleteRequest(let requestID):
             return "\(Resources.Request.basePath)/\(requestID)"
-        case .Estimate:
+        case .estimate:
             return "\(Resources.Request.basePath)/estimate"
-        case .GetCurrent:
+        case .getCurrent:
             return "\(Resources.Request.basePath)/current"
-        case .GetRequest(let requestID):
+        case .getRequest(let requestID):
             return "\(Resources.Request.basePath)/\(requestID)"
-        case .Make:
+        case .make:
             return Resources.Request.basePath
-        case .PatchCurrent:
+        case .patchCurrent:
             return "\(Resources.Request.basePath)/current"
-        case .PatchRequest(let requestID, _):
+        case .patchRequest(let requestID, _):
             return "\(Resources.Request.basePath)/\(requestID)"
-        case .RideMap(let requestID):
+        case .rideMap(let requestID):
             return "\(Resources.Request.basePath)/\(requestID)/map"
-        case .RideReceipt(let requestID):
+        case .rideReceipt(let requestID):
             return "\(Resources.Request.basePath)/\(requestID)/receipt"
         }
     }
     
-    var query: [NSURLQueryItem] {
+    var query: [URLQueryItem] {
         return []
     }
 }
 
 enum Payment: UberAPI {
-    case GetMethods
+    case getMethods
     
-    var body: NSData? {
+    var body: Data? {
         return nil
     }
     
@@ -540,22 +540,22 @@ enum Payment: UberAPI {
         return Resources.PaymentMethod.basePath
     }
     
-    var query: [NSURLQueryItem] {
+    var query: [URLQueryItem] {
         return []
     }
 }
 
 enum Places: UberAPI {
-    case GetPlace(placeID: String)
-    case PutPlace(placeID: String, address: String)
+    case getPlace(placeID: String)
+    case putPlace(placeID: String, address: String)
     
-    var body: NSData? {
+    var body: Data? {
         switch self {
-        case .GetPlace:
+        case .getPlace:
             return nil
-        case .PutPlace(_, let address):
+        case .putPlace(_, let address):
             do {
-                let data = try NSJSONSerialization.dataWithJSONObject(["address": address], options: .PrettyPrinted)
+                let data = try JSONSerialization.data(withJSONObject: ["address": address], options: .prettyPrinted)
                 return data
             } catch { }
             return nil
@@ -564,32 +564,32 @@ enum Places: UberAPI {
     
     var headers: [String : String]? {
         switch self {
-        case .GetPlace:
+        case .getPlace:
             return nil
-        case .PutPlace:
+        case .putPlace:
             return [Header.ContentType.rawValue: "application/json"]
         }
     }
     
     var method: Method {
         switch self {
-        case .GetPlace:
+        case .getPlace:
             return .GET
-        case .PutPlace:
+        case .putPlace:
             return .PUT
         }
     }
     
     var path: String {
         switch self {
-        case .GetPlace(let placeID):
+        case .getPlace(let placeID):
             return "\(Resources.Places.basePath)/\(placeID)"
-        case .PutPlace(let placeID, _):
+        case .putPlace(let placeID, _):
             return "\(Resources.Places.basePath)/\(placeID)"
         }
     }
     
-    var query: [NSURLQueryItem] {
+    var query: [URLQueryItem] {
         return []
     }
 }

--- a/source/UberRides/LoginButton.swift
+++ b/source/UberRides/LoginButton.swift
@@ -25,8 +25,8 @@
 import UIKit
 
 @objc public enum LoginButtonState : Int {
-    case SignedIn
-    case SignedOut
+    case signedIn
+    case signedOut
 }
 
 /**
@@ -40,7 +40,7 @@ import UIKit
      - parameter button:  The LoginButton involved
      - parameter success: True if log out succeeded, false otherwise
      */
-    @objc func loginButton(button: LoginButton, didLogoutWithSuccess success: Bool)
+    @objc func loginButton(_ button: LoginButton, didLogoutWithSuccess success: Bool)
     
     /**
      THe Login Button completed a login
@@ -49,50 +49,50 @@ import UIKit
      - parameter accessToken: The access token that
      - parameter error:       The error that occured
      */
-    @objc func loginButton(button: LoginButton, didCompleteLoginWithToken accessToken: AccessToken?, error: NSError?)
+    @objc func loginButton(_ button: LoginButton, didCompleteLoginWithToken accessToken: AccessToken?, error: NSError?)
 }
 
 /// Button to handle logging in to Uber
-@objc(UBSDKLoginButton) public class LoginButton: UberButton {
+@objc(UBSDKLoginButton) open class LoginButton: UberButton {
     
     let horizontalCenterPadding: CGFloat = 50
     let loginVerticalPadding: CGFloat = 15
     let loginHorizontalEdgePadding: CGFloat = 15
     
     /// The LoginButtonDelegate for this button
-    public weak var delegate: LoginButtonDelegate?
+    open weak var delegate: LoginButtonDelegate?
     
     /// The LoginManager to use for log in
-    public var loginManager: LoginManager {
+    open var loginManager: LoginManager {
         didSet {
             refreshContent()
         }
     }
     
     /// The RidesScopes to request
-    public var scopes: [RidesScope]
+    open var scopes: [RidesScope]
     
     /// The view controller to present login over. Used
-    public var presentingViewController: UIViewController?
+    open var presentingViewController: UIViewController?
     
     /// The current LoginButtonState of this button (signed in / signed out)
-    public var buttonState: LoginButtonState {
+    open var buttonState: LoginButtonState {
         if let _ = TokenManager.fetchToken(accessTokenIdentifier, accessGroup: keychainAccessGroup) {
-            return .SignedIn
+            return .signedIn
         } else {
-            return .SignedOut
+            return .signedOut
         }
     }
     
-    private var accessTokenIdentifier: String {
+    fileprivate var accessTokenIdentifier: String {
         return loginManager.accessTokenIdentifier
     }
     
-    private var keychainAccessGroup: String {
+    fileprivate var keychainAccessGroup: String {
         return loginManager.keychainAccessGroup
     }
     
-    private var loginCompletion: ((accessToken: AccessToken?, error: NSError?) -> Void)?
+    fileprivate var loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?
     
     public init(frame: CGRect, scopes: [RidesScope], loginManager: LoginManager) {
         self.loginManager = loginManager
@@ -102,14 +102,14 @@ import UIKit
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        loginManager = LoginManager(loginType: .Native)
+        loginManager = LoginManager(loginType: .native)
         scopes = []
         super.init(coder: aDecoder)
         setup()
     }
     
     deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
+        NotificationCenter.default.removeObserver(self)
     }
     
     //Mark: UberButton
@@ -117,11 +117,11 @@ import UIKit
     /**
      Setup the LoginButton by adding  a target to the button and setting the login completion block
      */
-    override public func setup() {
+    override open func setup() {
         super.setup()
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(refreshContent), name: TokenManager.TokenManagerDidSaveTokenNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(refreshContent), name: TokenManager.TokenManagerDidDeleteTokenNotification, object: nil)
-        addTarget(self, action: #selector(uberButtonTapped), forControlEvents: .TouchUpInside)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshContent), name: NSNotification.Name(rawValue: TokenManager.TokenManagerDidSaveTokenNotification), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshContent), name: NSNotification.Name(rawValue: TokenManager.TokenManagerDidDeleteTokenNotification), object: nil)
+        addTarget(self, action: #selector(uberButtonTapped), for: .touchUpInside)
         loginCompletion = { token, error in
             self.delegate?.loginButton(self, didCompleteLoginWithToken: token, error: error)
             self.refreshContent()
@@ -131,10 +131,10 @@ import UIKit
     /**
      Updates the content of the button. Sets the image icon and font, as well as the text
      */
-    override public func setContent() {
+    override open func setContent() {
         super.setContent()
         
-        let buttonFont = UIFont.systemFontOfSize(13)
+        let buttonFont = UIFont.systemFont(ofSize: 13)
         let titleText = titleForButtonState(buttonState)
         let logo = getImage("ic_logo_white")
         
@@ -143,31 +143,31 @@ import UIKit
         uberTitleLabel.text = titleText
         
         uberImageView.image = logo
-        uberImageView.contentMode = .Center
+        uberImageView.contentMode = .center
     }
     
     /**
      Adds the layout constraints for the Login button.
      */
-    override public func setConstraints() {
+    override open func setConstraints() {
         
         uberTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         uberImageView.translatesAutoresizingMaskIntoConstraints = false
         
-        uberImageView.setContentHuggingPriority(UILayoutPriorityDefaultHigh, forAxis: .Horizontal)
-        uberTitleLabel.setContentHuggingPriority(UILayoutPriorityDefaultHigh, forAxis: .Horizontal)
-        uberTitleLabel.setContentHuggingPriority(UILayoutPriorityDefaultHigh, forAxis: .Vertical)
+        uberImageView.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .horizontal)
+        uberTitleLabel.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .horizontal)
+        uberTitleLabel.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .vertical)
         
-        let imageLeftConstraint = NSLayoutConstraint(item: uberImageView, attribute: .Left, relatedBy: .Equal, toItem: self, attribute: .Left, multiplier: 1.0, constant: loginHorizontalEdgePadding)
-        let imageTopConstraint = NSLayoutConstraint(item: uberImageView, attribute: .Top, relatedBy: .Equal, toItem: self, attribute: .Top, multiplier: 1.0, constant: loginVerticalPadding)
-        let imageBottomConstraint = NSLayoutConstraint(item: uberImageView, attribute: .Bottom, relatedBy: .Equal, toItem: self, attribute: .Bottom, multiplier: 1.0, constant: -loginVerticalPadding)
+        let imageLeftConstraint = NSLayoutConstraint(item: uberImageView, attribute: .left, relatedBy: .equal, toItem: self, attribute: .left, multiplier: 1.0, constant: loginHorizontalEdgePadding)
+        let imageTopConstraint = NSLayoutConstraint(item: uberImageView, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: loginVerticalPadding)
+        let imageBottomConstraint = NSLayoutConstraint(item: uberImageView, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: -loginVerticalPadding)
         
-        let titleLabelRightConstraint = NSLayoutConstraint(item: uberTitleLabel, attribute: .Right, relatedBy: .Equal, toItem: self, attribute: .Right, multiplier: 1.0, constant: -loginHorizontalEdgePadding)
-        let titleLabelCenterYConstraint = NSLayoutConstraint(item: uberTitleLabel, attribute: .CenterY, relatedBy: .Equal, toItem: uberImageView, attribute: .CenterY, multiplier: 1.0, constant: 0.0)
+        let titleLabelRightConstraint = NSLayoutConstraint(item: uberTitleLabel, attribute: .right, relatedBy: .equal, toItem: self, attribute: .right, multiplier: 1.0, constant: -loginHorizontalEdgePadding)
+        let titleLabelCenterYConstraint = NSLayoutConstraint(item: uberTitleLabel, attribute: .centerY, relatedBy: .equal, toItem: uberImageView, attribute: .centerY, multiplier: 1.0, constant: 0.0)
         
-        let imagePaddingRightConstraint = NSLayoutConstraint(item: uberTitleLabel, attribute: .Left, relatedBy: .GreaterThanOrEqual , toItem: uberImageView, attribute: .Right, multiplier: 1.0, constant: imageLabelPadding)
+        let imagePaddingRightConstraint = NSLayoutConstraint(item: uberTitleLabel, attribute: .left, relatedBy: .greaterThanOrEqual , toItem: uberImageView, attribute: .right, multiplier: 1.0, constant: imageLabelPadding)
         
-        let horizontalCenterPaddingConstraint = NSLayoutConstraint(item: uberTitleLabel, attribute: .Left, relatedBy: .GreaterThanOrEqual , toItem: uberImageView, attribute: .Right, multiplier: 1.0, constant: horizontalCenterPadding)
+        let horizontalCenterPaddingConstraint = NSLayoutConstraint(item: uberTitleLabel, attribute: .left, relatedBy: .greaterThanOrEqual , toItem: uberImageView, attribute: .right, multiplier: 1.0, constant: horizontalCenterPadding)
         horizontalCenterPaddingConstraint.priority = UILayoutPriorityDefaultLow
         
         addConstraints([imageLeftConstraint, imageTopConstraint, imageBottomConstraint])
@@ -177,57 +177,57 @@ import UIKit
     
     //Mark: UIView
     
-    override public func sizeThatFits(size: CGSize) -> CGSize {
+    override open func sizeThatFits(_ size: CGSize) -> CGSize {
         let sizeThatFits = super.sizeThatFits(size)
         
-        let iconSizeThatFits = uberImageView.image?.size ?? CGSizeZero
-        let labelSizeThatFits = uberTitleLabel.intrinsicContentSize()
+        let iconSizeThatFits = uberImageView.image?.size ?? CGSize.zero
+        let labelSizeThatFits = uberTitleLabel.intrinsicContentSize
         
         let labelMinHeight = labelSizeThatFits.height + 2 * loginVerticalPadding
         let iconMinHeight = iconSizeThatFits.height + 2 * loginVerticalPadding
             
         let height = max(iconMinHeight, labelMinHeight)
         
-        return CGSizeMake(sizeThatFits.width + horizontalCenterPadding, height)
+        return CGSize(width: sizeThatFits.width + horizontalCenterPadding, height: height)
     }
     
-    override public func updateConstraints() {
+    override open func updateConstraints() {
         refreshContent()
         super.updateConstraints()
     }
     
     //Mark: Internal Interface
     
-    func uberButtonTapped(button: UIButton) {
+    func uberButtonTapped(_ button: UIButton) {
         switch buttonState {
-        case .SignedIn:
+        case .signedIn:
             let success = TokenManager.deleteToken(accessTokenIdentifier, accessGroup: keychainAccessGroup)
             delegate?.loginButton(self, didLogoutWithSuccess: success)
             refreshContent()
-        case .SignedOut:
+        case .signedOut:
             loginManager.login(requestedScopes: scopes, presentingViewController: presentingViewController, completion: loginCompletion)
         }
     }
     
     //Mark: Private Interface
     
-    @objc private func refreshContent() {
+    @objc fileprivate func refreshContent() {
         uberTitleLabel.text = titleForButtonState(buttonState)
     }
     
-    private func titleForButtonState(buttonState: LoginButtonState) -> String {
+    fileprivate func titleForButtonState(_ buttonState: LoginButtonState) -> String {
         var titleText: String!
         switch buttonState {
-        case .SignedIn:
-            titleText = LocalizationUtil.localizedString(forKey: "Sign Out", comment: "Login Button Sign Out Description").uppercaseString
-        case .SignedOut:
-            titleText = LocalizationUtil.localizedString(forKey: "Sign In", comment: "Login Button Sign In Description").uppercaseString
+        case .signedIn:
+            titleText = LocalizationUtil.localizedString(forKey: "Sign Out", comment: "Login Button Sign Out Description").uppercased()
+        case .signedOut:
+            titleText = LocalizationUtil.localizedString(forKey: "Sign In", comment: "Login Button Sign In Description").uppercased()
         }
         return titleText
     }
 
-    private func getImage(name: String) -> UIImage? {
-        let bundle = NSBundle(forClass: RideRequestButton.self)
-        return UIImage(named: name, inBundle: bundle, compatibleWithTraitCollection: nil)?.imageWithRenderingMode(.AlwaysTemplate)
+    fileprivate func getImage(_ name: String) -> UIImage? {
+        let bundle = Bundle(for: RideRequestButton.self)
+        return UIImage(named: name, in: bundle, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
     }
 }

--- a/source/UberRides/ModalRideRequestViewController.swift
+++ b/source/UberRides/ModalRideRequestViewController.swift
@@ -23,9 +23,9 @@
 //  THE SOFTWARE.
 
 /// Modal View Controller to use for presenting a RideRequestViewController. Handles errors & closing the modal for you
-@objc(UBSDKModalRideRequestViewController) public class ModalRideRequestViewController : ModalViewController {
+@objc(UBSDKModalRideRequestViewController) open class ModalRideRequestViewController : ModalViewController {
     /// The RideRequestViewController this modal is wrapping
-    public internal(set) var rideRequestViewController : RideRequestViewController
+    open internal(set) var rideRequestViewController : RideRequestViewController
     
     /**
      Initializer for the ModalRideRequestViewController. Wraps the provided RideRequestViewController
@@ -38,7 +38,7 @@
      */
     @objc public init(rideRequestViewController: RideRequestViewController) {
         self.rideRequestViewController = rideRequestViewController
-        super.init(childViewController: rideRequestViewController, buttonStyle: ModalViewControllerButtonStyle.BackButton)
+        super.init(childViewController: rideRequestViewController, buttonStyle: ModalViewControllerButtonStyle.backButton)
         self.rideRequestViewController.delegate = self
     }
     
@@ -48,8 +48,8 @@
 
     // MARK: UIViewController
 
-    public override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
-        return [.Portrait, .PortraitUpsideDown]
+    open override var supportedInterfaceOrientations : UIInterfaceOrientationMask {
+        return [.portrait, .portraitUpsideDown]
     }
 }
 
@@ -60,16 +60,16 @@ extension ModalRideRequestViewController : RideRequestViewControllerDelegate {
      - parameter rideRequestViewController: The RideRequestViewController that experienced an error
      - parameter error:                     The RideRequestViewError that occured
      */
-    public func rideRequestViewController(rideRequestViewController: RideRequestViewController, didReceiveError error: NSError) {
-        let errorType = RideRequestViewErrorType(rawValue: error.code) ?? RideRequestViewErrorType.Unknown
+    public func rideRequestViewController(_ rideRequestViewController: RideRequestViewController, didReceiveError error: NSError) {
+        let errorType = RideRequestViewErrorType(rawValue: error.code) ?? RideRequestViewErrorType.unknown
         var errorString: String?
         navigationItem.title = LocalizationUtil.localizedString(forKey: "Sign in with Uber", comment: "Title of navigation bar during OAuth")
         switch errorType {
-        case .AccessTokenExpired:
+        case .accessTokenExpired:
             fallthrough
-        case .AccessTokenMissing:
+        case .accessTokenMissing:
             errorString = LocalizationUtil.localizedString(forKey: "There was a problem authenticating you. Please try again.", comment: "RideRequestView error text for authentication error")
-        case .NetworkError:
+        case .networkError:
             break
         default:
             errorString = LocalizationUtil.localizedString(forKey: "The Ride Request Widget encountered a problem. Please try again.", comment: "RideRequestView error text for a generic error")
@@ -77,12 +77,12 @@ extension ModalRideRequestViewController : RideRequestViewControllerDelegate {
         
         if let errorString = errorString {
             let actionString = LocalizationUtil.localizedString(forKey: "OK", comment: "OK button title")
-            let alert = UIAlertController(title: nil, message: errorString, preferredStyle: UIAlertControllerStyle.Alert)
-            let okayAction = UIAlertAction(title: actionString, style: UIAlertActionStyle.Default, handler: { (_) -> Void in
+            let alert = UIAlertController(title: nil, message: errorString, preferredStyle: UIAlertControllerStyle.alert)
+            let okayAction = UIAlertAction(title: actionString, style: UIAlertActionStyle.default, handler: { (_) -> Void in
                 self.dismiss()
             })
             alert.addAction(okayAction)
-            self.presentViewController(alert, animated: true, completion: nil)
+            self.present(alert, animated: true, completion: nil)
         } else {
             self.dismiss()
         }

--- a/source/UberRides/ModalViewController.swift
+++ b/source/UberRides/ModalViewController.swift
@@ -29,9 +29,9 @@ Possible Styles for the ModalViewController
 - DoneButton:  Presents the view mdoally with a Done BarButtonItem in the top right corner
 */
 @objc public enum ModalViewControllerButtonStyle : Int {
-    case Empty
-    case DoneButton
-    case BackButton
+    case empty
+    case doneButton
+    case backButton
 }
 
 /**
@@ -41,8 +41,8 @@ Possible Styles for the ModalViewController
  - Light:   Light color style, light navigation bar with dark text
  */
 @objc public enum ModalViewControllerColorStyle : Int {
-    case Default
-    case Light
+    case `default`
+    case light
 }
 
 /**
@@ -54,22 +54,22 @@ Possible Styles for the ModalViewController
      
      - parameter modalViewController: The ModalViewController that will be dismissed
      */
-    @objc func modalViewControllerWillDismiss(modalViewController: ModalViewController)
+    @objc func modalViewControllerWillDismiss(_ modalViewController: ModalViewController)
     
     /**
      Called after the ModalViewController is dismissed.
      
      - parameter modalViewController: The ModalViewController that was dismissed
      */
-    @objc func modalViewControllerDidDismiss(modalViewController: ModalViewController)
+    @objc func modalViewControllerDidDismiss(_ modalViewController: ModalViewController)
 }
 
 /// Convenience to wrap a ViewController in a UINavigationController and add the appropriate buttons. Allows you to modally present a view controller w/ Uber branding.
-@objc(UBSDKModalViewController) public class ModalViewController : UIViewController {
+@objc(UBSDKModalViewController) open class ModalViewController : UIViewController {
     /// The ModalViewControllerDelegate
-    public var delegate: ModalViewControllerDelegate?
+    open var delegate: ModalViewControllerDelegate?
     
-    public var colorStyle: ModalViewControllerColorStyle = .Default {
+    open var colorStyle: ModalViewControllerColorStyle = .default {
         didSet {
             setupStyle()
         }
@@ -109,7 +109,7 @@ Possible Styles for the ModalViewController
      - returns: An initialized ModalViewController
      */
     @objc public convenience init(childViewController: UIViewController) {
-        self.init(childViewController: childViewController, buttonStyle: .DoneButton)
+        self.init(childViewController: childViewController, buttonStyle: .doneButton)
     }
 
     /**
@@ -124,16 +124,16 @@ Possible Styles for the ModalViewController
     
     //MARK: View Lifecycle
     
-    public override func viewDidLoad() {
+    open override func viewDidLoad() {
         super.viewDidLoad()
         
         self.addChildViewController(wrappedNavigationController)
         self.view.addSubview(self.wrappedNavigationController.view)
         
-        self.wrappedNavigationController.didMoveToParentViewController(self)
+        self.wrappedNavigationController.didMove(toParentViewController: self)
     }
     
-    public override func viewDidDisappear(animated: Bool) {
+    open override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         self.delegate?.modalViewControllerDidDismiss(self)
     }
@@ -143,62 +143,62 @@ Possible Styles for the ModalViewController
     /**
      Function to dimiss the modalViewController.
     */
-    public func dismiss() {
+    open func dismiss() {
         self.delegate?.modalViewControllerWillDismiss(self)
-        self.dismissViewControllerAnimated(true, completion: nil)
+        self.dismiss(animated: true, completion: nil)
     }
     
-    public override func preferredStatusBarStyle() -> UIStatusBarStyle {
+    open override var preferredStatusBarStyle : UIStatusBarStyle {
         switch colorStyle {
-        case .Light:
-            return UIStatusBarStyle.Default
-        case .Default:
-            return UIStatusBarStyle.LightContent
+        case .light:
+            return UIStatusBarStyle.default
+        case .default:
+            return UIStatusBarStyle.lightContent
         }
         
     }
     
     //MARK: Button Actions
     
-    func doneButtonPressed(button: UIButton) {
+    func doneButtonPressed(_ button: UIButton) {
         dismiss()
     }
     
-    func backButtonPressed(button: UIButton) {
+    func backButtonPressed(_ button: UIButton) {
         dismiss()
     }
     
     //MARK: Private Helpers
     
-    private func setupStyle() {
-        let bundle = NSBundle(forClass: RideRequestButton.self)
+    fileprivate func setupStyle() {
+        let bundle = Bundle(for: RideRequestButton.self)
         self.wrappedViewController.navigationItem.leftBarButtonItem = nil
         self.wrappedViewController.navigationItem.rightBarButtonItem = nil
-        var iconTintColor = UIColor.whiteColor()
+        var iconTintColor = UIColor.white
         switch colorStyle {
-        case .Light:
-            iconTintColor = UIColor.blackColor()
-            wrappedViewController.navigationController?.navigationBar.barStyle = .Default
-        case .Default:
-            wrappedViewController.navigationController?.navigationBar.barStyle = .Black
+        case .light:
+            iconTintColor = UIColor.black
+            wrappedViewController.navigationController?.navigationBar.barStyle = .default
+        case .default:
+            wrappedViewController.navigationController?.navigationBar.barStyle = .black
             break
         }
         
         switch buttonStyle {
-        case .Empty:
+        case .empty:
             break
-        case .DoneButton:
-            let doneButton = UIBarButtonItem(barButtonSystemItem: .Done , target: self, action: #selector(doneButtonPressed(_:)))
+        case .doneButton:
+            let doneButton = UIBarButtonItem(barButtonSystemItem: .done , target: self, action: #selector(doneButtonPressed(_:)))
             doneButton.tintColor = iconTintColor
             self.wrappedViewController.navigationItem.rightBarButtonItem = doneButton
-        case .BackButton:
-            let backImage =  UIImage(named: "ic_back_arrow_white", inBundle: bundle, compatibleWithTraitCollection: nil)
-            let backButton = UIBarButtonItem(image: backImage, style: .Plain, target: self, action: #selector(backButtonPressed(_:)))
+        case .backButton:
+            let backImage =  UIImage(named: "ic_back_arrow_white", in: bundle, compatibleWith: nil)
+            let backButton = UIBarButtonItem(image: backImage, style: .plain, target: self, action: #selector(backButtonPressed(_:)))
             backButton.tintColor = iconTintColor
             self.wrappedViewController.navigationItem.leftBarButtonItem = backButton
         }
         
-        let logoImage = UIImage(named: "ic_logo_white", inBundle: bundle, compatibleWithTraitCollection: nil)?.imageWithRenderingMode(.AlwaysTemplate)
+        let logoImage = UIImage(named: "ic_logo_white", in: bundle, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
         let logoImageView = UIImageView(image: logoImage)
         logoImageView.tintColor = iconTintColor
         

--- a/source/UberRides/Model/DistanceEstimate.swift
+++ b/source/UberRides/Model/DistanceEstimate.swift
@@ -29,18 +29,18 @@ import ObjectMapper
 /**
  *  Estimate information on an Uber trip.
  */
-@objc(UBSDKDistanceEstimate) public class DistanceEstimate: NSObject {
+@objc(UBSDKDistanceEstimate) open class DistanceEstimate: NSObject {
     
     /// Expected activity distance.
-    public private(set) var distance: Double = 0.0
+    open fileprivate(set) var distance: Double = 0.0
     
     /// The unit of distance (mile or km).
-    public private(set) var distanceUnit: String?
+    open fileprivate(set) var distanceUnit: String?
     
     /// Expected activity duration (in seconds).
-    public private(set) var duration: Int = 0
+    open fileprivate(set) var duration: Int = 0
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/Driver.swift
+++ b/source/UberRides/Model/Driver.swift
@@ -29,21 +29,21 @@ import ObjectMapper
 /**
  *  Contains information for an Uber driver dispatched for a ride request.
  */
-@objc(UBSDKDriver) public class Driver: NSObject {
+@objc(UBSDKDriver) open class Driver: NSObject {
     
     /// The first name of the driver.
-    public private(set) var name: String?
+    open fileprivate(set) var name: String?
     
     /// The URL to the photo of the driver.
-    public private(set) var pictureURL: String?
+    open fileprivate(set) var pictureURL: String?
     
     /// The formatted phone number for contacting the driver.
-    public private(set) var phoneNumber: String?
+    open fileprivate(set) var phoneNumber: String?
     
     /// The driver's star rating out of 5 stars.
-    public private(set) var rating: Double = 0.0
+    open fileprivate(set) var rating: Double = 0.0
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/PaymentMethod.swift
+++ b/source/UberRides/Model/PaymentMethod.swift
@@ -33,7 +33,7 @@ struct PaymentMethods {
     var lastUsed: String?
     var list: [PaymentMethod]?
     
-    init?(_ map: Map) {
+    init?(map: Map) {
     }
 }
 
@@ -46,18 +46,18 @@ extension PaymentMethods: UberModel {
 
 // MARK: PaymentMethod
 
-@objc(UBSDKPaymentMethod) public class PaymentMethod: NSObject {
+@objc(UBSDKPaymentMethod) open class PaymentMethod: NSObject {
     
     /// The account identification or description associated with the payment method.
-    public private(set) var paymentDescription: String?
+    open fileprivate(set) var paymentDescription: String?
     
     /// Unique identifier of the payment method.
-    public private(set) var methodID: String?
+    open fileprivate(set) var methodID: String?
     
     /// The type of the payment method. See https://developer.uber.com/docs/v1-payment-methods.
-    public private(set) var type: String?
+    open fileprivate(set) var type: String?
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/Place.swift
+++ b/source/UberRides/Model/Place.swift
@@ -27,18 +27,18 @@ import ObjectMapper
 /**
  *  Describes a pre-set place for an Uber account (home or work).
  */
-@objc(UBSDKPlace) public class Place: NSObject {
+@objc(UBSDKPlace) open class Place: NSObject {
     
     /// Convenience constant for "home" place ID
-    public static let Home = "home"
+    open static let Home = "home"
     
     /// Convenience constant for "work" place ID
-    public static let Work = "work"
+    open static let Work = "work"
     
     /// Fully qualified address of the location.
-    public private(set) var address: String?
+    open fileprivate(set) var address: String?
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/PriceEstimate.swift
+++ b/source/UberRides/Model/PriceEstimate.swift
@@ -31,7 +31,7 @@ import ObjectMapper
 */
 struct PriceEstimates {
     var list: [PriceEstimate]?
-    init?(_ map: Map) {
+    init?(map: Map) {
     }
 }
 
@@ -46,42 +46,42 @@ extension PriceEstimates: UberModel {
 /**
 *  Contains information about estimated price range for each Uber product offered at a location.
 */
-@objc(UBSDKPriceEstimate) public class PriceEstimate: NSObject {
+@objc(UBSDKPriceEstimate) open class PriceEstimate: NSObject {
     
     /// ISO 4217 currency code.
-    public private(set) var currencyCode: String?
+    open fileprivate(set) var currencyCode: String?
     
     /// Expected activity distance (in miles).
-    public private(set) var distance: Double = 0.0
+    open fileprivate(set) var distance: Double = 0.0
     
     /// Expected activity duration (in seconds).
-    public private(set) var duration: Int = 0
+    open fileprivate(set) var duration: Int = 0
     
     /// A formatted string representing the estimate in local currency. Could be range, single number, or "Metered" for TAXI.
-    public private(set) var estimate: String?
+    open fileprivate(set) var estimate: String?
     
     /// Upper bound of the estimated price.
-    public private(set) var highEstimate: Int = 0
+    open fileprivate(set) var highEstimate: Int = 0
     
     /// Lower bound of the estimated price.
-    public private(set) var lowEstimate: Int = 0
+    open fileprivate(set) var lowEstimate: Int = 0
     
     /// Display name of product. Ex: "UberBLACK".
-    public private(set) var name: String?
+    open fileprivate(set) var name: String?
     
     /// Unique identifier representing a specific product for a given latitude & longitude.
-    public private(set) var productID: String?
+    open fileprivate(set) var productID: String?
     
     /// The unique identifier of the surge session for a user. Nil for no surge.
-    public private(set) var surgeConfirmationID: String?
+    open fileprivate(set) var surgeConfirmationID: String?
     
     /// The URL a user must visit to accept surge pricing.
-    public private(set) var surgeConfirmationURL: String?
+    open fileprivate(set) var surgeConfirmationURL: String?
     
     /// Expected surge multiplier (active if surge is greater than 1).
-    public private(set) var surgeMultiplier: Double = 1.0
+    open fileprivate(set) var surgeMultiplier: Double = 1.0
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/Ride.swift
+++ b/source/UberRides/Model/Ride.swift
@@ -29,36 +29,36 @@ import ObjectMapper
 /**
  *  Contains the status of an ongoing/completed trip created using the Ride Request endpoint
  */
-@objc(UBSDKRide) public class Ride: NSObject {
+@objc(UBSDKRide) open class Ride: NSObject {
     
     /// Contains the information about the destination of the trip, if one has been set.
-    public private(set) var destination: RideRequestLocation?
+    open fileprivate(set) var destination: RideRequestLocation?
     
     /// The object that contains driver details. Only non-null during an ongoing trip.
-    public private(set) var driver: Driver?
+    open fileprivate(set) var driver: Driver?
     
     /// The object that contains the location information of the vehicle and driver.
-    public private(set) var driverLocation: RideRequestLocation?
+    open fileprivate(set) var driverLocation: RideRequestLocation?
     
     /// The estimated time of vehicle arrival in minutes.
-    public private(set) var eta: Int = 0
+    open fileprivate(set) var eta: Int = 0
     
     /// The object containing the information about the pickup for the trip.
-    public private(set) var pickup: RideRequestLocation?
+    open fileprivate(set) var pickup: RideRequestLocation?
     
     /// The unique ID of the Request.
-    public private(set) var requestID: String?
+    open fileprivate(set) var requestID: String?
     
     /// The status of the Request indicating state.
-    public private(set) var status: RideStatus?
+    open fileprivate(set) var status: RideStatus?
     
     /// The surge pricing multiplier used to calculate the increased price of a Request.
-    public private(set) var surgeMultiplier: Double = 1.0
+    open fileprivate(set) var surgeMultiplier: Double = 1.0
     
     /// The object that contains vehicle details. Only non-null during an ongoing trip.
-    public private(set) var vehicle: Vehicle?
+    open fileprivate(set) var vehicle: Vehicle?
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 
@@ -73,7 +73,7 @@ extension Ride: UberModel {
         surgeMultiplier <- map["surge_multiplier"]
         vehicle         <- map["vehicle"]
         
-        status = .Unknown
+        status = .unknown
         if let value = map["status"].currentValue as? String {
             status = RideStatusFactory.convertRideStatus(value)
         }

--- a/source/UberRides/Model/RideCharge.swift
+++ b/source/UberRides/Model/RideCharge.swift
@@ -29,18 +29,18 @@ import ObjectMapper
 /**
  *  Describes the charges made against the rider in a ride receipt.
  */
-@objc(UBSDKRideCharge) public class RideCharge: NSObject {
+@objc(UBSDKRideCharge) open class RideCharge: NSObject {
     
     /// The amount of the charge.
-    public private(set) var amount: Float = 0.0
+    open fileprivate(set) var amount: Float = 0.0
     
     /// The name of the charge.
-    public private(set) var name: String?
+    open fileprivate(set) var name: String?
     
     /// The type of the charge.
-    public private(set) var type: String?
+    open fileprivate(set) var type: String?
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/RideEstimate.swift
+++ b/source/UberRides/Model/RideEstimate.swift
@@ -29,18 +29,18 @@ import ObjectMapper
 /**
  *  Contains estimates for a desired ride request.
  */
-@objc(UBSDKRideEstimate) public class RideEstimate: NSObject {
+@objc(UBSDKRideEstimate) open class RideEstimate: NSObject {
     
     /// Details of the estimated fare. If end location omitted, only the minimum is returned.
-    public private(set) var priceEstimate: PriceEstimate?
+    open fileprivate(set) var priceEstimate: PriceEstimate?
     
     /// Details of the estimated distance. Nil if end location is omitted.
-    public private(set) var distanceEstimate: DistanceEstimate?
+    open fileprivate(set) var distanceEstimate: DistanceEstimate?
     
     /// The estimated time of vehicle arrival in minutes. -1 if there are no cars available.
-    public private(set) var pickupEstimate: Int = -1
+    open fileprivate(set) var pickupEstimate: Int = -1
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/RideMap.swift
+++ b/source/UberRides/Model/RideMap.swift
@@ -29,15 +29,15 @@ import ObjectMapper
 /**
  *  Visual representation of a ride request, only available after a request is accepted.
  */
-@objc(UBSDKRideMap) public class RideMap: NSObject {
+@objc(UBSDKRideMap) open class RideMap: NSObject {
     
     /// URL to a map representing the requested trip.
-    public private(set) var path: String?
+    open fileprivate(set) var path: String?
     
     /// Unique identifier representing a ride request.
-    public private(set) var requestID: String?
+    open fileprivate(set) var requestID: String?
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/RideParameters.swift
+++ b/source/UberRides/Model/RideParameters.swift
@@ -25,47 +25,47 @@
 import MapKit
 
 /// Object to represent the parameters needed to request a ride. Should be built using a RideParametersBuilder
-@objc(UBSDKRideParameters) public class RideParameters : NSObject {
+@objc(UBSDKRideParameters) open class RideParameters : NSObject {
     
     /// True if the pickup location should use the device's current location, false if a location has been set
-    public let useCurrentLocationForPickup: Bool
+    open let useCurrentLocationForPickup: Bool
     
     /// ProductID to use for the ride
-    public let productID: String?
+    open let productID: String?
     
     /// The pickup location to use for the ride
-    public let pickupLocation: CLLocation?
+    open let pickupLocation: CLLocation?
     
     /// The nickname of the pickup location of the ride
-    public let pickupNickname: String?
+    open let pickupNickname: String?
     
     /// The address of the pickup location of the ride
-    public let pickupAddress: String?
+    open let pickupAddress: String?
     
     /// This is the name of an Uber saved place. Only “home” or “work” is acceptable.
-    public let pickupPlaceID: String?
+    open let pickupPlaceID: String?
     
     /// The dropoff location to use for the ride
-    public let dropoffLocation: CLLocation?
+    open let dropoffLocation: CLLocation?
     
     /// The nickname of the dropoff location for the ride
-    public let dropoffNickname: String?
+    open let dropoffNickname: String?
     
     /// The adress of the dropoff location of the ride
-    public let dropoffAddress: String?
+    open let dropoffAddress: String?
     
     /// This is the name of an Uber saved place. Only “home” or “work” is acceptable.
-    public let dropoffPlaceID: String?
+    open let dropoffPlaceID: String?
     
     /// The unique identifier of the payment method selected by a user.
-    public let paymentMethod: String?
+    open let paymentMethod: String?
     
     /// The unique identifier of the surge session for a user.
-    public let surgeConfirmationID: String?
+    open let surgeConfirmationID: String?
     
     var userAgent: String {
         var userAgentString: String = ""
-        if let versionNumber: String = NSBundle(forClass: self.dynamicType).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String {
+        if let versionNumber: String = Bundle(for: type(of: self)).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String {
             userAgentString = "rides-ios-v\(versionNumber)"
             if let source = source {
                 userAgentString = "\(userAgentString)-\(source)"
@@ -76,7 +76,7 @@ import MapKit
     
     var source: String?
     
-    private init(dropoffAddress: String?,
+    fileprivate init(dropoffAddress: String?,
         dropoffLocation: CLLocation?,
         dropoffNickname: String?,
         dropoffPlaceID: String?,
@@ -108,21 +108,21 @@ import MapKit
 }
 
 /// Builder for a RideParameters object.
-@objc(UBSDKRideParametersBuilder) public class RideParametersBuilder : NSObject {
+@objc(UBSDKRideParametersBuilder) open class RideParametersBuilder : NSObject {
     
-    private var useCurrentLocationForPickup: Bool
-    private var productID: String?
-    private var pickupLocation: CLLocation?
-    private var pickupNickname: String?
-    private var pickupAddress: String?
-    private var pickupPlaceID: String?
-    private var dropoffLocation: CLLocation?
-    private var dropoffNickname: String?
-    private var dropoffAddress: String?
-    private var dropoffPlaceID: String?
-    private var paymentMethod: String?
-    private var surgeConfirmationID: String?
-    private var source: String?
+    fileprivate var useCurrentLocationForPickup: Bool
+    fileprivate var productID: String?
+    fileprivate var pickupLocation: CLLocation?
+    fileprivate var pickupNickname: String?
+    fileprivate var pickupAddress: String?
+    fileprivate var pickupPlaceID: String?
+    fileprivate var dropoffLocation: CLLocation?
+    fileprivate var dropoffNickname: String?
+    fileprivate var dropoffAddress: String?
+    fileprivate var dropoffPlaceID: String?
+    fileprivate var paymentMethod: String?
+    fileprivate var surgeConfirmationID: String?
+    fileprivate var source: String?
     
     @objc public convenience override init() {
         self.init(rideParameters: nil)
@@ -156,7 +156,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    public func setProductID(productID: String) -> RideParametersBuilder {
+    open func setProductID(_ productID: String) -> RideParametersBuilder {
         self.productID = productID
         
         return self
@@ -166,7 +166,7 @@ import MapKit
      Sets the builder to use your current location for pickup. Will clear any set
      pickupLocation, pickupNickname, and pickupAddress.
      */
-    public func setPickupToCurrentLocation() -> RideParametersBuilder {
+    open func setPickupToCurrentLocation() -> RideParametersBuilder {
         useCurrentLocationForPickup = true
         pickupLocation = nil
         pickupNickname = nil
@@ -183,7 +183,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    public func setPickupPlaceID(placeID: String) -> RideParametersBuilder {
+    open func setPickupPlaceID(_ placeID: String) -> RideParametersBuilder {
         useCurrentLocationForPickup = false
         pickupPlaceID = placeID
         pickupLocation = nil
@@ -202,7 +202,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    public func setPickupLocation(location: CLLocation, nickname: String?, address: String?) -> RideParametersBuilder {
+    open func setPickupLocation(_ location: CLLocation, nickname: String?, address: String?) -> RideParametersBuilder {
         useCurrentLocationForPickup = false
         pickupLocation = location
         pickupNickname = nickname
@@ -219,7 +219,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    public func setPickupLocation(location: CLLocation, address: String?) -> RideParametersBuilder {
+    open func setPickupLocation(_ location: CLLocation, address: String?) -> RideParametersBuilder {
         return self.setPickupLocation(location, nickname: nil, address: address)
     }
     
@@ -231,7 +231,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    public func setPickupLocation(location: CLLocation, nickname: String?) -> RideParametersBuilder {
+    open func setPickupLocation(_ location: CLLocation, nickname: String?) -> RideParametersBuilder {
         return self.setPickupLocation(location, nickname: nickname, address: nil)
     }
     
@@ -242,7 +242,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    public func setPickupLocation(location: CLLocation) -> RideParametersBuilder {
+    open func setPickupLocation(_ location: CLLocation) -> RideParametersBuilder {
         return self.setPickupLocation(location, nickname: nil, address: nil)
     }
     
@@ -255,7 +255,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    public func setDropoffLocation(location: CLLocation, nickname: String?, address: String?) -> RideParametersBuilder {
+    open func setDropoffLocation(_ location: CLLocation, nickname: String?, address: String?) -> RideParametersBuilder {
         dropoffLocation = location
         dropoffNickname = nickname
         dropoffAddress = address
@@ -271,7 +271,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    public func setDropoffLocation(location: CLLocation, address: String?) -> RideParametersBuilder {
+    open func setDropoffLocation(_ location: CLLocation, address: String?) -> RideParametersBuilder {
         return self.setDropoffLocation(location, nickname: nil, address: address)
     }
     
@@ -283,7 +283,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    public func setDropoffLocation(location: CLLocation, nickname: String?) -> RideParametersBuilder {
+    open func setDropoffLocation(_ location: CLLocation, nickname: String?) -> RideParametersBuilder {
         return self.setDropoffLocation(location, nickname: nickname, address: nil)
     }
     
@@ -294,7 +294,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    public func setDropoffLocation(location: CLLocation) -> RideParametersBuilder {
+    open func setDropoffLocation(_ location: CLLocation) -> RideParametersBuilder {
         return self.setDropoffLocation(location, nickname: nil, address: nil)
     }
     
@@ -306,7 +306,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    public func setDropoffPlaceID(placeID: String) -> RideParametersBuilder {
+    open func setDropoffPlaceID(_ placeID: String) -> RideParametersBuilder {
         dropoffPlaceID = placeID
         dropoffLocation = nil
         dropoffNickname = nil
@@ -325,7 +325,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    public func setPaymentMethod(method: String) -> RideParametersBuilder {
+    open func setPaymentMethod(_ method: String) -> RideParametersBuilder {
         paymentMethod = method
         
         return self
@@ -339,7 +339,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    public func setSurgeConfirmationID(surgeConfirmation: String) -> RideParametersBuilder {
+    open func setSurgeConfirmationID(_ surgeConfirmation: String) -> RideParametersBuilder {
         surgeConfirmationID = surgeConfirmation
         
         return self
@@ -352,7 +352,7 @@ import MapKit
      
      - returns: RideParametersBuilder to continue chaining.
      */
-    func setSource(source: String?) -> RideParametersBuilder {
+    func setSource(_ source: String?) -> RideParametersBuilder {
         self.source = source
         
         return self
@@ -363,7 +363,7 @@ import MapKit
      
      - returns: An initialized RideParameters object
      */
-    public func build() -> RideParameters {
+    open func build() -> RideParameters {
         return RideParameters(dropoffAddress: dropoffAddress,
             dropoffLocation: dropoffLocation,
             dropoffNickname: dropoffNickname,

--- a/source/UberRides/Model/RideReceipt.swift
+++ b/source/UberRides/Model/RideReceipt.swift
@@ -29,45 +29,45 @@ import ObjectMapper
 /**
  *  Get the receipt information of a completed request that was made with the request endpoint.
  */
-@objc(UBSDKRideReceipt) public class RideReceipt: NSObject {
+@objc(UBSDKRideReceipt) open class RideReceipt: NSObject {
     
     /// Adjustments made to the charges such as promotions, and fees.
-    public private(set) var chargeAdjustments: [RideCharge]?
+    open fileprivate(set) var chargeAdjustments: [RideCharge]?
     
     /// Describes the charges made against the rider.
-    public private(set) var charges: [RideCharge]?
+    open fileprivate(set) var charges: [RideCharge]?
     
     /// ISO 4217
-    public private(set) var currencyCode: String?
+    open fileprivate(set) var currencyCode: String?
     
     /// Distance of the trip charged.
-    public private(set) var distance: String?
+    open fileprivate(set) var distance: String?
     
     /// The localized unit of distance.
-    public private(set) var distanceLabel: String?
+    open fileprivate(set) var distanceLabel: String?
     
     /// Time duration of the trip in ISO 8601 HH:MM:SS format.
-    public private(set) var duration: String?
+    open fileprivate(set) var duration: String?
     
     /// The summation of the charges array.
-    public private(set) var normalFare: String?
+    open fileprivate(set) var normalFare: String?
     
     /// Unique identifier representing a Request.
-    public private(set) var requestID: String?
+    open fileprivate(set) var requestID: String?
     
     /// The summation of the normal fare and surge charge amount.
-    public private(set) var subtotal: String?
+    open fileprivate(set) var subtotal: String?
     
     /// Describes the surge charge. May be null if surge pricing was not in effect.
-    public private(set) var surgeCharge: RideCharge?
+    open fileprivate(set) var surgeCharge: RideCharge?
     
     /// The total amount charged to the users payment method. This is the the subtotal (split if applicable) with taxes included.
-    public private(set) var totalCharged: String?
+    open fileprivate(set) var totalCharged: String?
     
     /// The total amount still owed after attempting to charge the user. May be 0 if amount was paid in full.
-    public private(set) var totalOwed: Double = 0.0
+    open fileprivate(set) var totalOwed: Double = 0.0
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/RideRequestDataBuilder.swift
+++ b/source/UberRides/Model/RideRequestDataBuilder.swift
@@ -43,60 +43,60 @@ class RideRequestDataBuilder {
     let productIDKey = "product_id"
     let surgeConfirmationKey = "surge_confirmation_id"
     
-    private var rideParameters: RideParameters
+    fileprivate var rideParameters: RideParameters
     
     init(rideParameters: RideParameters) {
         self.rideParameters = rideParameters
     }
     
-    func build() -> NSData? {
+    func build() -> Data? {
         var data = [String: AnyObject]()
         
         if let productID = rideParameters.productID {
-            data[productIDKey] = productID
+            data[productIDKey] = productID as AnyObject?
         }
         
         if let pickupLocation = rideParameters.pickupLocation {
-            data["\(pickupKey)_\(latitudeKey)"] = pickupLocation.coordinate.latitude
-            data["\(pickupKey)_\(longitudeKey)"] = pickupLocation.coordinate.longitude
+            data["\(pickupKey)_\(latitudeKey)"] = pickupLocation.coordinate.latitude as AnyObject?
+            data["\(pickupKey)_\(longitudeKey)"] = pickupLocation.coordinate.longitude as AnyObject?
         } else if let pickupPlace = rideParameters.pickupPlaceID {
-            data["\(pickupKey)_\(placeIDKey)"] = pickupPlace
+            data["\(pickupKey)_\(placeIDKey)"] = pickupPlace as AnyObject?
         }
         
         if let pickupNickname = rideParameters.pickupNickname {
-            data["\(pickupKey)_\(nicknameKey)"] = pickupNickname
+            data["\(pickupKey)_\(nicknameKey)"] = pickupNickname as AnyObject?
         }
         
         if let pickupAddress = rideParameters.pickupAddress {
-            data["\(pickupKey)_\(addressKey)"] = pickupAddress
+            data["\(pickupKey)_\(addressKey)"] = pickupAddress as AnyObject?
         }
         
         if let dropoffLocation = rideParameters.dropoffLocation {
-            data["\(dropoffKey)_\(latitudeKey)"] = dropoffLocation.coordinate.latitude
-            data["\(dropoffKey)_\(longitudeKey)"] = dropoffLocation.coordinate.longitude
+            data["\(dropoffKey)_\(latitudeKey)"] = dropoffLocation.coordinate.latitude as AnyObject?
+            data["\(dropoffKey)_\(longitudeKey)"] = dropoffLocation.coordinate.longitude as AnyObject?
         } else if let dropoffPlace = rideParameters.dropoffPlaceID {
-            data["\(dropoffKey)_\(placeIDKey)"] = dropoffPlace
+            data["\(dropoffKey)_\(placeIDKey)"] = dropoffPlace as AnyObject?
         }
         
         if let dropoffNickname = rideParameters.dropoffNickname {
-            data["\(dropoffKey)_\(nicknameKey)"] = dropoffNickname
+            data["\(dropoffKey)_\(nicknameKey)"] = dropoffNickname as AnyObject?
         }
         
         if let dropoffAddress = rideParameters.dropoffAddress {
-            data["\(dropoffKey)_\(addressKey)"] = dropoffAddress
+            data["\(dropoffKey)_\(addressKey)"] = dropoffAddress as AnyObject?
         }
         
         if let paymentMethod = rideParameters.paymentMethod {
-            data["\(paymentMethodKey)"] = paymentMethod
+            data["\(paymentMethodKey)"] = paymentMethod as AnyObject?
         }
         
         if let surgeConfirmation = rideParameters.surgeConfirmationID {
-            data["\(surgeConfirmationKey)"] = surgeConfirmation
+            data["\(surgeConfirmationKey)"] = surgeConfirmation as AnyObject?
         }
         
-        var bodyData: NSData?
+        var bodyData: Data?
         do {
-            bodyData = try NSJSONSerialization.dataWithJSONObject(data, options: .PrettyPrinted)
+            bodyData = try JSONSerialization.data(withJSONObject: data, options: .prettyPrinted)
             return bodyData
         } catch { }
         return nil

--- a/source/UberRides/Model/RideRequestLocation.swift
+++ b/source/UberRides/Model/RideRequestLocation.swift
@@ -29,21 +29,21 @@ import ObjectMapper
 /**
  *  Location of a pickup or destination in a ride request.
  */
-@objc(UBSDKRideRequestLocation) public class RideRequestLocation: NSObject {
+@objc(UBSDKRideRequestLocation) open class RideRequestLocation: NSObject {
     
     /// The current bearing in degrees for a moving location.
-    public private(set) var bearing: Int = 0
+    open fileprivate(set) var bearing: Int = 0
     
     /// ETA is only available when the trips is accepted or arriving.
-    public private(set) var eta: Int = 0
+    open fileprivate(set) var eta: Int = 0
     
     /// The latitude of the location.
-    public private(set) var latitude: Double = 0
+    open fileprivate(set) var latitude: Double = 0
     
     /// The longitude of the location.
-    public private(set) var longitude: Double = 0
+    open fileprivate(set) var longitude: Double = 0
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/RideStatus.swift
+++ b/source/UberRides/Model/RideStatus.swift
@@ -38,15 +38,15 @@
  - Unknown:            An unexpected status.
  */
 @objc(UBSDKRideStatus) public enum RideStatus: Int {
-    case Accepted
-    case Arriving
-    case Completed
-    case DriverCanceled
-    case InProgress
-    case NoDriversAvailable
-    case Processing
-    case RiderCanceled
-    case Unknown
+    case accepted
+    case arriving
+    case completed
+    case driverCanceled
+    case inProgress
+    case noDriversAvailable
+    case processing
+    case riderCanceled
+    case unknown
 }
 
 // MARK: Objective-C Compatibility
@@ -63,28 +63,28 @@ private enum RideStatusString: String {
 }
 
 class RideStatusFactory: NSObject {
-    static func convertRideStatus(stringValue: String) -> RideStatus {
+    static func convertRideStatus(_ stringValue: String) -> RideStatus {
         guard let status = RideStatusString(rawValue: stringValue) else {
-            return .Unknown
+            return .unknown
         }
         
         switch status {
         case .Accepted:
-            return .Accepted
+            return .accepted
         case .Arriving:
-            return .Arriving
+            return .arriving
         case .Completed:
-            return .Completed
+            return .completed
         case .DriverCanceled:
-            return .DriverCanceled
+            return .driverCanceled
         case .InProgress:
-            return .InProgress
+            return .inProgress
         case .NoDriversAvailable:
-            return .NoDriversAvailable
+            return .noDriversAvailable
         case .Processing:
-            return .Processing
+            return .processing
         case .RiderCanceled:
-            return .RiderCanceled
+            return .riderCanceled
         }
     }
 }

--- a/source/UberRides/Model/RidesError.swift
+++ b/source/UberRides/Model/RidesError.swift
@@ -27,26 +27,26 @@ import ObjectMapper
 // MARK: RidesError
 
 /// Base class for errors that can be mapped from HTTP responses.
-@objc(UBSDKRidesError) public class RidesError : NSObject {
+@objc(UBSDKRidesError) open class RidesError : NSObject {
     /// HTTP status code for error.
-    public internal(set) var status: Int = -1
+    open internal(set) var status: Int = -1
     
     /// Human readable message which corresponds to the client error.
-    public internal(set) var title: String?
+    open internal(set) var title: String?
     
     /// Underscore delimited string.
-    public internal(set) var code: String?
+    open internal(set) var code: String?
     
     /// Additional information about errors. Can be "fields" or "meta" as the key.
-    public internal(set) var meta: [String: AnyObject]?
+    open internal(set) var meta: [String: AnyObject]?
     
     /// List of additional errors. This can be populated instead of status/code/title.
-    public internal(set) var errors: [RidesError]?
+    open internal(set) var errors: [RidesError]?
 
     override init() {
     }
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 
@@ -77,30 +77,30 @@ extension RidesError: UberModel {
 // MARK: RidesError subclasses
 
 /// Client error 4xx.
-@objc(UBSDKRidesClientError) public class RidesClientError: RidesError {
+@objc(UBSDKRidesClientError) open class RidesClientError: RidesError {
 
-    public required init?(_ map: Map) {
-        super.init(map)
+    public required init?(map: Map) {
+        super.init(map: map)
     }
 }
 
 /// Server error 5xx.
-@objc(UBSDKRidesServerError) public class RidesServerError: RidesError {
+@objc(UBSDKRidesServerError) open class RidesServerError: RidesError {
     
-    public required init?(_ map: Map) {
-        super.init(map)
+    public required init?(map: Map) {
+        super.init(map: map)
     }
 }
 
 /// Unknown error type.
-@objc(UBSDKRidesUnknownError) public class RidesUnknownError: RidesError {
+@objc(UBSDKRidesUnknownError) open class RidesUnknownError: RidesError {
     
     override init() {
         super.init()
     }
     
-    public required init?(_ map: Map) {
-        super.init(map)
+    public required init?(map: Map) {
+        super.init(map: map)
     }
 }
 
@@ -137,143 +137,143 @@ extension RidesError: UberModel {
  - UserCancelled:           User cancelled the auth process
  */
 @objc public enum RidesAuthenticationErrorType: Int {
-    case AccessDenied
-    case ExpiredJWT
-    case GeneralError
-    case InternalServerError
-    case InvalidAppSignature
-    case InvalidAuthCode
-    case InvalidClientID
-    case InvalidFlowError
-    case InvalidJWT
-    case InvalidJWTSignature
-    case InvalidNonce
-    case InvalidRedirect
-    case InvalidRefreshToken
-    case InvalidRequest
-    case InvalidResponse
-    case InvalidScope
-    case InvalidSSOResponse
-    case InvalidUserID
-    case MalformedRequest
-    case MismatchingRedirect
-    case NetworkError
-    case ServerError
-    case UnableToPresentLogin
-    case UnableToSaveAccessToken
-    case Unavailable
-    case UserCancelled
+    case accessDenied
+    case expiredJWT
+    case generalError
+    case internalServerError
+    case invalidAppSignature
+    case invalidAuthCode
+    case invalidClientID
+    case invalidFlowError
+    case invalidJWT
+    case invalidJWTSignature
+    case invalidNonce
+    case invalidRedirect
+    case invalidRefreshToken
+    case invalidRequest
+    case invalidResponse
+    case invalidScope
+    case invalidSSOResponse
+    case invalidUserID
+    case malformedRequest
+    case mismatchingRedirect
+    case networkError
+    case serverError
+    case unableToPresentLogin
+    case unableToSaveAccessToken
+    case unavailable
+    case userCancelled
     
     func toString() -> String {
         switch self {
-        case .AccessDenied:
+        case .accessDenied:
             return "access_denied"
-        case .ExpiredJWT:
+        case .expiredJWT:
             return "expired_jwt"
-        case .GeneralError:
+        case .generalError:
             return "general_error"
-        case .InternalServerError:
+        case .internalServerError:
             return "internal_server_error"
-        case .InvalidAppSignature:
+        case .invalidAppSignature:
             return "invalid_app_signature"
-        case .InvalidAuthCode:
+        case .invalidAuthCode:
             return "invalid_auth_code"
-        case .InvalidClientID:
+        case .invalidClientID:
             return "invalid_client_id"
-        case .InvalidFlowError:
+        case .invalidFlowError:
             return "invalid_flow_error"
-        case .InvalidJWT:
+        case .invalidJWT:
             return "invalid_jwt"
-        case .InvalidJWTSignature:
+        case .invalidJWTSignature:
             return "invalid_jwt_signature"
-        case .InvalidNonce:
+        case .invalidNonce:
             return "invalid_nonce"
-        case .InvalidRedirect:
+        case .invalidRedirect:
             return "invalid_redirect_uri"
-        case .InvalidRefreshToken:
+        case .invalidRefreshToken:
             return "invalid_refresh_token"
-        case .InvalidRequest:
+        case .invalidRequest:
             return "invalid_parameters"
-        case .InvalidResponse:
+        case .invalidResponse:
             return "invalid_response"
-        case .InvalidScope:
+        case .invalidScope:
             return "invalid_scope"
-        case .InvalidSSOResponse:
+        case .invalidSSOResponse:
             return "invalid_sso_response"
-        case .InvalidUserID:
+        case .invalidUserID:
             return "invalid_user_id"
-        case .MalformedRequest:
+        case .malformedRequest:
             return "malformed_request"
-        case .MismatchingRedirect:
+        case .mismatchingRedirect:
             return "mismatching_redirect_uri"
-        case .NetworkError:
+        case .networkError:
             return "network_error"
-        case .ServerError:
+        case .serverError:
             return "server_error"
-        case .UnableToPresentLogin:
+        case .unableToPresentLogin:
             return "present_login_failed"
-        case .UnableToSaveAccessToken:
+        case .unableToSaveAccessToken:
             return "token_not_saved"
-        case .Unavailable:
+        case .unavailable:
             return "temporarily_unavailable"
-        case .UserCancelled:
+        case .userCancelled:
             return "cancelled"
         }
     }
     
     var localizedDescriptionKey: String {
         switch self {
-        case .AccessDenied:
+        case .accessDenied:
             return "The user denied the requested scopes."
-        case .ExpiredJWT:
+        case .expiredJWT:
             return "The scope accept session expired."
-        case .GeneralError:
+        case .generalError:
             return "A general error occured."
-        case .InternalServerError:
+        case .internalServerError:
             return "An internal server error occured."
-        case .InvalidAppSignature:
+        case .invalidAppSignature:
             return "The provided app signature did not match what was expected."
-        case .InvalidAuthCode:
+        case .invalidAuthCode:
             return "There was a problem authorizing you."
-        case .InvalidClientID:
+        case .invalidClientID:
             return "Invalid Client ID provided."
-        case .InvalidFlowError:
+        case .invalidFlowError:
             return "There was a problem displaying the authorize screen."
-        case .InvalidJWT:
+        case .invalidJWT:
             return "There was a problem authorizing you."
-        case .InvalidJWTSignature:
+        case .invalidJWTSignature:
             return "There was a problem authorizing you."
-        case .InvalidNonce:
+        case .invalidNonce:
             return "There was a problem authorizing you."
-        case .InvalidRedirect:
+        case .invalidRedirect:
             return "Invalid Redirect URI provided."
-        case .InvalidRefreshToken:
+        case .invalidRefreshToken:
             return "Invalid Refresh TOken provided."
-        case .InvalidRequest:
+        case .invalidRequest:
             return "The server was unable to understand your request."
-        case .InvalidResponse:
+        case .invalidResponse:
             return "Unable to interpret the response from the server."
-        case .InvalidScope:
+        case .invalidScope:
             return "Your app is not authorized for the requested scopes."
-        case .InvalidSSOResponse:
+        case .invalidSSOResponse:
             return "The server responded with an invalid response."
-        case .InvalidUserID:
+        case .invalidUserID:
             return "There was a problem with your user ID."
-        case .MalformedRequest:
+        case .malformedRequest:
             return "There was a problem loading the authorize screen."
-        case .MismatchingRedirect:
+        case .mismatchingRedirect:
             return "The Redirect URI provided did not match what was expected."
-        case .NetworkError:
+        case .networkError:
             return "A network error occured."
-        case .ServerError:
+        case .serverError:
             return "A server error occurred."
-        case .UnableToPresentLogin:
+        case .unableToPresentLogin:
             return "Unable to present the login view."
-        case .UnableToSaveAccessToken:
+        case .unableToSaveAccessToken:
             return "Unable to save the access token."
-        case .Unavailable:
+        case .unavailable:
             return "Login is temporarily unavailable."
-        case .UserCancelled:
+        case .userCancelled:
             return "User cancelled the login process."
         }
     }
@@ -294,71 +294,71 @@ class RidesAuthenticationErrorFactory : NSObject {
      
      - returns: An initialized RidesAuthenticationError
      */
-    static func errorForType(ridesAuthenticationErrorType ridesAuthenticationErrorType : RidesAuthenticationErrorType) -> NSError {
+    static func errorForType(ridesAuthenticationErrorType : RidesAuthenticationErrorType) -> NSError {
         return NSError(domain: errorDomain, code: ridesAuthenticationErrorType.rawValue, userInfo: [NSLocalizedDescriptionKey : ridesAuthenticationErrorType.toLocalizedDescription()])
     }
     
-    static func createRidesAuthenticationError(rawValue rawValue: String) -> NSError? {
+    static func createRidesAuthenticationError(rawValue: String) -> NSError? {
         guard let ridesAuthenticationErrorType = ridesAuthenticationErrorType(rawValue) else {
             return nil
         }
         return RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: ridesAuthenticationErrorType)
     }
     
-    static func ridesAuthenticationErrorType(rawValue: String) -> RidesAuthenticationErrorType? {
+    static func ridesAuthenticationErrorType(_ rawValue: String) -> RidesAuthenticationErrorType? {
         switch rawValue {
         case "access_denied":
-            return .AccessDenied
+            return .accessDenied
         case "cancelled":
-            return .UserCancelled
+            return .userCancelled
         case "expired_jwt":
-            return .ExpiredJWT
+            return .expiredJWT
         case "general_error":
-            return .GeneralError
+            return .generalError
         case "internal_server_error":
-            return .InternalServerError
+            return .internalServerError
         case "invalid_app_signature":
-            return .InvalidAppSignature
+            return .invalidAppSignature
         case "invalid_auth_code":
-            return .InvalidAuthCode
+            return .invalidAuthCode
         case "invalid_client_id":
-            return .InvalidClientID
+            return .invalidClientID
         case "invalid_flow_error":
-            return .InvalidFlowError
+            return .invalidFlowError
         case "invalid_jwt":
-            return .InvalidJWT
+            return .invalidJWT
         case "invalid_jwt_signature":
-            return .InvalidJWTSignature
+            return .invalidJWTSignature
         case "invalid_nonce":
-            return .InvalidNonce
+            return .invalidNonce
         case "invalid_parameters":
-            return .InvalidRequest
+            return .invalidRequest
         case "invalid_redirect_uri":
-            return .InvalidRedirect
+            return .invalidRedirect
         case "invalid_refresh_token":
-            return .InvalidRefreshToken
+            return .invalidRefreshToken
         case "invalid_response":
-            return .InvalidResponse
+            return .invalidResponse
         case "invalid_scope":
-            return .InvalidScope
+            return .invalidScope
         case "invalid_sso_response":
-            return .InvalidSSOResponse
+            return .invalidSSOResponse
         case "invalid_user_id":
-            return .InvalidUserID
+            return .invalidUserID
         case "malformed_request":
-            return .MalformedRequest
+            return .malformedRequest
         case "mismatching_redirect_uri":
-            return .MismatchingRedirect
+            return .mismatchingRedirect
         case "network_error":
-            return .NetworkError
+            return .networkError
         case "present_login_failed":
-            return .UnableToPresentLogin
+            return .unableToPresentLogin
         case "server_error":
-            return .ServerError
+            return .serverError
         case "temporarily_unavailable":
-            return .Unavailable
+            return .unavailable
         case "token_not_saved":
-            return .UnableToSaveAccessToken
+            return .unableToSaveAccessToken
         default:
             return nil
         }

--- a/source/UberRides/Model/RidesScope.swift
+++ b/source/UberRides/Model/RidesScope.swift
@@ -31,7 +31,7 @@ import UIKit
  - Privileged: scopes that require approval before opened to your users in production.
  */
 @objc public enum ScopeType : Int {
-    case General, Privileged
+    case general, privileged
 }
 
 /**
@@ -47,48 +47,48 @@ import UIKit
  - RideWidgets:    The scope for using the Ride Request Widget.
  */
 @objc public enum RidesScopeType: Int {
-    case AllTrips
-    case History
-    case HistoryLite
-    case Places
-    case Profile
-    case Request
-    case RequestReceipt
-    case RideWidgets
+    case allTrips
+    case history
+    case historyLite
+    case places
+    case profile
+    case request
+    case requestReceipt
+    case rideWidgets
     
     
     var type: ScopeType {
         switch(self) {
-        case .History: fallthrough
-        case .HistoryLite: fallthrough
-        case .Places: fallthrough
-        case .Profile: fallthrough
-        case .RideWidgets:
-            return .General
-        case .AllTrips: fallthrough
-        case .Request: fallthrough
-        case .RequestReceipt:
-            return .Privileged
+        case .history: fallthrough
+        case .historyLite: fallthrough
+        case .places: fallthrough
+        case .profile: fallthrough
+        case .rideWidgets:
+            return .general
+        case .allTrips: fallthrough
+        case .request: fallthrough
+        case .requestReceipt:
+            return .privileged
         }
     }
     
     func toString() -> String {
         switch self {
-        case .AllTrips:
+        case .allTrips:
             return "all_trips"
-        case .History:
+        case .history:
             return "history"
-        case .HistoryLite:
+        case .historyLite:
             return "history_lite"
-        case .Places:
+        case .places:
             return "places"
-        case .Profile:
+        case .profile:
             return "profile"
-        case .Request:
+        case .request:
             return "request"
-        case .RequestReceipt:
+        case .requestReceipt:
             return "request_receipt"
-        case .RideWidgets:
+        case .rideWidgets:
             return "ride_widgets"
         }
     }
@@ -97,13 +97,13 @@ import UIKit
 /**
  *  Object representing an access scope to the Uber API
  */
-@objc(UBSDKRidesScope) public class RidesScope : NSObject {
+@objc(UBSDKRidesScope) open class RidesScope : NSObject {
     /// The RidesScopeType of this RidesScope
-    public let ridesScopeType: RidesScopeType
+    open let ridesScopeType: RidesScopeType
     /// The ScopeType of this RidesScope (General / Privileged)
-    public let scopeType : ScopeType
+    open let scopeType : ScopeType
     /// The String raw value of the scope
-    public let rawValue : String
+    open let rawValue : String
     
     public init(ridesScopeType: RidesScopeType) {
         self.ridesScopeType = ridesScopeType
@@ -111,7 +111,7 @@ import UIKit
         rawValue = ridesScopeType.toString()
     }
     
-    override public func isEqual(object: AnyObject?) -> Bool {
+    override open func isEqual(_ object: Any?) -> Bool {
         if let object = object as? RidesScope {
             return self.ridesScopeType == object.ridesScopeType
         } else {
@@ -119,60 +119,60 @@ import UIKit
         }
     }
     
-    override public var hash: Int {
+    override open var hash: Int {
         return ridesScopeType.rawValue.hashValue
     }
     
     /// Convenience variable for the AllTrips scope
-    public static let AllTrips = RidesScope(ridesScopeType: .AllTrips)
+    open static let AllTrips = RidesScope(ridesScopeType: .allTrips)
     
     /// Convenience variable for the History scope
-    public static let History = RidesScope(ridesScopeType: .History)
+    open static let History = RidesScope(ridesScopeType: .history)
     
     /// Convenience variable for the HistoryLite scope
-    public static let HistoryLite = RidesScope(ridesScopeType: .HistoryLite)
+    open static let HistoryLite = RidesScope(ridesScopeType: .historyLite)
     
     /// Convenience variable for the Places scope
-    public static let Places = RidesScope(ridesScopeType: .Places)
+    open static let Places = RidesScope(ridesScopeType: .places)
     
     /// Convenience variable for the Profile scope
-    public static let Profile = RidesScope(ridesScopeType: .Profile)
+    open static let Profile = RidesScope(ridesScopeType: .profile)
     
     /// Convenience variable for the Request scope
-    public static let Request = RidesScope(ridesScopeType: .Request)
+    open static let Request = RidesScope(ridesScopeType: .request)
     
     /// Convenience variable for the RequestReceipt scope
-    public static let RequestReceipt = RidesScope(ridesScopeType: .RequestReceipt)
+    open static let RequestReceipt = RidesScope(ridesScopeType: .requestReceipt)
     
     /// Convenience variable for the RideWidgets scope
-    public static let RideWidgets = RidesScope(ridesScopeType: .RideWidgets)
+    open static let RideWidgets = RidesScope(ridesScopeType: .rideWidgets)
     
 }
 
 class RidesScopeFactory : NSObject {
-    static func ridesScopeForType(ridesScopeType: RidesScopeType) -> RidesScope {
+    static func ridesScopeForType(_ ridesScopeType: RidesScopeType) -> RidesScope {
         return RidesScope(ridesScopeType: ridesScopeType)
     }
     
-    static func ridesScopeForString(rawString: String) -> RidesScope? {
+    static func ridesScopeForString(_ rawString: String) -> RidesScope? {
         guard let type = ridesScopeTypeForRawValue(rawString) else {
             return nil
         }
         return ridesScopeForType(type)
     }
     
-    static func ridesScopeTypeForRawValue(rawValue: String) -> RidesScopeType? {
-        switch rawValue.lowercaseString {
-        case RidesScopeType.History.toString():
-            return .History
-        case RidesScopeType.HistoryLite.toString():
-            return .HistoryLite
-        case RidesScopeType.Places.toString():
-            return .Places
-        case RidesScopeType.Profile.toString():
-            return .Profile
-        case RidesScopeType.RideWidgets.toString():
-            return .RideWidgets
+    static func ridesScopeTypeForRawValue(_ rawValue: String) -> RidesScopeType? {
+        switch rawValue.lowercased() {
+        case RidesScopeType.history.toString():
+            return .history
+        case RidesScopeType.historyLite.toString():
+            return .historyLite
+        case RidesScopeType.places.toString():
+            return .places
+        case RidesScopeType.profile.toString():
+            return .profile
+        case RidesScopeType.rideWidgets.toString():
+            return .rideWidgets
         default:
             return nil
         }
@@ -191,7 +191,7 @@ extension String {
     func toRidesScopesArray() -> [RidesScope]
     {
         var scopesArray = [RidesScope]()
-        for scopeString in self.componentsSeparatedByString(" ") {
+        for scopeString in self.components(separatedBy: " ") {
             guard let scope = RidesScopeFactory.ridesScopeForString(scopeString) else {
                 continue
             }
@@ -205,7 +205,7 @@ extension String {
  Extends SequenceType of RidesScope to allow for easy conversion to a space 
  delimited scope string
  */
-extension SequenceType where Generator.Element == RidesScope {
+extension Sequence where Iterator.Element == RidesScope {
     /**
      Converts an array of RidesScopes into a space delimited String
      - parameter scopes: The array of RidesScopes to convert
@@ -218,6 +218,6 @@ extension SequenceType where Generator.Element == RidesScope {
             scopeStringArray.append(scope.rawValue)
         }
         
-        return scopeStringArray.joinWithSeparator(" ")
+        return scopeStringArray.joined(separator: " ")
     }
 }

--- a/source/UberRides/Model/TimeEstimate.swift
+++ b/source/UberRides/Model/TimeEstimate.swift
@@ -31,7 +31,7 @@ import ObjectMapper
 */
 struct TimeEstimates {
     var list: [TimeEstimate]?
-    init?(_ map: Map) {
+    init?(map: Map) {
     }
 }
 
@@ -46,17 +46,17 @@ extension TimeEstimates: UberModel {
 /**
 *  Contains information regarding the ETA of an Uber product.
 */
-@objc(UBSDKTimeEstimate) public class TimeEstimate: NSObject {
+@objc(UBSDKTimeEstimate) open class TimeEstimate: NSObject {
     /// Unique identifier representing a specific product for a given latitude & longitude.
-    public private(set) var productID: String?
+    open fileprivate(set) var productID: String?
     
     /// Display name of product. Ex: "UberBLACK".
-    public private(set) var name: String?
+    open fileprivate(set) var name: String?
     
     /// ETA for the product (in seconds).
-    public private(set) var estimate: Int = 0
+    open fileprivate(set) var estimate: Int = 0
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/UberProduct.swift
+++ b/source/UberRides/Model/UberProduct.swift
@@ -32,7 +32,7 @@ import ObjectMapper
 */
 struct UberProducts {
     var list: [UberProduct]?
-    init?(_ map: Map){
+    init?(map: Map){
     }
 }
 
@@ -47,26 +47,26 @@ extension UberProducts: UberModel {
 /**
 *  Contains information for a single Uber product.
 */
-@objc(UBSDKUberProduct) public class UberProduct: NSObject {
+@objc(UBSDKUberProduct) open class UberProduct: NSObject {
     /// Unique identifier representing a specific product for a given latitude & longitude.
-    public private(set) var productID: String?
+    open fileprivate(set) var productID: String?
     
     /// Display name of product. Ex: "UberBLACK".
-    public private(set) var name: String?
+    open fileprivate(set) var name: String?
     
     /// Description of product. Ex: "The original Uber".
-    public private(set) var details: String?
+    open fileprivate(set) var details: String?
     
     /// Capacity of product. Ex: 4, for a product that fits 4.
-    public private(set) var capacity: Int = 0
+    open fileprivate(set) var capacity: Int = 0
     
     /// Path of image URL representing the product.
-    public private(set) var imagePath: String?
+    open fileprivate(set) var imagePath: String?
     
     /// The basic price details. See `PriceDetails` for structure.
-    public private(set) var priceDetails: PriceDetails?
+    open fileprivate(set) var priceDetails: PriceDetails?
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 
@@ -86,32 +86,32 @@ extension UberProduct : UberModel {
 /**
 *  Contains basic price details for an Uber product.
 */
-@objc(UBSDKPriceDetails) public class PriceDetails : NSObject {
+@objc(UBSDKPriceDetails) open class PriceDetails : NSObject {
     /// Unit of distance used to calculate fare (mile or km).
-    public private(set) var distanceUnit: String?
+    open fileprivate(set) var distanceUnit: String?
     
     /// ISO 4217 currency code.
-    public private(set) var currencyCode: String?
+    open fileprivate(set) var currencyCode: String?
     
     /// The charge per minute (if applicable).
-    public private(set) var costPerMinute: Double = -1
+    open fileprivate(set) var costPerMinute: Double = -1
     
     /// The charge per distance unit (if applicable).
-    public private(set) var costPerDistance: Double = -1
+    open fileprivate(set) var costPerDistance: Double = -1
     
     /// The base price.
-    public private(set) var baseFee: Double = 0
+    open fileprivate(set) var baseFee: Double = 0
     
     /// The minimum price of a trip.
-    public private(set) var minimumFee: Double = 0
+    open fileprivate(set) var minimumFee: Double = 0
     
     /// The fee if a rider cancels the trip after a grace period.
-    public private(set) var cancellationFee: Double = 0
+    open fileprivate(set) var cancellationFee: Double = 0
     
     /// Array containing additional fees added to the price. See `ServiceFee`.
-    public private(set) var serviceFees: [ServiceFee]?
+    open fileprivate(set) var serviceFees: [ServiceFee]?
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 
@@ -133,14 +133,14 @@ extension PriceDetails : Mappable {
 /**
 *  Contains information for additional fees that can be added to the price of an Uber product.
 */
-public class ServiceFee : NSObject {
+open class ServiceFee : NSObject {
     /// The name of the service fee.
-    public private(set) var name: String?
+    open fileprivate(set) var name: String?
     
     /// The amount of the service fee.
-    public private(set) var fee: Double = 0.0
+    open fileprivate(set) var fee: Double = 0.0
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/UserActivity.swift
+++ b/source/UberRides/Model/UserActivity.swift
@@ -29,20 +29,20 @@ import ObjectMapper
 /**
 *  User's lifetime trip activity with Uber.
 */
-@objc(UBSDKTripHistory) public class TripHistory: NSObject {
+@objc(UBSDKTripHistory) open class TripHistory: NSObject {
     /// Position in pagination.
-    public private(set) var offset: Int = 0
+    open fileprivate(set) var offset: Int = 0
     
     /// Number of items retrieved.
-    public private(set) var limit: Int = 0
+    open fileprivate(set) var limit: Int = 0
     
     /// Total number of items available.
-    public private(set) var count: Int = 0
+    open fileprivate(set) var count: Int = 0
     
     /// Array of trip information.
-    public private(set) var history: [UserActivity]?
+    open fileprivate(set) var history: [UserActivity]?
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 
@@ -60,32 +60,32 @@ extension TripHistory: UberModel {
 /**
 *  Information regarding an Uber trip in a user's activity history.
 */
-@objc(UBSDKUserActivity) public class UserActivity: NSObject {
+@objc(UBSDKUserActivity) open class UserActivity: NSObject {
     /// Status of the activity. Only returns completed for now.
-    public private(set) var status: RideStatus?
+    open fileprivate(set) var status: RideStatus?
     
     /// Length of activity in miles.
-    public private(set) var distance: Float = 0.0
+    open fileprivate(set) var distance: Float = 0.0
     
     /// Represents timestamp of activity request time in current locale.
-    public private(set) var requestTime: NSDate?
+    open fileprivate(set) var requestTime: Date?
     
     /// Represents timestamp of activity start time in current locale.
-    public private(set) var startTime: NSDate?
+    open fileprivate(set) var startTime: Date?
     
     /// Represents timestamp of activity end time in current locale.
-    public private(set) var endTime: NSDate?
+    open fileprivate(set) var endTime: Date?
     
     /// City that activity started in.
-    public private(set) var startCity: TripCity?
+    open fileprivate(set) var startCity: TripCity?
     
     /// Unique activity identifier.
-    public private(set) var requestID: String?
+    open fileprivate(set) var requestID: String?
     
     /// Unique identifier representing a specific product for a given latitude & longitude.
-    public private(set) var productID: String?
+    open fileprivate(set) var productID: String?
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 
@@ -99,7 +99,7 @@ extension UserActivity: UberModel {
         requestID   <- map["request_id"]
         productID   <- map["product_id"]
         
-        status = .Unknown
+        status = .unknown
         if let value = map["status"].currentValue as? String {
             status = RideStatusFactory.convertRideStatus(value)
         }
@@ -111,17 +111,17 @@ extension UserActivity: UberModel {
 /**
 *  Information relating to a city in a trip activity.
 */
-@objc(UBSDKTripCity) public class TripCity : NSObject {
+@objc(UBSDKTripCity) open class TripCity : NSObject {
     /// Latitude of city location.
-    public private(set) var latitude: Float = 0.0
+    open fileprivate(set) var latitude: Float = 0.0
     
     /// Longitude of city location.
-    public private(set) var longitude: Float = 0.0
+    open fileprivate(set) var longitude: Float = 0.0
     
     /// Display name of city.
-    public private(set) var name: String?
+    open fileprivate(set) var name: String?
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/UserProfile.swift
+++ b/source/UberRides/Model/UserProfile.swift
@@ -29,26 +29,26 @@ import ObjectMapper
 /**
 *  Information regarding an Uber user.
 */
-@objc(UBSDKUserProfile) public class UserProfile: NSObject {
+@objc(UBSDKUserProfile) open class UserProfile: NSObject {
     /// First name of the Uber user.
-    public private(set) var firstName: String?
+    open fileprivate(set) var firstName: String?
     
     /// Last name of the Uber user.
-    public private(set) var lastName: String?
+    open fileprivate(set) var lastName: String?
     
     /// Email address of the Uber user.
-    public private(set) var email: String?
+    open fileprivate(set) var email: String?
     
     /// Image URL of the Uber user.
-    public private(set) var picturePath: String?
+    open fileprivate(set) var picturePath: String?
     
     /// Promo code of the Uber user.
-    public private(set) var promoCode: String?
+    open fileprivate(set) var promoCode: String?
     
     /// Unique identifier of the Uber user.
-    public private(set) var UUID: String?
+    open fileprivate(set) var UUID: String?
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/Model/Vehicle.swift
+++ b/source/UberRides/Model/Vehicle.swift
@@ -29,21 +29,21 @@ import ObjectMapper
 /**
  *  Contains information for an Uber driver's car.
  */
-@objc(UBSDKVehicle) public class Vehicle: NSObject {
+@objc(UBSDKVehicle) open class Vehicle: NSObject {
     
     /// The license plate number of the vehicle.
-    public private(set) var licensePlate: String?
+    open fileprivate(set) var licensePlate: String?
     
     /// The vehicle make or brand.
-    public private(set) var make: String?
+    open fileprivate(set) var make: String?
     
     /// The vehicle model or type.
-    public private(set) var model: String?
+    open fileprivate(set) var model: String?
     
     /// The URL to a stock photo of the vehicle (may be null).
-    public private(set) var pictureURL: String?
+    open fileprivate(set) var pictureURL: String?
     
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
 }
 

--- a/source/UberRides/ModelMapper.swift
+++ b/source/UberRides/ModelMapper.swift
@@ -25,21 +25,21 @@
 import ObjectMapper
 
 protocol UberModel: Mappable {
-    init?(_ map: Map)
+    init?(map: Map)
     mutating func mapping(map: Map)
 }
 
 /**
  *  Layer between models and external callers mapping JSON to and from models.
  */
-struct ModelMapper<U where U:UberModel> {
+struct ModelMapper<U> where U:UberModel {
     /**
      Map a JSON string representation to a model that conforms to the Mappable protocol.
      
      - parameter json: string representing the JSON information.
      - returns: an object that conforms to the Mappable protocol.
      */
-    func mapFromJSON(json: NSString) -> U? {
-        return Mapper<U>().map(json)
+    func mapFromJSON(_ json: NSString) -> U? {
+        return Mapper<U>().map(JSONString: json as String)
     }
 }

--- a/source/UberRides/OAuth/AccessToken.swift
+++ b/source/UberRides/OAuth/AccessToken.swift
@@ -25,19 +25,19 @@
 import ObjectMapper
 
 /// Stores information about an access token used for authorizing requests.
-@objc(UBSDKAccessToken) public class AccessToken: NSObject, NSCoding, UberModel {
+@objc(UBSDKAccessToken) open class AccessToken: NSObject, NSCoding, UberModel {
     
     /// String containing the bearer token.
-    public private(set) var tokenString: String?
+    open fileprivate(set) var tokenString: String?
     
     /// String containing the refresh token.
-    public private(set) var refreshToken: String?
+    open fileprivate(set) var refreshToken: String?
     
     /// The expiration date for this access token
-    public private(set) var expirationDate: NSDate?
+    open fileprivate(set) var expirationDate: Date?
     
     /// The scopes this token is valid for
-    public private(set) var grantedScopes: [RidesScope]?
+    open fileprivate(set) var grantedScopes: [RidesScope]?
     
     /**
      Initializes an AccessToken with the provided tokenString
@@ -61,13 +61,13 @@ import ObjectMapper
      */
     @objc public required init?(coder decoder: NSCoder) {
         super.init()
-        guard let token = decoder.decodeObjectForKey("tokenString") as? String else {
+        guard let token = decoder.decodeObject(forKey: "tokenString") as? String else {
             return nil
         }
         tokenString = token
-        refreshToken = decoder.decodeObjectForKey("refreshToken") as? String
-        expirationDate = decoder.decodeObjectForKey("expirationDate") as? NSDate
-        if let scopesString = decoder.decodeObjectForKey("grantedScopes") as? String {
+        refreshToken = decoder.decodeObject(forKey: "refreshToken") as? String
+        expirationDate = decoder.decodeObject(forKey: "expirationDate") as? Date
+        if let scopesString = decoder.decodeObject(forKey: "grantedScopes") as? String {
             grantedScopes = scopesString.toRidesScopesArray()
         }
     }
@@ -79,7 +79,7 @@ import ObjectMapper
      
      - returns: An initialized AccessToken, or nil if someting went wrong
      */
-    public required init?(_ map: Map) {
+    public required init?(map: Map) {
     }
     
     /**
@@ -87,11 +87,11 @@ import ObjectMapper
      
      - parameter coder: The NSCoder to encode the access token on
      */
-    @objc public func encodeWithCoder(coder: NSCoder) {
-        coder.encodeObject(self.tokenString, forKey: "tokenString")
-        coder.encodeObject(self.refreshToken, forKey:  "refreshToken")
-        coder.encodeObject(self.expirationDate, forKey: "expirationDate")
-        coder.encodeObject(self.grantedScopes?.toRidesScopeString(), forKey: "grantedScopes")
+    @objc open func encode(with coder: NSCoder) {
+        coder.encode(self.tokenString, forKey: "tokenString")
+        coder.encode(self.refreshToken, forKey:  "refreshToken")
+        coder.encode(self.expirationDate, forKey: "expirationDate")
+        coder.encode(self.grantedScopes?.toRidesScopeString(), forKey: "grantedScopes")
     }
     
     /**
@@ -100,7 +100,7 @@ import ObjectMapper
      
      - parameter map: The Map to use for populatng this AccessToken.
      */
-    public func mapping(map: Map) {
+    open func mapping(map: Map) {
         tokenString         <- map["access_token"]
         refreshToken        <- map["refresh_token"]
         expirationDate <- (map["expiration_date"], DateTransform())

--- a/source/UberRides/OAuth/AccessTokenFactory.swift
+++ b/source/UberRides/OAuth/AccessTokenFactory.swift
@@ -28,10 +28,10 @@ import Foundation
 /**
 Factory class to build access tokens
 */
-@objc(UBSDKAccessTokenFactory) public class AccessTokenFactory: NSObject {
+@objc(UBSDKAccessTokenFactory) open class AccessTokenFactory: NSObject {
     
-    @objc public static func createAccessTokenFromJSONString(string: String) -> AccessToken? {
-        return ModelMapper<AccessToken>().mapFromJSON(string)
+    @objc open static func createAccessTokenFromJSONString(_ string: String) -> AccessToken? {
+        return ModelMapper<AccessToken>().mapFromJSON(string as NSString)
     }
     
     /**
@@ -41,9 +41,9 @@ Factory class to build access tokens
      - parameter url: The URL to parse the token from
      - returns: An initialized AccessToken, or nil if one couldn't be created
      */
-    static func createAccessTokenFromRedirectURL(url : NSURL) throws -> AccessToken {
-        guard let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false) else {
-            throw RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .InvalidResponse)
+    static func createAccessTokenFromRedirectURL(_ url : URL) throws -> AccessToken {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            throw RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidResponse)
         }
 
         var finalQueryArray = [String]()
@@ -54,10 +54,10 @@ Factory class to build access tokens
             finalQueryArray.append(existingFragment)
         }
         components.fragment = nil
-        components.query = finalQueryArray.joinWithSeparator("&")
+        components.query = finalQueryArray.joined(separator: "&")
         
         guard let queryItems = components.queryItems else {
-            throw RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .InvalidRequest)
+            throw RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidRequest)
         }
         var queryDictionary = [String : String]()
         for queryItem in queryItems {
@@ -68,20 +68,20 @@ Factory class to build access tokens
         }
         if let error = queryDictionary["error"] {
             guard let error = RidesAuthenticationErrorFactory.createRidesAuthenticationError(rawValue: error) else {
-                throw RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .InvalidRequest)
+                throw RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidRequest)
             }
             throw error
         } else {
             if let expiresInString = queryDictionary["expires_in"] as String? {
-                let expiresInSeconds =  NSTimeInterval(atof(expiresInString))
-                let expirationDateSeconds = NSDate().timeIntervalSince1970 + expiresInSeconds
+                let expiresInSeconds =  TimeInterval(atof(expiresInString))
+                let expirationDateSeconds = Date().timeIntervalSince1970 + expiresInSeconds
                 queryDictionary["expiration_date"] = "\(expirationDateSeconds)"
-                queryDictionary.removeValueForKey("expires_in")
+                queryDictionary.removeValue(forKey: "expires_in")
             }
             if let token = AccessToken(JSON: queryDictionary) {
                 return token
             }
         }
-        throw RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .InvalidResponse)
+        throw RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidResponse)
     }
 }

--- a/source/UberRides/OAuth/AuthorizationCodeGrantAuthenticator.swift
+++ b/source/UberRides/OAuth/AuthorizationCodeGrantAuthenticator.swift
@@ -24,28 +24,28 @@
 
 import UIKit
 
-@objc(UBSDKAuthorizationCodeGrantAuthenticator) public class AuthorizationCodeGrantAuthenticator: LoginViewAuthenticator {
-    public var state: String?
+@objc(UBSDKAuthorizationCodeGrantAuthenticator) open class AuthorizationCodeGrantAuthenticator: LoginViewAuthenticator {
+    open var state: String?
     
     @objc public init(presentingViewController: UIViewController, scopes: [RidesScope], state: String?) {
         self.state = state
         super.init(presentingViewController: presentingViewController, scopes: scopes)
-        callbackURIType = .AuthorizationCode
+        callbackURIType = .authorizationCode
     }
     
     override var endpoint: UberAPI {
-        return OAuth.AuthorizationCodeLogin(clientID: Configuration.getClientID(), redirect: Configuration.getCallbackURIString(.AuthorizationCode), scopes: scopes, state: state)
+        return OAuth.authorizationCodeLogin(clientID: Configuration.getClientID(), redirect: Configuration.getCallbackURIString(.authorizationCode), scopes: scopes, state: state)
     }
     
     override public convenience init(presentingViewController: UIViewController, scopes: [RidesScope]) {
         self.init(presentingViewController: presentingViewController, scopes: scopes, state: nil)
     }
     
-    override func handleRedirectRequest(request: NSURLRequest) -> Bool {
+    override func handleRedirectRequest(_ request: URLRequest) -> Bool {
         var shouldHandle = false
-        if let url = request.URL where AuthenticationURLUtility.shouldHandleRedirectURL(url, type: callbackURIType) {
-            if let urlComponents = NSURLComponents(URL: url, resolvingAgainstBaseURL: false),
-                let queryItems = urlComponents.queryItems where queryItems.contains({ $0.name == "error" }) {
+        if let url = request.url , AuthenticationURLUtility.shouldHandleRedirectURL(url, type: callbackURIType) {
+            if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                let queryItems = urlComponents.queryItems , queryItems.contains(where: { $0.name == "error" }) {
                 shouldHandle = false
             } else {
                 shouldHandle = true
@@ -54,14 +54,14 @@ import UIKit
         
         if shouldHandle {
             executeRedirect(request)
-            loginCompletion?(accessToken: nil, error: nil)
+            loginCompletion?(nil, nil)
         } else {
             shouldHandle = super.handleRedirectRequest(request)
         }
         return shouldHandle
     }
     
-    func executeRedirect(request: NSURLRequest) {
-        NSURLSession.sharedSession().dataTaskWithRequest(request).resume()
+    func executeRedirect(_ request: URLRequest) {
+        URLSession.shared.dataTask(with: request).resume()
     }
 }

--- a/source/UberRides/OAuth/BaseAuthenticator.swift
+++ b/source/UberRides/OAuth/BaseAuthenticator.swift
@@ -25,31 +25,31 @@
 import UIKit
 
 /// Base class for authorization flows that use the LoginView.
-@objc(UBSDKBaseAuthenticator) public class BaseAuthenticator: NSObject, UberAuthenticating {
+@objc(UBSDKBaseAuthenticator) open class BaseAuthenticator: NSObject, UberAuthenticating {
     
     /// Optional identifier for saving the access token in keychain
-    public var accessTokenIdentifier: String?
+    open var accessTokenIdentifier: String?
     
     /// Optional access group for saving the access token in keychain
-    public var keychainAccessGroup: String?
+    open var keychainAccessGroup: String?
     
     /// Completion block for when login has completed
-    public var loginCompletion: ((accessToken: AccessToken?, error: NSError?) -> Void)?
+    open var loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?
     
     /// Scopes to request during login
-    public var scopes: [RidesScope]
+    open var scopes: [RidesScope]
     
     /// The Callback URL Type to use for this authentication method
-    public var callbackURIType: CallbackURIType = .General
+    open var callbackURIType: CallbackURIType = .general
     
     init(scopes: [RidesScope]) {
         self.scopes = scopes
         super.init()
     }
     
-    func handleRedirectRequest(request: NSURLRequest) -> Bool {
+    func handleRedirectRequest(_ request: URLRequest) -> Bool {
         var didHandleRedirect = false
-        if let url = request.URL where AuthenticationURLUtility.shouldHandleRedirectURL(url, type: callbackURIType) {
+        if let url = request.url , AuthenticationURLUtility.shouldHandleRedirectURL(url, type: callbackURIType) {
             do {
                 let accessToken = try AccessTokenFactory.createAccessTokenFromRedirectURL(url)
                 
@@ -58,14 +58,14 @@ import UIKit
                 var error: NSError?
                 let success = TokenManager.saveToken(accessToken, tokenIdentifier: tokenIdentifier, accessGroup: accessGroup)
                 if !success {
-                    error = RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .UnableToSaveAccessToken)
+                    error = RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .unableToSaveAccessToken)
                     print("Error: access token failed to save to keychain")
                 }
-                loginCompletion?(accessToken: accessToken, error: error)
+                loginCompletion?(accessToken, error)
             } catch let ridesError as NSError {
-                loginCompletion?(accessToken: nil, error: ridesError)
+                loginCompletion?(nil, ridesError)
             } catch {
-                loginCompletion?(accessToken: nil, error: RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .InvalidResponse))
+                loginCompletion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidResponse))
             }
             didHandleRedirect = true
         }

--- a/source/UberRides/OAuth/ImplicitGrantAuthenticator.swift
+++ b/source/UberRides/OAuth/ImplicitGrantAuthenticator.swift
@@ -27,14 +27,14 @@ import UIKit
 /**
  *  Defines the implicit grant authorization flow where access token is extracted from redirect fragment.
  */
-@objc(UBSDKImplicitGrantAuthenticator) public class ImplicitGrantAuthenticator: LoginViewAuthenticator {
+@objc(UBSDKImplicitGrantAuthenticator) open class ImplicitGrantAuthenticator: LoginViewAuthenticator {
     
     override var endpoint: UberAPI {
-        return OAuth.ImplicitLogin(clientID: Configuration.getClientID(), scopes: self.scopes, redirect: Configuration.getCallbackURIString(.Implicit))
+        return OAuth.implicitLogin(clientID: Configuration.getClientID(), scopes: self.scopes, redirect: Configuration.getCallbackURIString(.implicit))
     }
     
     override public init(presentingViewController: UIViewController, scopes: [RidesScope]) {
         super.init(presentingViewController: presentingViewController, scopes: scopes)
-        callbackURIType = .Implicit
+        callbackURIType = .implicit
     }
 }

--- a/source/UberRides/OAuth/KeychainWrapper.swift
+++ b/source/UberRides/OAuth/KeychainWrapper.swift
@@ -24,25 +24,25 @@
 
 /// Wraps saving and retrieving objects from keychain.
 class KeychainWrapper: NSObject {
-    private static let serviceName = "com.uber.rides-ios-sdk"
-    private var accessGroup = ""
+    fileprivate static let serviceName = "com.uber.rides-ios-sdk"
+    fileprivate var accessGroup = ""
     
-    private let Class = kSecClass as String
-    private let AttrAccount = kSecAttrAccount as String
-    private let AttrService = kSecAttrService as String
-    private let AttrAccessGroup = kSecAttrAccessGroup as String
-    private let AttrGeneric = kSecAttrGeneric as String
-    private let AttrAccessible = kSecAttrAccessible as String
-    private let ReturnData = kSecReturnData as String
-    private let ValueData = kSecValueData as String
-    private let MatchLimit = kSecMatchLimit as String
+    fileprivate let Class = kSecClass as String
+    fileprivate let AttrAccount = kSecAttrAccount as String
+    fileprivate let AttrService = kSecAttrService as String
+    fileprivate let AttrAccessGroup = kSecAttrAccessGroup as String
+    fileprivate let AttrGeneric = kSecAttrGeneric as String
+    fileprivate let AttrAccessible = kSecAttrAccessible as String
+    fileprivate let ReturnData = kSecReturnData as String
+    fileprivate let ValueData = kSecValueData as String
+    fileprivate let MatchLimit = kSecMatchLimit as String
     
     /**
      Set the access group for keychain to use.
      
      - parameter group: String representing name of keychain access group.
      */
-    func setAccessGroup(accessGroup: String) {
+    func setAccessGroup(_ accessGroup: String) {
         self.accessGroup = accessGroup
     }
     
@@ -54,17 +54,17 @@ class KeychainWrapper: NSObject {
      
      - returns: true if object was successfully added to keychain.
      */
-    func setObject(object: NSCoding, key: String) -> Bool {
+    func setObject(_ object: NSCoding, key: String) -> Bool {
         var keychainItemData = getKeychainItemData(key)
 
-        let value = NSKeyedArchiver.archivedDataWithRootObject(object)
+        let value = NSKeyedArchiver.archivedData(withRootObject: object)
         keychainItemData[AttrAccessible] = kSecAttrAccessibleWhenUnlocked
-        keychainItemData[ValueData] = value
+        keychainItemData[ValueData] = value as AnyObject?
         
-        var result: OSStatus = SecItemAdd(keychainItemData, nil)
+        var result: OSStatus = SecItemAdd(keychainItemData as CFDictionary, nil)
         
         if result == errSecDuplicateItem {
-            result = SecItemUpdate(keychainItemData, [ValueData: value])
+            result = SecItemUpdate(keychainItemData as CFDictionary, [ValueData: value] as CFDictionary)
         }
         
         return result == errSecSuccess
@@ -77,21 +77,21 @@ class KeychainWrapper: NSObject {
      
      - returns: the object in keychain or nil if none exists for the given key.
      */
-    func getObjectForKey(key: String) -> NSCoding? {
+    func getObjectForKey(_ key: String) -> NSCoding? {
         var keychainItemData = getKeychainItemData(key)
         
         keychainItemData[MatchLimit] = kSecMatchLimitOne
         keychainItemData[ReturnData] = kCFBooleanTrue
         
         var data: AnyObject?
-        let result = withUnsafeMutablePointer(&data) {
-            SecItemCopyMatching(keychainItemData, UnsafeMutablePointer($0))
+        let result = withUnsafeMutablePointer(to: &data) {
+            SecItemCopyMatching(keychainItemData as CFDictionary, UnsafeMutablePointer($0))
         }
         
         var object: AnyObject?
         
-        if let data = data as? NSData {
-            object = NSKeyedUnarchiver.unarchiveObjectWithData(data)
+        if let data = data as? Data {
+            object = NSKeyedUnarchiver.unarchiveObject(with: data) as AnyObject?
         }
         
         return result == noErr ? object as? NSCoding : nil
@@ -104,10 +104,10 @@ class KeychainWrapper: NSObject {
      
      - returns: true if object was successfully deleted.
      */
-    func deleteObjectForKey(key: String) -> Bool {
+    func deleteObjectForKey(_ key: String) -> Bool {
         let keychainItemData = getKeychainItemData(key)
         
-        let result = SecItemDelete(keychainItemData)
+        let result = SecItemDelete(keychainItemData as CFDictionary)
         
         return result == noErr
     }
@@ -117,17 +117,17 @@ class KeychainWrapper: NSObject {
      
      - returns: dictionary of base attributes for keychain query.
      */
-    private func getKeychainItemData(key: String) -> [String: AnyObject] {
+    fileprivate func getKeychainItemData(_ key: String) -> [String: AnyObject] {
         var keychainItemData = [String: AnyObject]()
         
-        let identifier = key.dataUsingEncoding(NSUTF8StringEncoding)
-        keychainItemData[AttrGeneric] = identifier
-        keychainItemData[AttrAccount] = identifier
-        keychainItemData[AttrService] = self.dynamicType.serviceName
+        let identifier = key.data(using: String.Encoding.utf8)
+        keychainItemData[AttrGeneric] = identifier as AnyObject?
+        keychainItemData[AttrAccount] = identifier as AnyObject?
+        keychainItemData[AttrService] = type(of: self).serviceName as AnyObject?
         keychainItemData[Class] = kSecClassGenericPassword
         
         if !accessGroup.isEmpty {
-            keychainItemData[AttrAccount] = accessGroup
+            keychainItemData[AttrAccount] = accessGroup as AnyObject?
         }
         
         return keychainItemData

--- a/source/UberRides/OAuth/LoginManager.swift
+++ b/source/UberRides/OAuth/LoginManager.swift
@@ -25,10 +25,10 @@
 
 
 /// Manages user login via SSO, authorization code grant, or implicit grant.
-@objc(UBSDKLoginManager) public class LoginManager: NSObject, LoginManaging {
+@objc(UBSDKLoginManager) open class LoginManager: NSObject, LoginManaging {
     
     /// Optional state to use for explcit grant authorization
-    public var state: String?
+    open var state: String?
     
     var accessTokenIdentifier: String
     var keychainAccessGroup: String
@@ -66,7 +66,7 @@
      */
     @objc public convenience init(accessTokenIdentifier: String, keychainAccessGroup: String?) {
         let accessGroup = keychainAccessGroup ?? Configuration.getDefaultKeychainAccessGroup()
-        self.init(accessTokenIdentifier: accessTokenIdentifier, keychainAccessGroup: accessGroup, loginType: LoginType.Implicit)
+        self.init(accessTokenIdentifier: accessTokenIdentifier, keychainAccessGroup: accessGroup, loginType: LoginType.implicit)
     }
     
     /**
@@ -102,7 +102,7 @@
      - returns: An initialized LoginManager
      */
     @objc public convenience override init() {
-        self.init(accessTokenIdentifier: Configuration.getDefaultAccessTokenIdentifier(), keychainAccessGroup: Configuration.getDefaultAccessTokenIdentifier(), loginType: LoginType.Native)
+        self.init(accessTokenIdentifier: Configuration.getDefaultAccessTokenIdentifier(), keychainAccessGroup: Configuration.getDefaultAccessTokenIdentifier(), loginType: LoginType.native)
     }
     
     // Mark: LoginManaging
@@ -115,28 +115,28 @@
      - parameter presentingViewController: The presenting view controller present the login view controller over.
      - parameter completion:               The LoginManagerRequestTokenHandler completion handler for login success/failure.
      */
-    @objc public func login(requestedScopes scopes: [RidesScope], presentingViewController: UIViewController? = nil, completion: ((accessToken: AccessToken?, error: NSError?) -> Void)? = nil) {
+    @objc open func login(requestedScopes scopes: [RidesScope], presentingViewController: UIViewController? = nil, completion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)? = nil) {
         guard !loggingIn else {
-            completion?(accessToken: nil, error: RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .Unavailable))
+            completion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .unavailable))
             return
         }
         
         var loginAuthenticator: UberAuthenticating!
         
         switch loginType {
-        case .AuthorizationCode:
+        case .authorizationCode:
             guard let presentingViewController = presentingViewController else {
-                completion?(accessToken: nil, error: RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .UnableToPresentLogin))
+                completion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .unableToPresentLogin))
                 return
             }
             loginAuthenticator = AuthorizationCodeGrantAuthenticator(presentingViewController: presentingViewController, scopes: scopes, state: state)
-        case .Implicit:
+        case .implicit:
             guard let presentingViewController = presentingViewController else {
-                completion?(accessToken: nil, error: RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .UnableToPresentLogin))
+                completion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .unableToPresentLogin))
                 return
             }
             loginAuthenticator = ImplicitGrantAuthenticator(presentingViewController: presentingViewController, scopes: scopes)
-        case .Native:
+        case .native:
             let nativeAuthenticator = NativeAuthenticator(scopes: scopes)
             nativeAuthenticator.deeplinkCompletion = { error in
                 if (error == nil) {
@@ -173,12 +173,12 @@
      
      - returns: true if the url was meant to be handled by the SDK, false otherwise
      */
-    public func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject?) -> Bool {
-        guard let source = sourceApplication where source.hasPrefix("com.ubercab"),
+    open func application(_ application: UIApplication, openURL url: URL, sourceApplication: String?, annotation: AnyObject?) -> Bool {
+        guard let source = sourceApplication , source.hasPrefix("com.ubercab"),
         let nativeAuthenticator = authenticator as? NativeAuthenticator else {
             return false
         }
-        let redirectURL = NSURLRequest(URL: url)
+        let redirectURL = URLRequest(url: url)
         let handled = nativeAuthenticator.handleRedirectRequest(redirectURL)
         loggingIn = false
         authenticator = nil
@@ -191,7 +191,7 @@
      
      - parameter application: The UIApplication object. Pass in the value from the App Delegate
      */
-    public func applicationDidBecomeActive() {
+    open func applicationDidBecomeActive() {
         if loggingIn {
             self.handleLoginCanceled()
         }
@@ -205,39 +205,39 @@
     
     // Mark: Private Interface
     
-    private func handleLoginCanceled() {
+    fileprivate func handleLoginCanceled() {
         loggingIn = false
-        authenticator?.loginCompletion?(accessToken: nil, error: RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .UserCancelled))
+        authenticator?.loginCompletion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .userCancelled))
         authenticator = nil
     }
     
-    private func loginCompletion(loginType: LoginType, presentingViewController: UIViewController?, completion: ((accessToken: AccessToken?, error: NSError?) -> Void)?) -> ((accessToken: AccessToken?, error: NSError?) -> Void)? {
-        var loginCompletion: ((accessToken: AccessToken?, error: NSError?) -> Void)?
+    fileprivate func loginCompletion(_ loginType: LoginType, presentingViewController: UIViewController?, completion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?) -> ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)? {
+        var loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?
         
         switch loginType {
-        case .Native:
+        case .native:
             loginCompletion = { token, error in
                 self.loggingIn = false
-                if let error = error where error.code == RidesAuthenticationErrorType.Unavailable.rawValue {
+                if let error = error , error.code == RidesAuthenticationErrorType.unavailable.rawValue {
                     self.handleNativeFallback(error, presentingViewController: presentingViewController, completion: completion)
                 } else {
-                    completion?(accessToken: token, error: error)
+                    completion?(token, error)
                 }
             }
             break
-        case .Implicit:
+        case .implicit:
             fallthrough
-        case .AuthorizationCode:
+        case .authorizationCode:
             fallthrough
         default:
             loginCompletion = { token, error in
                 self.loggingIn = false
                 if let presentingViewController = presentingViewController {
-                    presentingViewController.dismissViewControllerAnimated(true, completion: { () -> Void in
-                        completion?(accessToken: token, error: error)
+                    presentingViewController.dismiss(animated: true, completion: { () -> Void in
+                        completion?(token, error)
                     })
                 } else {
-                    completion?(accessToken: token, error: error)
+                    completion?(token, error)
                 }
             }
             break
@@ -246,24 +246,24 @@
         return loginCompletion
     }
     
-    private func handleNativeFallback(error: NSError?, presentingViewController: UIViewController?, completion: ((accessToken: AccessToken?, error: NSError?) -> Void)?) {
+    fileprivate func handleNativeFallback(_ error: NSError?, presentingViewController: UIViewController?, completion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?) {
         guard let manager = authenticator as? NativeAuthenticator else {
-            completion?(accessToken: nil, error: error)
+            completion?(nil, error)
             return
         }
         
-        if manager.scopes.contains({ $0.scopeType == .Privileged }) {
+        if manager.scopes.contains(where: { $0.scopeType == .privileged }) {
             if (Configuration.getFallbackEnabled()) {
-                loginType = .AuthorizationCode
+                loginType = .authorizationCode
             } else {
                 let appstoreDeeplink = AppStoreDeeplink(userAgent: nil)
                 appstoreDeeplink.execute({ _ in
-                    completion?(accessToken: nil, error: error)
+                    completion?(nil, error)
                 })
                 return
             }
         } else {
-            loginType = .Implicit
+            loginType = .implicit
         }
         login(requestedScopes: manager.scopes, presentingViewController: presentingViewController, completion: completion)
     }

--- a/source/UberRides/OAuth/LoginManagingProtocol.swift
+++ b/source/UberRides/OAuth/LoginManagingProtocol.swift
@@ -30,9 +30,9 @@
  - Native:   Native login (SSO via the Uber App)
  */
 @objc(UBSDKLoginType) public enum LoginType: Int {
-    case AuthorizationCode
-    case Implicit
-    case Native
+    case authorizationCode
+    case implicit
+    case native
 }
 
 @objc public protocol LoginManaging {
@@ -43,7 +43,7 @@
      - parameter presentingViewController: The presenting view controller present the login view controller over.
      - parameter completion:               The LoginManagerRequestTokenHandler completion handler for login success/failure.
      */
-    @objc func login(requestedScopes scopes: [RidesScope], presentingViewController: UIViewController?, completion: ((accessToken: AccessToken?, error: NSError?) -> Void)?)
+    @objc func login(requestedScopes scopes: [RidesScope], presentingViewController: UIViewController?, completion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?)
     
     /**
      Called via the RidesAppDelegate when the application is opened via a URL. Responsible
@@ -63,7 +63,7 @@
      
      - returns: true if the url was meant to be handled by the SDK, false otherwise
      */
-    func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject?) -> Bool
+    func application(_ application: UIApplication, openURL url: URL, sourceApplication: String?, annotation: AnyObject?) -> Bool
     
     /**
      Called via the RidesAppDelegate when the application becomes active. Used to determine

--- a/source/UberRides/OAuth/LoginView.swift
+++ b/source/UberRides/OAuth/LoginView.swift
@@ -26,9 +26,9 @@ import Foundation
 import WebKit
 
 /// Login Web View class. Wrapper around a WKWebView to handle Login flow for Implicit Grant
-@objc(UBSDKLoginView) public class LoginView : UIView {
+@objc(UBSDKLoginView) open class LoginView : UIView {
     
-    public var loginAuthenticator: LoginViewAuthenticator
+    open var loginAuthenticator: LoginViewAuthenticator
     
     var clientID = Configuration.getClientID()
     let webView: WKWebView
@@ -63,7 +63,7 @@ import WebKit
      - returns: An initialized LoginWebView
      */
     @objc public convenience init(loginAuthenticator: LoginViewAuthenticator) {
-        self.init(loginAuthenticator: loginAuthenticator, frame: CGRectZero)
+        self.init(loginAuthenticator: loginAuthenticator, frame: CGRect.zero)
     }
 
     /**
@@ -90,8 +90,8 @@ import WebKit
         self.webView.translatesAutoresizingMaskIntoConstraints = false
 
         let views = ["webView": webView]
-        let horizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[webView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
-        let verticalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[webView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
+        let horizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|[webView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
+        let verticalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "V:|[webView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
         
         addConstraints(horizontalConstraints)
         addConstraints(verticalConstraints)
@@ -102,51 +102,51 @@ import WebKit
     /**
     Loads the login page
     */
-    public func load() {
+    open func load() {
         // Create URL for request
         let request = Request(session: nil, endpoint: loginAuthenticator.endpoint)
         request.prepare()
         
         guard let _ = request.requestURL() else {
-            loginAuthenticator.loginCompletion?(accessToken: nil, error: RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType:.InvalidRequest))
+            loginAuthenticator.loginCompletion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType:.invalidRequest))
             
             return
         }
         
         // Load request in web view
-        self.webView.loadRequest(request.urlRequest)
+        self.webView.load(request.urlRequest as URLRequest)
     }
     
     /**
      Stops loading the login page and clears the view.
      If the login page has already loaded, calling this still clears the view.
      */
-    public func cancelLoad() {
+    open func cancelLoad() {
         webView.stopLoading()
-        if let url = NSURL(string: "about:blank") {
-            webView.loadRequest(NSURLRequest(URL: url))
+        if let url = URL(string: "about:blank") {
+            webView.load(URLRequest(url: url))
         }
     }
 }
 
 extension LoginView : WKNavigationDelegate {
     
-    public func webView(webView: WKWebView, decidePolicyForNavigationAction navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {
+    public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
             
         if loginAuthenticator.handleRedirectRequest(navigationAction.request) {
-            decisionHandler(WKNavigationActionPolicy.Cancel)
+            decisionHandler(WKNavigationActionPolicy.cancel)
         } else {
-            decisionHandler(WKNavigationActionPolicy.Allow)
+            decisionHandler(WKNavigationActionPolicy.allow)
         }
     }
     
-    public func webView(webView: WKWebView, didFailNavigation navigation: WKNavigation!, withError error: NSError) {
-        loginAuthenticator.loginCompletion?(accessToken: nil, error: RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .NetworkError))
+    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        loginAuthenticator.loginCompletion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .networkError))
     }
     
-    public func webView(webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: NSError) {
-        if error.code != 102 {
-            loginAuthenticator.loginCompletion?(accessToken: nil, error: RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .NetworkError))
+    public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        if error._code != 102 {
+            loginAuthenticator.loginCompletion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .networkError))
         }
     }
 }

--- a/source/UberRides/OAuth/LoginViewAuthenticator.swift
+++ b/source/UberRides/OAuth/LoginViewAuthenticator.swift
@@ -25,10 +25,10 @@
 import UIKit
 
 /// Base class for authorization flows that use the LoginView.
-@objc public class LoginViewAuthenticator: BaseAuthenticator {
+@objc open class LoginViewAuthenticator: BaseAuthenticator {
     
     /// View controller that will present the login
-    public var presentingViewController: UIViewController
+    open var presentingViewController: UIViewController
     
     /// Endpoint to hit for authorization request.
     var endpoint: UberAPI {
@@ -44,6 +44,6 @@ import UIKit
     override func login() {
         let oauthViewController = OAuthViewController(loginAuthenticator: self)
         let navController = UINavigationController(rootViewController: oauthViewController)
-        presentingViewController.presentViewController(navController, animated: true, completion: nil)
+        presentingViewController.present(navController, animated: true, completion: nil)
     }
 }

--- a/source/UberRides/OAuth/NativeAuthenticator.swift
+++ b/source/UberRides/OAuth/NativeAuthenticator.swift
@@ -27,10 +27,10 @@ import Foundation
 /**
  * UberAuthenticating object for authenticating a user via the Native Uber app
  */
-@objc(UBSSONativeAuthenticator) public class NativeAuthenticator: BaseAuthenticator {
+@objc(UBSSONativeAuthenticator) open class NativeAuthenticator: BaseAuthenticator {
     
     /// The completion block to call when the deeplink is completed. Bool indicates if the deeplink was successful
-    public var deeplinkCompletion: ((NSError?) -> ())?
+    open var deeplinkCompletion: ((NSError?) -> ())?
 
     
     var deeplink: Deeplinking
@@ -45,16 +45,16 @@ import Foundation
     @objc public override init(scopes: [RidesScope]) {
         deeplink = AuthenticationDeeplink(scopes: scopes)
         super.init(scopes: scopes)
-        callbackURIType = .Native
+        callbackURIType = .native
     }
     
     override func login() {
         deeplink.execute { error in
             
-            if let error = error where error.code == DeeplinkErrorType.UnableToFollow.rawValue {
-                self.loginCompletion?(accessToken: nil, error: RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .InvalidRequest))
+            if let error = error , error.code == DeeplinkErrorType.unableToFollow.rawValue {
+                self.loginCompletion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidRequest))
             } else if let _ = error {
-                self.loginCompletion?(accessToken: nil, error: RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .Unavailable))
+                self.loginCompletion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .unavailable))
             }
             self.deeplinkCompletion?(error)
         }

--- a/source/UberRides/OAuth/OAuthViewController.swift
+++ b/source/UberRides/OAuth/OAuthViewController.swift
@@ -51,16 +51,16 @@ class OAuthViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.edgesForExtendedLayout = UIRectEdge.None
+        self.edgesForExtendedLayout = UIRectEdge()
         self.view.addSubview(loginView)
         self.setupLoginView()
         // Set up navigation item
-        let cancelButton = UIBarButtonItem(barButtonSystemItem: .Cancel, target: self, action: #selector(cancel))
+        let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel))
         navigationItem.leftBarButtonItem = cancelButton
         navigationItem.title = LocalizationUtil.localizedString(forKey: "Sign in with Uber", comment: "Title of navigation bar during OAuth")
     }
     
-    override func viewWillAppear(animated: Bool) {
+    override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         if !hasLoaded {
@@ -69,8 +69,8 @@ class OAuthViewController: UIViewController {
     }
     
     func cancel() {
-        self.loginView.loginAuthenticator.loginCompletion?(accessToken: nil, error: RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .UserCancelled))
-        dismissViewControllerAnimated(true, completion: nil)
+        self.loginView.loginAuthenticator.loginCompletion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .userCancelled))
+        dismiss(animated: true, completion: nil)
     }
     
     //MARK: View Setup
@@ -79,8 +79,8 @@ class OAuthViewController: UIViewController {
         self.loginView.translatesAutoresizingMaskIntoConstraints = false
         
         let views = ["loginView": self.loginView]
-        let horizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[loginView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
-        let verticalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[loginView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
+        let horizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|[loginView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
+        let verticalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "V:|[loginView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
         
         self.view.addConstraints(horizontalConstraints)
         self.view.addConstraints(verticalConstraints)

--- a/source/UberRides/OAuth/UberAuthenticatingProtocol.swift
+++ b/source/UberRides/OAuth/UberAuthenticatingProtocol.swift
@@ -36,7 +36,7 @@ protocol UberAuthenticating {
     var keychainAccessGroup: String? { get set }
     
     /// Completion handler for success and errors.
-    var loginCompletion: ((accessToken: AccessToken?, error: NSError?) -> Void)? { get set }
+    var loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)? { get set }
     
     /// Scopes to request during authorization.
     var scopes: [RidesScope] { get set }
@@ -52,7 +52,7 @@ protocol UberAuthenticating {
      
      - returns: true if a redirect was handled, false otherwise.
      */
-    func handleRedirectRequest(request: NSURLRequest) -> Bool
+    func handleRedirectRequest(_ request: URLRequest) -> Bool
     
     /**
      Performs login for the requested scopes.

--- a/source/UberRides/Request.swift
+++ b/source/UberRides/Request.swift
@@ -25,18 +25,18 @@
 /**
 *  Struct that packages the response from an executed NSURLRequest.
 */
-@objc(UBSDKResponse) public class Response: NSObject {
+@objc(UBSDKResponse) open class Response: NSObject {
     /// String representing JSON response data.
-    public var data: NSData?
+    open var data: Data?
     
     /// HTTP status code of response.
-    public var statusCode: Int
+    open var statusCode: Int
     
     /// Response metadata.
-    public var response: NSHTTPURLResponse?
+    open var response: HTTPURLResponse?
     
     /// NSError representing an optional error.
-    public var error: RidesError?
+    open var error: RidesError?
     
     /**
      Initialize a Response object.
@@ -45,7 +45,7 @@
      - parameter response: Provides response metadata, such as HTTP headers and status code.
      - parameter error:    Indicates why the request failed, or nil if the request was successful.
      */
-    init(data: NSData?, statusCode: Int, response: NSHTTPURLResponse?, error: RidesError?) {
+    init(data: Data?, statusCode: Int, response: HTTPURLResponse?, error: RidesError?) {
         self.data = data
         self.response = response
         self.statusCode = statusCode
@@ -60,13 +60,13 @@
             return ""
         }
         
-        return NSString(data: data, encoding: NSUTF8StringEncoding)!
+        return NSString(data: data, encoding: String.Encoding.utf8.rawValue)!
     }
 }
 
 /// Class to create and execute NSURLRequests.
 class Request: NSObject {
-    let session: NSURLSession?
+    let session: URLSession?
     let endpoint: UberAPI
     let urlRequest: NSMutableURLRequest
     let serverToken: NSString?
@@ -80,7 +80,7 @@ class Request: NSObject {
      - parameter endpoint:    UberAPI conforming endpoint.
      - parameter serverToken: Developer's server token.
      */
-    init(session: NSURLSession?, endpoint: UberAPI, serverToken: NSString? = nil, bearerToken: NSString? = nil) {
+    init(session: URLSession?, endpoint: UberAPI, serverToken: NSString? = nil, bearerToken: NSString? = nil) {
         self.session = session
         self.endpoint = endpoint
         self.urlRequest = NSMutableURLRequest()
@@ -93,18 +93,18 @@ class Request: NSObject {
      
      - returns: constructed NSURL or nil if construction failed.
      */
-    func requestURL() -> NSURL? {
-        let components = NSURLComponents(string: endpoint.host)!
+    func requestURL() -> URL? {
+        var components = URLComponents(string: endpoint.host)!
         components.path = endpoint.path
-        components.queryItems = endpoint.query
+        components.queryItems = endpoint.query as [URLQueryItem]?
         
-        return components.URL
+        return components.url
     }
     
     /**
      Adds HTTP Headers to the request.
      */
-    private func addHeaders() {
+    fileprivate func addHeaders() {
         urlRequest.setValue("gzip, deflate", forHTTPHeaderField: "Accept-Encoding")
         if let token = bearerToken {
             urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: Header.Authorization.rawValue)
@@ -122,9 +122,9 @@ class Request: NSObject {
      Prepares the NSURLRequest by adding necessary fields.
      */
     func prepare() {
-        urlRequest.URL = requestURL()
-        urlRequest.HTTPMethod = endpoint.method.rawValue
-        urlRequest.HTTPBody = endpoint.body
+        urlRequest.url = requestURL()
+        urlRequest.httpMethod = endpoint.method.rawValue
+        urlRequest.httpBody = endpoint.body as Data?
         addHeaders()
     }
     
@@ -133,15 +133,15 @@ class Request: NSObject {
      
      - parameter completion: completion handler for returned Response.
      */
-    func execute(completion: (response: Response) -> Void) {
+    func execute(_ completion: @escaping (_ response: Response) -> Void) {
         guard let session = session else {
             return
         }
         
         prepare()
-        let task = session.dataTaskWithRequest(urlRequest, completionHandler: {
+        let task = session.dataTask(with: urlRequest as URLRequest, completionHandler: {
             (data, response, error) in
-            let httpResponse: NSHTTPURLResponse? = response as? NSHTTPURLResponse
+            let httpResponse: HTTPURLResponse? = response as? HTTPURLResponse
             var statusCode: Int = 0
             var ridesError: RidesError?
             
@@ -153,7 +153,7 @@ class Request: NSObject {
                     break errorCheck
                 }
                 
-                let jsonString = NSString(data: data!, encoding: NSUTF8StringEncoding)!
+                let jsonString = NSString(data: data!, encoding: String.Encoding.utf8.rawValue)!
                 if statusCode >= 400 && statusCode <= 499 {
                     ridesError = ModelMapper<RidesClientError>().mapFromJSON(jsonString)
                 } else if (statusCode >= 500 && statusCode <= 599) {
@@ -170,8 +170,8 @@ class Request: NSObject {
                 ridesError = RidesUnknownError()
                 
                 if let error = error {
-                    ridesError!.title = error.domain
-                    ridesError!.status = error.code
+                    ridesError!.title = error._domain
+                    ridesError!.status = error._code
                 } else {
                     ridesError!.title = "Request could not complete"
                     ridesError!.code = "request_error"
@@ -179,7 +179,7 @@ class Request: NSObject {
             }
             
             let ridesResponse = Response(data: data, statusCode: statusCode, response: httpResponse, error: ridesError)
-            completion(response: ridesResponse)
+            completion(ridesResponse)
         })
         task.resume()
     }

--- a/source/UberRides/RequestDeeplink.swift
+++ b/source/UberRides/RequestDeeplink.swift
@@ -29,10 +29,10 @@ import UIKit
 /**
  *  Builds and executes a deeplink to the native Uber app to request a ride.
  */
-@objc(UBSDKRequestDeeplink) public class RequestDeeplink: BaseDeeplink {
+@objc(UBSDKRequestDeeplink) open class RequestDeeplink: BaseDeeplink {
     
-    private let parameters: RideParameters
-    private let clientID: String
+    fileprivate let parameters: RideParameters
+    fileprivate let clientID: String
     
     static let sourceString = "deeplink"
     

--- a/source/UberRides/RequestURLBuilder.swift
+++ b/source/UberRides/RequestURLBuilder.swift
@@ -26,7 +26,7 @@ import CoreLocation
 
 class RequestURLBuilder {
     
-    private enum LocationType: String {
+    fileprivate enum LocationType: String {
         case Pickup = "pickup"
         case Dropoff = "dropoff"
     }
@@ -43,66 +43,66 @@ class RequestURLBuilder {
     static let deeplinkScheme = "uber"
     static let userAgentKey = "user-agent"
     
-    private let clientID: String
-    private var rideParameters: RideParameters?
+    fileprivate let clientID: String
+    fileprivate var rideParameters: RideParameters?
     
     init() {
         clientID = Configuration.getClientID()
     }
     
-    func setRideParameters(rideParameters: RideParameters) -> RequestURLBuilder {
+    func setRideParameters(_ rideParameters: RideParameters) -> RequestURLBuilder {
         self.rideParameters = rideParameters
         
         return self
     }
     
-    func build() -> NSURL? {
+    func build() -> URL? {
         guard let rideParameters = rideParameters else {
             return nil
         }
-        let urlComponents = NSURLComponents()
+        var urlComponents = URLComponents()
         
         urlComponents.scheme = RequestURLBuilder.deeplinkScheme
         urlComponents.host = ""
         
-        var queryItems = [NSURLQueryItem]()
-        queryItems.append(NSURLQueryItem(name: RequestURLBuilder.actionKey, value: RequestURLBuilder.setPickupValue))
-        queryItems.append(NSURLQueryItem(name: RequestURLBuilder.clientIDKey, value: clientID))
+        var queryItems = [URLQueryItem]()
+        queryItems.append(URLQueryItem(name: RequestURLBuilder.actionKey, value: RequestURLBuilder.setPickupValue))
+        queryItems.append(URLQueryItem(name: RequestURLBuilder.clientIDKey, value: clientID))
         
         if let productID = rideParameters.productID {
-            queryItems.append(NSURLQueryItem(name: RequestURLBuilder.productIDKey, value: productID))
+            queryItems.append(URLQueryItem(name: RequestURLBuilder.productIDKey, value: productID))
         }
         
         if let location = rideParameters.pickupLocation {
-            queryItems.appendContentsOf(addLocation(LocationType.Pickup, location: location, nickname: rideParameters.pickupNickname, address: rideParameters.pickupAddress))
+            queryItems.append(contentsOf: addLocation(LocationType.Pickup, location: location, nickname: rideParameters.pickupNickname, address: rideParameters.pickupAddress))
         } else {
-            queryItems.append(NSURLQueryItem(name: LocationType.Pickup.rawValue, value: RequestURLBuilder.currentLocationValue))
+            queryItems.append(URLQueryItem(name: LocationType.Pickup.rawValue, value: RequestURLBuilder.currentLocationValue))
         }
         
         if let location = rideParameters.dropoffLocation {
-            queryItems.appendContentsOf(addLocation(LocationType.Dropoff, location: location, nickname: rideParameters.dropoffNickname, address: rideParameters.dropoffAddress))
+            queryItems.append(contentsOf: addLocation(LocationType.Dropoff, location: location, nickname: rideParameters.dropoffNickname, address: rideParameters.dropoffAddress))
         }
         
-        queryItems.append(NSURLQueryItem(name: RequestURLBuilder.userAgentKey, value: rideParameters.userAgent))
+        queryItems.append(URLQueryItem(name: RequestURLBuilder.userAgentKey, value: rideParameters.userAgent))
         
         urlComponents.queryItems = queryItems
         
-        return urlComponents.URL
+        return urlComponents.url
     }
     
-    private func addLocation(locationType: LocationType, location: CLLocation, nickname: String?, address: String?) -> [NSURLQueryItem] {
-        var queryItems = [NSURLQueryItem]()
+    fileprivate func addLocation(_ locationType: LocationType, location: CLLocation, nickname: String?, address: String?) -> [URLQueryItem] {
+        var queryItems = [URLQueryItem]()
         
         let locationPrefix = locationType.rawValue
         let latitudeString = "\(location.coordinate.latitude)"
         let longitudeString = "\(location.coordinate.longitude)"
-        queryItems.append(NSURLQueryItem(name: locationPrefix + RequestURLBuilder.latitudeKey, value: latitudeString))
-        queryItems.append(NSURLQueryItem(name: locationPrefix + RequestURLBuilder.longitudeKey, value: longitudeString))
+        queryItems.append(URLQueryItem(name: locationPrefix + RequestURLBuilder.latitudeKey, value: latitudeString))
+        queryItems.append(URLQueryItem(name: locationPrefix + RequestURLBuilder.longitudeKey, value: longitudeString))
         if let nickname = nickname {
-            queryItems.append(NSURLQueryItem(name: locationPrefix + RequestURLBuilder.nicknameKey, value: nickname))
+            queryItems.append(URLQueryItem(name: locationPrefix + RequestURLBuilder.nicknameKey, value: nickname))
         }
         if let address = address {
-            queryItems.append(NSURLQueryItem(name: locationPrefix + RequestURLBuilder.formattedAddressKey, value: address))
+            queryItems.append(URLQueryItem(name: locationPrefix + RequestURLBuilder.formattedAddressKey, value: address))
         }
         
         return queryItems

--- a/source/UberRides/RideRequestButton.swift
+++ b/source/UberRides/RideRequestButton.swift
@@ -34,7 +34,7 @@ import CoreLocation
      
      - parameter button: the RideRequestButton
      */
-    @objc func rideRequestButtonDidLoadRideInformation(button: RideRequestButton)
+    @objc func rideRequestButtonDidLoadRideInformation(_ button: RideRequestButton)
     
     /**
      The button encountered an error when refreshing its metadata content.
@@ -42,29 +42,29 @@ import CoreLocation
      - parameter button: the RideRequestButton
      - parameter error:  the error that it encountered
      */
-    @objc func rideRequestButton(button: RideRequestButton, didReceiveError error: RidesError)
+    @objc func rideRequestButton(_ button: RideRequestButton, didReceiveError error: RidesError)
 }
 
 /// RequestButton implements a button on the touch screen to request a ride.
-@objc(UBSDKRideRequestButton) public class RideRequestButton: UberButton {
+@objc(UBSDKRideRequestButton) open class RideRequestButton: UberButton {
     /// Delegate is informed of events that occur with request button.
-    public var delegate: RideRequestButtonDelegate?
+    open var delegate: RideRequestButtonDelegate?
     
     /// The RideParameters object this button will use to make a request
-    public var rideParameters: RideParameters
+    open var rideParameters: RideParameters
     
     /// The RideRequesting object the button will use to make a request
-    public var requestBehavior: RideRequesting
+    open var requestBehavior: RideRequesting
     
     /// The RidesClient used for retrieving metadata for the button.
-    public var client: RidesClient?
+    open var client: RidesClient?
     
     static let sourceString = "button"
     
     var metadata: ButtonMetadata = ButtonMetadata()
     var uberMetadataLabel: UILabel = UILabel()
     
-    private let opticalCorrection: CGFloat = 1.0
+    fileprivate let opticalCorrection: CGFloat = 1.0
     
     /**
      Initializer to use in storyboard. Must call setRidesClient for request button to show metadata.
@@ -89,7 +89,7 @@ import CoreLocation
     @objc public init(client: RidesClient, rideParameters: RideParameters, requestingBehavior: RideRequesting) {
         requestBehavior = requestingBehavior
         self.rideParameters = rideParameters
-        super.init(frame: CGRectZero)
+        super.init(frame: CGRect.zero)
         self.client = client
     }
     
@@ -162,16 +162,16 @@ import CoreLocation
     /**
      Setup the RideRequestButton by adding  a target to the button and setting the login completion block
      */
-    override public func setup() {
+    override open func setup() {
         super.setup()
-        addTarget(self, action: #selector(uberButtonTapped(_:)), forControlEvents: .TouchUpInside)
+        addTarget(self, action: #selector(uberButtonTapped(_:)), for: .touchUpInside)
         sizeToFit()
     }
     
     /**
      Adds the Metadata Label to the button
      */
-    override public func addSubviews() {
+    override open func addSubviews() {
         super.addSubviews()
         addSubview(uberMetadataLabel)
     }
@@ -179,27 +179,27 @@ import CoreLocation
     /**
      Updates the content of the button. Sets the image icon and font, as well as the text
      */
-    override public func setContent() {
+    override open func setContent() {
         super.setContent()
         
         uberMetadataLabel.numberOfLines = 2
-        uberMetadataLabel.textColor = colorStyle == .Black ? ColorUtil.colorForUberButtonColor(.UberWhite) : ColorUtil.colorForUberButtonColor(.UberBlack)
-        uberMetadataLabel.textAlignment = .Right
+        uberMetadataLabel.textColor = colorStyle == .black ? ColorUtil.colorForUberButtonColor(.uberWhite) : ColorUtil.colorForUberButtonColor(.uberBlack)
+        uberMetadataLabel.textAlignment = .right
         
-        uberTitleLabel.font = UIFont(name: "HelveticaNeue-Medium", size: 15) ?? UIFont.systemFontOfSize(16)
+        uberTitleLabel.font = UIFont(name: "HelveticaNeue-Medium", size: 15) ?? UIFont.systemFont(ofSize: 16)
         
         let titleText = LocalizationUtil.localizedString(forKey: "Ride there with Uber", comment: "Request button description")
         uberTitleLabel.text = titleText
         
         let logo = getImage("Badge")
         uberImageView.image = logo
-        uberImageView.contentMode = .Center
+        uberImageView.contentMode = .center
     }
     
     /**
      Adds the layout constraints for the ride request button.
      */
-    override public func setConstraints() {
+    override open func setConstraints() {
         
         uberTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         uberImageView.translatesAutoresizingMaskIntoConstraints = false
@@ -208,33 +208,33 @@ import CoreLocation
         let views = ["image": uberImageView, "titleLabel": uberTitleLabel, "metadataLabel": uberMetadataLabel]
         let metrics = ["edgePadding": horizontalEdgePadding, "verticalPadding": verticalPadding, "imageLabelPadding": imageLabelPadding, "middlePadding": horizontalEdgePadding*2]
         
-        uberImageView.setContentHuggingPriority(UILayoutPriorityDefaultHigh, forAxis: .Horizontal)
-        uberTitleLabel.setContentHuggingPriority(UILayoutPriorityDefaultHigh, forAxis: .Horizontal)
-        uberTitleLabel.setContentHuggingPriority(UILayoutPriorityDefaultHigh, forAxis: .Vertical)
-        uberMetadataLabel.setContentHuggingPriority(UILayoutPriorityDefaultLow, forAxis: .Horizontal)
+        uberImageView.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .horizontal)
+        uberTitleLabel.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .horizontal)
+        uberTitleLabel.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .vertical)
+        uberMetadataLabel.setContentHuggingPriority(UILayoutPriorityDefaultLow, for: .horizontal)
         
-        let horizontalConstraints: [NSLayoutConstraint] = NSLayoutConstraint.constraintsWithVisualFormat("H:|-edgePadding-[image]-imageLabelPadding-[titleLabel]-middlePadding-[metadataLabel]-edgePadding-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views)
-        let verticalConstraints: [NSLayoutConstraint] = NSLayoutConstraint.constraintsWithVisualFormat("V:|-verticalPadding-[image]-verticalPadding-|", options: .AlignAllLeading, metrics: metrics, views: views)
+        let horizontalConstraints: [NSLayoutConstraint] = NSLayoutConstraint.constraints(withVisualFormat: "H:|-edgePadding-[image]-imageLabelPadding-[titleLabel]-middlePadding-[metadataLabel]-edgePadding-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views)
+        let verticalConstraints: [NSLayoutConstraint] = NSLayoutConstraint.constraints(withVisualFormat: "V:|-verticalPadding-[image]-verticalPadding-|", options: .alignAllLeading, metrics: metrics, views: views)
         
         let titleLabelCenterConstraint = NSLayoutConstraint(item: self,
-                                                            attribute: .CenterY,
-                                                            relatedBy: .Equal,
+                                                            attribute: .centerY,
+                                                            relatedBy: .equal,
                                                             toItem: uberTitleLabel,
-                                                            attribute: .CenterY,
+                                                            attribute: .centerY,
                                                             multiplier: 1.0,
                                                             constant: opticalCorrection)
         let metadataLabelCenterConstraint = NSLayoutConstraint(item: self,
-                                                               attribute: .CenterY,
-                                                               relatedBy: .Equal,
+                                                               attribute: .centerY,
+                                                               relatedBy: .equal,
                                                                toItem: uberMetadataLabel,
-                                                               attribute: .CenterY,
+                                                               attribute: .centerY,
                                                                multiplier: 1.0,
                                                                constant: 0)
         let imageViewCenterConstraint = NSLayoutConstraint(item: self,
-                                                           attribute: .CenterY,
-                                                           relatedBy: .Equal,
+                                                           attribute: .centerY,
+                                                           relatedBy: .equal,
                                                            toItem: uberImageView,
-                                                           attribute: .CenterY,
+                                                           attribute: .centerY,
                                                            multiplier: 1.0,
                                                            constant: 0)
         
@@ -243,23 +243,23 @@ import CoreLocation
         addConstraints([titleLabelCenterConstraint, metadataLabelCenterConstraint, imageViewCenterConstraint])
     }
     
-    override func colorStyleDidUpdate(style: RequestButtonColorStyle) {
+    override func colorStyleDidUpdate(_ style: RequestButtonColorStyle) {
         super.colorStyleDidUpdate(style)
         
         switch style {
-        case .Black:
-            uberMetadataLabel.textColor = ColorUtil.colorForUberButtonColor(.UberWhite)
-        case .White :
-            uberMetadataLabel.textColor = ColorUtil.colorForUberButtonColor(.UberBlack)
+        case .black:
+            uberMetadataLabel.textColor = ColorUtil.colorForUberButtonColor(.uberWhite)
+        case .white :
+            uberMetadataLabel.textColor = ColorUtil.colorForUberButtonColor(.uberBlack)
         }
     }
     
     //Mark: UIView
     
-    override public func sizeThatFits(size: CGSize) -> CGSize {
-        let logoSize = uberImageView.image?.size ?? CGSizeZero
-        let titleSize = uberTitleLabel.intrinsicContentSize()
-        let metadataSize = uberMetadataLabel.intrinsicContentSize()
+    override open func sizeThatFits(_ size: CGSize) -> CGSize {
+        let logoSize = uberImageView.image?.size ?? CGSize.zero
+        let titleSize = uberTitleLabel.intrinsicContentSize
+        let metadataSize = uberMetadataLabel.intrinsicContentSize
         var width: CGFloat = 4*horizontalEdgePadding + imageLabelPadding + logoSize.width + titleSize.width
         var height: CGFloat = 2*verticalPadding + max(logoSize.height, titleSize.height)
         
@@ -268,7 +268,7 @@ import CoreLocation
             height = max(height, metadataSize.height)
         }
         
-        return CGSizeMake(width, height)
+        return CGSize(width: width, height: height)
     }
     
     //Mark: Public Interface
@@ -276,7 +276,7 @@ import CoreLocation
     /**
      Manual refresh for the ride information on the button. The product ID must be set in order to show any metadata.
      */
-    public func loadRideInformation() {
+    open func loadRideInformation() {
         guard client != nil else {
             return
         }
@@ -293,7 +293,7 @@ import CoreLocation
     //Mark: Internal Interface
     
     // Initiate deeplink when button is tapped
-    func uberButtonTapped(sender: UIButton) {
+    func uberButtonTapped(_ sender: UIButton) {
         rideParameters.source = RideRequestButton.sourceString
         requestBehavior.requestRide(rideParameters)
     }
@@ -307,50 +307,50 @@ import CoreLocation
      - parameter subtitle: The subtitle of the label. (ex. "$6-8 for uberX")
      - parameter surge:    Whether the price estimate should include a surge image. Default false.
      */
-    private func setMultilineAttributedString(title: String, subtitle: String = "", surge: Bool = false) {
-        let metadataFont = UIFont(name: "HelveticaNeue-Regular", size: 12) ?? UIFont.systemFontOfSize(12)
+    fileprivate func setMultilineAttributedString(_ title: String, subtitle: String = "", surge: Bool = false) {
+        let metadataFont = UIFont(name: "HelveticaNeue-Regular", size: 12) ?? UIFont.systemFont(ofSize: 12)
         
         let attrString = NSMutableAttributedString(string: title)
         
         // If there is a price estimate to include, add a new line
         if !subtitle.isEmpty {
-            attrString.appendAttributedString(NSAttributedString(string: "\n"))
+            attrString.append(NSAttributedString(string: "\n"))
             
             // If the price estimate is higher due to a surge, add the surge icon
             if surge == true {
                 let attachment = getSurgeAttachment()
                 
                 // Adjust bounds to center the text attachment
-                attachment.bounds = CGRectMake(0, metadataFont.descender-opticalCorrection, attachment.image!.size.width, attachment.image!.size.height)
+                attachment.bounds = CGRect(x: 0, y: metadataFont.descender-opticalCorrection, width: attachment.image!.size.width, height: attachment.image!.size.height)
                 let surgeImage = NSAttributedString(attachment: attachment)
                 
-                attrString.appendAttributedString(surgeImage)
-                attrString.appendAttributedString(NSAttributedString(string: " "))
+                attrString.append(surgeImage)
+                attrString.append(NSAttributedString(string: " "))
                 
                 // Adding the text attachment increases the space between lines so set the max line height
                 let paragraphStyle = NSMutableParagraphStyle()
-                paragraphStyle.alignment = .Right
+                paragraphStyle.alignment = .right
                 paragraphStyle.maximumLineHeight = 16
                 attrString.addAttribute(NSParagraphStyleAttributeName, value:paragraphStyle, range:NSMakeRange(0, attrString.length))
             }
             
-            attrString.appendAttributedString(NSAttributedString(string: "\(subtitle)"))
+            attrString.append(NSAttributedString(string: "\(subtitle)"))
         }
         
-        attrString.addAttribute(NSFontAttributeName, value: metadataFont, range: (attrString.string as NSString).rangeOfString(title))
-        attrString.addAttribute(NSFontAttributeName, value: metadataFont, range: (attrString.string as NSString).rangeOfString(subtitle))
+        attrString.addAttribute(NSFontAttributeName, value: metadataFont, range: (attrString.string as NSString).range(of: title))
+        attrString.addAttribute(NSFontAttributeName, value: metadataFont, range: (attrString.string as NSString).range(of: subtitle))
         
         uberTitleLabel.text = LocalizationUtil.localizedString(forKey: "Get a ride", comment: "Request button shorter description")
         uberMetadataLabel.attributedText = attrString
     }
     
-    private func getSurgeAttachment() -> NSTextAttachment {
+    fileprivate func getSurgeAttachment() -> NSTextAttachment {
         let attachment = NSTextAttachment()
         
         switch colorStyle {
-        case .Black:
+        case .black:
             attachment.image = getImage("Surge-WhiteOutline")
-        case .White:
+        case .white:
             attachment.image = getImage("Surge-BlackOutline")
         }
     
@@ -360,7 +360,7 @@ import CoreLocation
     /**
      Sets metadata on button by fetching all required information.
      */
-    private func setMetadata() {
+    fileprivate func setMetadata() {
         /**
         *  These are all required for the following requests.
         */
@@ -368,13 +368,13 @@ import CoreLocation
             return
         }
         
-        let downloadGroup = dispatch_group_create()
-        dispatch_group_enter(downloadGroup)
+        let downloadGroup = DispatchGroup()
+        downloadGroup.enter()
         var errors = [RidesError]()
         let pickupLocation = CLLocation(latitude: pickupLatitude, longitude: pickupLongitude)
         
         // Set the information on the button label once all information is retrieved.
-        dispatch_group_notify(downloadGroup, dispatch_get_main_queue(), {
+        downloadGroup.notify(queue: DispatchQueue.main, execute: {
             guard let estimate = self.metadata.timeEstimate?.estimate else {
                 for error in errors {
                     self.delegate?.rideRequestButton(self, didReceiveError: error)
@@ -385,9 +385,9 @@ import CoreLocation
             let mins = estimate/60
             var titleText: String
             if mins == 1 {
-                titleText = String(format: LocalizationUtil.localizedString(forKey: "%d min away", comment: "Estimate is for car one minute away"), mins).uppercaseStringWithLocale(NSLocale.currentLocale())
+                titleText = String(format: LocalizationUtil.localizedString(forKey: "%d min away", comment: "Estimate is for car one minute away"), mins).uppercased(with: Locale.current)
             } else {
-                titleText = String(format: LocalizationUtil.localizedString(forKey: "%d mins away", comment: "Estimate is for car multiple minutes away"), mins).uppercaseStringWithLocale(NSLocale.currentLocale())
+                titleText = String(format: LocalizationUtil.localizedString(forKey: "%d mins away", comment: "Estimate is for car multiple minutes away"), mins).uppercased(with: Locale.current)
             }
             var subtitleText = ""
             var surge = false
@@ -415,38 +415,38 @@ import CoreLocation
         let timeEstimatesCompletion: ([TimeEstimate], Response) -> () = { timeEstimates, response in
             if let error = response.error {
                 errors.append(error)
-                dispatch_group_leave(downloadGroup)
+                downloadGroup.leave()
                 return
             }
             
             if timeEstimates.count == 0 {
-                dispatch_group_leave(downloadGroup)
+                downloadGroup.leave()
                 return
             }
             
             self.metadata.timeEstimate = timeEstimates.first!
             self.metadata.productName = timeEstimates.first!.name
-            dispatch_group_leave(downloadGroup)
+            downloadGroup.leave()
         }
         
         // If dropoff location was set, get price estimates.
         if let dropoffLatitude = metadata.dropoffLatitude, let dropoffLongitude = metadata.dropoffLongitude {
-            dispatch_group_enter(downloadGroup)
+            downloadGroup.enter()
             let dropoffLocation = CLLocation(latitude: dropoffLatitude, longitude: dropoffLongitude)
             let priceEstimatesCompletion: ([PriceEstimate], Response) -> () = {priceEstimates, response in
                 if let error = response.error {
                     errors.append(error)
-                    dispatch_group_leave(downloadGroup)
+                    downloadGroup.leave()
                     return
                 }
                 
                 if priceEstimates.count == 0 {
-                    dispatch_group_leave(downloadGroup)
+                    downloadGroup.leave()
                     return
                 }
                 
                 self.metadata.priceEstimates = priceEstimates
-                dispatch_group_leave(downloadGroup)
+                downloadGroup.leave()
             }
             
             client.fetchPriceEstimates(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation, completion:priceEstimatesCompletion )
@@ -456,9 +456,9 @@ import CoreLocation
     }
     
     // get image from media directory
-    private func getImage(name: String) -> UIImage {
-        let bundle = NSBundle(forClass: RideRequestButton.self)
-        let image = UIImage(named: name, inBundle: bundle, compatibleWithTraitCollection: nil)
+    fileprivate func getImage(_ name: String) -> UIImage {
+        let bundle = Bundle(for: RideRequestButton.self)
+        let image = UIImage(named: name, in: bundle, compatibleWith: nil)
         return image!
     }
 }
@@ -466,8 +466,8 @@ import CoreLocation
 // MARK: RideRequestButton structures
 
 @objc public enum RequestButtonColorStyle: Int {
-    case Black
-    case White
+    case black
+    case white
 }
 
 /**
@@ -481,7 +481,7 @@ struct ButtonMetadata {
     var dropoffLatitude: Double?
     var dropoffLongitude: Double?
     var timeEstimate: TimeEstimate?
-    private var priceEstimateList: [PriceEstimate]?
+    fileprivate var priceEstimateList: [PriceEstimate]?
     var priceEstimates: [PriceEstimate]! {
         get {
             return priceEstimateList != nil ? priceEstimateList : []

--- a/source/UberRides/RideRequestView.swift
+++ b/source/UberRides/RideRequestView.swift
@@ -35,19 +35,19 @@ import CoreLocation
      - parameter rideRequestView: the RideRequestView
      - parameter error:           the NSError that occured, with a code of RideRequestViewErrorType
      */
-    func rideRequestView(rideRequestView: RideRequestView, didReceiveError error: NSError)
+    func rideRequestView(_ rideRequestView: RideRequestView, didReceiveError error: NSError)
 }
 
 /// A view that shows the embedded Uber experience. 
-@objc(UBSDKRideRequestView) public class RideRequestView: UIView {
+@objc(UBSDKRideRequestView) open class RideRequestView: UIView {
     /// The RideRequestViewDelegate of this view.
-    public var delegate: RideRequestViewDelegate?
+    open var delegate: RideRequestViewDelegate?
     
     /// The access token used to authorize the web view
-    public var accessToken: AccessToken?
+    open var accessToken: AccessToken?
     
     /// Ther RideParameters to use for prefilling the RideRequestView
-    public var rideParameters: RideParameters
+    open var rideParameters: RideParameters
     
     var webView: WKWebView
     let redirectURL = "uberconnect://oauth"
@@ -68,7 +68,7 @@ import CoreLocation
         self.accessToken = accessToken
         let configuration = WKWebViewConfiguration()
         configuration.processPool = Configuration.processPool
-        webView = WKWebView(frame: CGRectZero, configuration: configuration)
+        webView = WKWebView(frame: CGRect.zero, configuration: configuration)
         super.init(frame: frame)
         initialSetup()
     }
@@ -96,7 +96,7 @@ import CoreLocation
      - returns: An initialized RideRequestView
      */
     @objc public convenience init(rideParameters: RideParameters) {
-        self.init(rideParameters: rideParameters, accessToken: TokenManager.fetchToken(), frame: CGRectZero)
+        self.init(rideParameters: rideParameters, accessToken: TokenManager.fetchToken(), frame: CGRect.zero)
     }
     
     /**
@@ -121,21 +121,21 @@ import CoreLocation
      - returns: An initialized RideRequestView
      */
     @objc public convenience init() {
-        self.init(rideParameters: RideParametersBuilder().build(), accessToken: TokenManager.fetchToken(), frame: CGRectZero)
+        self.init(rideParameters: RideParametersBuilder().build(), accessToken: TokenManager.fetchToken(), frame: CGRect.zero)
     }
     
     required public init?(coder aDecoder: NSCoder) {
         rideParameters = RideParametersBuilder().build()
         let configuration = WKWebViewConfiguration()
         configuration.processPool = Configuration.processPool
-        webView = WKWebView(frame: CGRectZero, configuration: configuration)
+        webView = WKWebView(frame: CGRect.zero, configuration: configuration)
         super.init(coder: aDecoder)
         initialSetup()
     }
     
     deinit {
         webView.scrollView.delegate = nil
-        NSNotificationCenter.defaultCenter().removeObserver(self)
+        NotificationCenter.default.removeObserver(self)
     }
     
     // MARK: Public
@@ -144,9 +144,9 @@ import CoreLocation
      Load the Uber Ride Request Widget view.
      Requires that the access token has been retrieved.
      */
-    public func load() {
+    open func load() {
         guard let accessToken = accessToken else {
-            self.delegate?.rideRequestView(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.AccessTokenMissing))
+            self.delegate?.rideRequestView(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.accessTokenMissing))
             return
         }
         
@@ -156,45 +156,45 @@ import CoreLocation
             rideParameters.source = RideRequestView.sourceString
         }
         
-        let endpoint = Components.RideRequestWidget(rideParameters: rideParameters)
-        let request = Request(session: nil, endpoint: endpoint, bearerToken: tokenString)
+        let endpoint = Components.rideRequestWidget(rideParameters: rideParameters)
+        let request = Request(session: nil, endpoint: endpoint, bearerToken: tokenString as NSString?)
         request.prepare()
         let urlRequest = request.urlRequest
-        urlRequest.cachePolicy = .ReturnCacheDataElseLoad
-        webView.loadRequest(urlRequest)
+        urlRequest.cachePolicy = .returnCacheDataElseLoad
+        webView.load(urlRequest as URLRequest)
     }
     
     /**
      Stop loading the Ride Request Widget View and clears the view.
      If the view has already loaded, calling this still clears the view.
     */
-    public func cancelLoad() {
+    open func cancelLoad() {
         webView.stopLoading()
-        if let url = NSURL(string: "about:blank") {
-            webView.loadRequest(NSURLRequest(URL: url))
+        if let url = URL(string: "about:blank") {
+            webView.load(URLRequest(url: url))
         }
     }
     
     // MARK: Private
     
-    private func initialSetup() {
+    fileprivate func initialSetup() {
         webView.navigationDelegate = self
         webView.scrollView.delegate = self
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(keyboardWillAppear(_:)), name: UIKeyboardWillShowNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(keyboardDidAppear(_:)), name: UIKeyboardDidShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillAppear(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardDidAppear(_:)), name: NSNotification.Name.UIKeyboardDidShow, object: nil)
         
         setupWebView()
     }
     
-    private func setupWebView() {
+    fileprivate func setupWebView() {
         addSubview(webView)
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.scrollView.bounces = false
         
         let views = ["webView": webView]
-        let horizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[webView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
-        let verticalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[webView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
+        let horizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|[webView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
+        let verticalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "V:|[webView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
         
         addConstraints(horizontalConstraints)
         addConstraints(verticalConstraints)
@@ -202,54 +202,54 @@ import CoreLocation
     
     // MARK: Keyboard Notifications
     
-    func keyboardWillAppear(notification: NSNotification) {
-        webView.scrollView.scrollEnabled = false
+    func keyboardWillAppear(_ notification: Notification) {
+        webView.scrollView.isScrollEnabled = false
     }
     
-    func keyboardDidAppear(notification: NSNotification) {
-        webView.scrollView.scrollEnabled = true
+    func keyboardDidAppear(_ notification: Notification) {
+        webView.scrollView.isScrollEnabled = true
     }
 }
 
 // MARK: WKNavigationDelegate
 
 extension RideRequestView: WKNavigationDelegate {
-    public func webView(webView: WKWebView, decidePolicyForNavigationAction navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {
-        if let url = navigationAction.request.URL {
-            if url.absoluteString.lowercaseString.hasPrefix(redirectURL.lowercaseString) {
+    public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        if let url = navigationAction.request.url {
+            if url.absoluteString.lowercased().hasPrefix(redirectURL.lowercased()) {
                 let error = OAuthUtil.parseRideWidgetErrorFromURL(url)
                 delegate?.rideRequestView(self, didReceiveError: error)
-                decisionHandler(.Cancel)
+                decisionHandler(.cancel)
                 return
             } else if url.scheme == "tel" || url.scheme == "sms" {
-                if (!UIApplication.sharedApplication().openURL(url)) {
-                    delegate?.rideRequestView(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.NotSupported))
+                if (!UIApplication.shared.openURL(url)) {
+                    delegate?.rideRequestView(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.notSupported))
                 }
-                decisionHandler(.Cancel)
+                decisionHandler(.cancel)
                 return
             }
         }
         
-        decisionHandler(.Allow)
+        decisionHandler(.allow)
     }
     
-    public func webView(webView: WKWebView, didFailNavigation navigation: WKNavigation!, withError error: NSError) {
-        delegate?.rideRequestView(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.NetworkError))
+    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        delegate?.rideRequestView(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.networkError))
     }
     
-    public func webView(webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: NSError) {
-        guard error.code != 102 else {
+    public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        guard error._code != 102 else {
             return
         }
-        delegate?.rideRequestView(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.NetworkError))
+        delegate?.rideRequestView(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.networkError))
     }
 }
 
 // MARK: UIScrollViewDelegate
 
 extension RideRequestView : UIScrollViewDelegate {
-    public func scrollViewDidScroll(scrollView: UIScrollView) {
-        if !scrollView.scrollEnabled {
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if !scrollView.isScrollEnabled {
             scrollView.bounds = self.webView.bounds
         }
     }

--- a/source/UberRides/RideRequestViewController.swift
+++ b/source/UberRides/RideRequestViewController.swift
@@ -37,16 +37,16 @@ import MapKit
      - parameter rideRequestViewController: The RideRequestViewController that experienced the error
      - parameter error:                     The NSError that was experienced, with a code related to the appropriate RideRequestViewErrorType
      */
-    @objc func rideRequestViewController(rideRequestViewController: RideRequestViewController, didReceiveError error: NSError)
+    @objc func rideRequestViewController(_ rideRequestViewController: RideRequestViewController, didReceiveError error: NSError)
 }
 
 // View controller to wrap the RideRequestView
-@objc (UBSDKRideRequestViewController) public class RideRequestViewController: UIViewController {
+@objc (UBSDKRideRequestViewController) open class RideRequestViewController: UIViewController {
     /// The RideRequestViewControllerDelegate to handle the errors
-    public var delegate: RideRequestViewControllerDelegate?
+    open var delegate: RideRequestViewControllerDelegate?
     
     /// The LoginManager to use for managing the login process
-    public var loginManager: LoginManager {
+    open var loginManager: LoginManager {
         didSet {
             accessTokenIdentifier = loginManager.accessTokenIdentifier
             keychainAccessGroup = loginManager.keychainAccessGroup
@@ -59,10 +59,10 @@ import MapKit
     
     static let sourceString = "ride_request_widget"
     
-    private var accessTokenWasUnauthorizedOnPreviousAttempt = false
-    private var accessTokenIdentifier: String
-    private var keychainAccessGroup: String
-    private var loginCompletion: ((accessToken: AccessToken?, error: NSError?) -> Void)?
+    fileprivate var accessTokenWasUnauthorizedOnPreviousAttempt = false
+    fileprivate var accessTokenIdentifier: String
+    fileprivate var keychainAccessGroup: String
+    fileprivate var loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?
     
     /**
      Initializes a RideRequestViewController using the provided coder. By default,
@@ -111,22 +111,22 @@ import MapKit
     
     // MARK: View Lifecycle
     
-    public override func viewDidLoad() {
+    open override func viewDidLoad() {
         super.viewDidLoad()
-        self.edgesForExtendedLayout = UIRectEdge.None
-        self.view.backgroundColor = UIColor.whiteColor()
+        self.edgesForExtendedLayout = UIRectEdge()
+        self.view.backgroundColor = UIColor.white
         
         setupRideRequestView()
         setupLoginView()
     }
     
-    public override func viewDidAppear(animated: Bool) {
+    open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         self.load()
     }
     
-    public override func viewWillDisappear(animated: Bool) {
+    open override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         stopLoading()
         accessTokenWasUnauthorizedOnPreviousAttempt = false
@@ -134,8 +134,8 @@ import MapKit
     
     // MARK: UIViewController
     
-    public override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
-        return [.Portrait, .PortraitUpsideDown]
+    open override var supportedInterfaceOrientations : UIInterfaceOrientationMask {
+        return [.portrait, .portraitUpsideDown]
     }
     
     // MARK: Internal
@@ -143,18 +143,18 @@ import MapKit
     func load() {
         if let accessToken = TokenManager.fetchToken(accessTokenIdentifier, accessGroup: keychainAccessGroup) {
             rideRequestView.accessToken = accessToken
-            rideRequestView.hidden = false
-            loginView.hidden = true
+            rideRequestView.isHidden = false
+            loginView.isHidden = true
             rideRequestView.load()
         } else {
             switch loginManager.loginType {
-            case .Native:
+            case .native:
                 executeNativeLogin()
-            case .Implicit:
+            case .implicit:
                 fallthrough
-            case .AuthorizationCode:
-                loginView.hidden = false
-                rideRequestView.hidden = true
+            case .authorizationCode:
+                loginView.isHidden = false
+                rideRequestView.isHidden = true
                 loginView.load()
             }
         }
@@ -174,35 +174,35 @@ import MapKit
     func displayNetworkErrorAlert() {
         self.rideRequestView.cancelLoad()
         self.loginView.cancelLoad()
-        let alertController = UIAlertController(title: nil, message: LocalizationUtil.localizedString(forKey: "The Ride Request Widget encountered a problem.", comment: "The Ride Request Widget encountered a problem."), preferredStyle: .Alert)
-        let tryAgainAction = UIAlertAction(title: LocalizationUtil.localizedString(forKey: "Try Again", comment: "Try Again"), style: .Default, handler: { (UIAlertAction) -> Void in
+        let alertController = UIAlertController(title: nil, message: LocalizationUtil.localizedString(forKey: "The Ride Request Widget encountered a problem.", comment: "The Ride Request Widget encountered a problem."), preferredStyle: .alert)
+        let tryAgainAction = UIAlertAction(title: LocalizationUtil.localizedString(forKey: "Try Again", comment: "Try Again"), style: .default, handler: { (UIAlertAction) -> Void in
             self.load()
         })
-        let cancelAction = UIAlertAction(title: LocalizationUtil.localizedString(forKey: "Cancel", comment: "Cancel"), style: .Cancel, handler: { (UIAlertAction) -> Void in
-            self.delegate?.rideRequestViewController(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.NetworkError))
+        let cancelAction = UIAlertAction(title: LocalizationUtil.localizedString(forKey: "Cancel", comment: "Cancel"), style: .cancel, handler: { (UIAlertAction) -> Void in
+            self.delegate?.rideRequestViewController(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.networkError))
         })
         alertController.addAction(tryAgainAction)
         alertController.addAction(cancelAction)
-        self.presentViewController(alertController, animated: true, completion: nil)
+        self.present(alertController, animated: true, completion: nil)
     }
     
     func displayNotSupportedErrorAlert() {
-        let alertController = UIAlertController(title: nil, message: LocalizationUtil.localizedString(forKey: "The operation you are attempting is not supported on the current device.", comment: "The operation you are attempting is not supported on the current device."), preferredStyle: .Alert)
-        let okayAction = UIAlertAction(title: LocalizationUtil.localizedString(forKey: "OK", comment: "OK"), style: .Default, handler: nil)
+        let alertController = UIAlertController(title: nil, message: LocalizationUtil.localizedString(forKey: "The operation you are attempting is not supported on the current device.", comment: "The operation you are attempting is not supported on the current device."), preferredStyle: .alert)
+        let okayAction = UIAlertAction(title: LocalizationUtil.localizedString(forKey: "OK", comment: "OK"), style: .default, handler: nil)
         alertController.addAction(okayAction)
-        self.presentViewController(alertController, animated: true, completion: nil)
+        self.present(alertController, animated: true, completion: nil)
     }
     
     //MARK: Private
     
-    private func setupRideRequestView() {
+    fileprivate func setupRideRequestView() {
         self.view.addSubview(rideRequestView)
         
         rideRequestView.translatesAutoresizingMaskIntoConstraints = false
         
         let views = ["rideRequestView": rideRequestView]
-        let horizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[rideRequestView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
-        let verticalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[rideRequestView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
+        let horizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|[rideRequestView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
+        let verticalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "V:|[rideRequestView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
         
         self.view.addConstraints(horizontalConstraints)
         self.view.addConstraints(verticalConstraints)
@@ -210,44 +210,44 @@ import MapKit
         rideRequestView.delegate = self
     }
     
-    private func setupLoginView() {
+    fileprivate func setupLoginView() {
         switch loginManager.loginType {
-        case .AuthorizationCode:
+        case .authorizationCode:
             fallthrough
-        case .Implicit:
+        case .implicit:
             setupImplicitLoginView()
             break
-        case .Native:
+        case .native:
             setupNativeLogin()
             break
         }
     }
     
-    private func setupImplicitLoginView() {
+    fileprivate func setupImplicitLoginView() {
         let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: self, scopes: [.RideWidgets])
         loginBehavior.loginCompletion = { token, error in
             guard let token = token else {
-                if error?.code == RidesAuthenticationErrorType.NetworkError.rawValue {
+                if error?.code == RidesAuthenticationErrorType.networkError.rawValue {
                     self.displayNetworkErrorAlert()
                 } else {
-                    self.delegate?.rideRequestViewController(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.AccessTokenMissing))
+                    self.delegate?.rideRequestViewController(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.accessTokenMissing))
                 }
                 return
             }
-            self.loginView.hidden = true
+            self.loginView.isHidden = true
             self.rideRequestView.accessToken = token
-            self.rideRequestView.hidden = false
+            self.rideRequestView.isHidden = false
             self.load()
         }
         loginManager.authenticator = loginBehavior
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         self.view.addSubview(loginView)
-        loginView.hidden = true
+        loginView.isHidden = true
         loginView.translatesAutoresizingMaskIntoConstraints = false
         
         let views = ["loginView": loginView]
-        let horizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[loginView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
-        let verticalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[loginView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
+        let horizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|[loginView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
+        let verticalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "V:|[loginView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views)
         
         self.view.addConstraints(horizontalConstraints)
         self.view.addConstraints(verticalConstraints)
@@ -255,25 +255,25 @@ import MapKit
         self.loginView = loginView
     }
     
-    private func setupNativeLogin() {
+    fileprivate func setupNativeLogin() {
         
         nativeAuthenticator.loginCompletion = { token, error in
             guard let token = token else {
-                if error?.code == RidesAuthenticationErrorType.NetworkError.rawValue {
+                if error?.code == RidesAuthenticationErrorType.networkError.rawValue {
                     self.displayNetworkErrorAlert()
-                } else if error?.code == RidesAuthenticationErrorType.Unavailable.rawValue {
-                    self.loginManager.loginType = .Implicit
+                } else if error?.code == RidesAuthenticationErrorType.unavailable.rawValue {
+                    self.loginManager.loginType = .implicit
                     self.setupLoginView()
                     self.load()
-                    self.loginManager.loginType = .Native
+                    self.loginManager.loginType = .native
                 } else {
-                    self.delegate?.rideRequestViewController(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.AccessTokenMissing))
+                    self.delegate?.rideRequestViewController(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.accessTokenMissing))
                 }
                 return
             }
-            self.loginView.hidden = true
+            self.loginView.isHidden = true
             self.rideRequestView.accessToken = token
-            self.rideRequestView.hidden = false
+            self.rideRequestView.isHidden = false
             self.load()
         }
         nativeAuthenticator.deeplinkCompletion = { error in
@@ -287,18 +287,18 @@ import MapKit
 //MARK: RideRequestView Delegate
 
 extension RideRequestViewController : RideRequestViewDelegate {
-    public func rideRequestView(rideRequestView: RideRequestView, didReceiveError error: NSError) {
-        let errorType = RideRequestViewErrorType(rawValue: error.code) ?? .Unknown
+    public func rideRequestView(_ rideRequestView: RideRequestView, didReceiveError error: NSError) {
+        let errorType = RideRequestViewErrorType(rawValue: error.code) ?? .unknown
         switch errorType {
-        case .NetworkError:
+        case .networkError:
             self.displayNetworkErrorAlert()
             break
-        case .NotSupported:
+        case .notSupported:
             self.displayNotSupportedErrorAlert()
             break
-        case .AccessTokenMissing:
+        case .accessTokenMissing:
             fallthrough
-        case .AccessTokenExpired:
+        case .accessTokenExpired:
             if accessTokenWasUnauthorizedOnPreviousAttempt {
                 fallthrough
             }
@@ -310,10 +310,10 @@ extension RideRequestViewController : RideRequestViewDelegate {
         }
     }
 
-    private func attemptTokenRefresh(tokenIdentifier: String?, accessGroup: String?) {
+    fileprivate func attemptTokenRefresh(_ tokenIdentifier: String?, accessGroup: String?) {
         let identifer = tokenIdentifier ?? Configuration.getDefaultAccessTokenIdentifier()
         let group = accessGroup ?? Configuration.getDefaultKeychainAccessGroup()
-        guard let accessToken = TokenManager.fetchToken(identifer, accessGroup: group), refreshToken = accessToken.refreshToken else {
+        guard let accessToken = TokenManager.fetchToken(identifer, accessGroup: group), let refreshToken = accessToken.refreshToken else {
             accessTokenWasUnauthorizedOnPreviousAttempt = true
             TokenManager.deleteToken(identifer, accessGroup: group)
             self.load()

--- a/source/UberRides/RideRequestViewErrorFactory.swift
+++ b/source/UberRides/RideRequestViewErrorFactory.swift
@@ -34,7 +34,7 @@ class RideRequestViewErrorFactory {
      
      - returns: An initialized NSError
      */
-    static func errorForType(rideRequestViewErrorType: RideRequestViewErrorType) -> NSError {
+    static func errorForType(_ rideRequestViewErrorType: RideRequestViewErrorType) -> NSError {
         return NSError(domain: errorDomain, code: rideRequestViewErrorType.rawValue, userInfo: nil)
     }
     
@@ -46,23 +46,23 @@ class RideRequestViewErrorFactory {
      
      - returns: An initialized RideRequestViewError
      */
-    static func errorForString(rawValue: String) -> NSError {
+    static func errorForString(_ rawValue: String) -> NSError {
         let errorType = rideRequestViewErrorType(rawValue)
         return RideRequestViewErrorFactory.errorForType(errorType)
     }
     
-    static func rideRequestViewErrorType(rawValue: String) -> RideRequestViewErrorType {
+    static func rideRequestViewErrorType(_ rawValue: String) -> RideRequestViewErrorType {
         switch rawValue {
         case "network_error":
-            return .NetworkError
+            return .networkError
         case "not_supported":
-            return .NotSupported
+            return .notSupported
         case "no_access_token":
-            return .AccessTokenMissing
+            return .accessTokenMissing
         case "unauthorized":
-            return .AccessTokenExpired
+            return .accessTokenExpired
         default:
-            return .Unknown
+            return .unknown
         }
     }
 }

--- a/source/UberRides/RideRequestViewErrorType.swift
+++ b/source/UberRides/RideRequestViewErrorType.swift
@@ -32,23 +32,23 @@ Possible errors that can occur in the RideRequestView.
 - Unknown:                    Unknown error occured.
 */
 @objc public enum RideRequestViewErrorType: Int {
-    case AccessTokenExpired
-    case AccessTokenMissing
-    case NetworkError
-    case NotSupported
-    case Unknown
+    case accessTokenExpired
+    case accessTokenMissing
+    case networkError
+    case notSupported
+    case unknown
     
     func toString() -> String {
         switch self {
-        case .AccessTokenExpired:
+        case .accessTokenExpired:
             return "unauthorized"
-        case .AccessTokenMissing:
+        case .accessTokenMissing:
             return "no_access_token"
-        case .NetworkError:
+        case .networkError:
             return "network_error"
-        case .NotSupported:
+        case .notSupported:
             return "not_supported"
-        case .Unknown:
+        case .unknown:
             return "unknown"
         }
     }

--- a/source/UberRides/RideRequestViewRequestingBehavior.swift
+++ b/source/UberRides/RideRequestViewRequestingBehavior.swift
@@ -24,17 +24,17 @@
 
 
 /// A RideRequesting object for requesting a ride via the RideRequestViewController
-@objc(UBSDKRideRequestViewRequestingBehavior) public class RideRequestViewRequestingBehavior : NSObject {
+@objc(UBSDKRideRequestViewRequestingBehavior) open class RideRequestViewRequestingBehavior : NSObject {
     
     /// The UIViewController to present the RideRequestViewController over
-    unowned public var presentingViewController: UIViewController
+    unowned open var presentingViewController: UIViewController
     
     /**
      The LoginManager to use with the RideRequestViewController. Uses the
      accessTokenIdentifier & keychainAccessGroup to get an AccessToken. Will be used
      to log a user in, if necessary
      */
-    public var loginManager: LoginManager {
+    open var loginManager: LoginManager {
         get {
             return self.modalRideRequestViewController.rideRequestViewController.loginManager
         }
@@ -44,7 +44,7 @@
     }
     
     /// The ModalRideRequestViewController that is created by this behavior, only exists after requestRide() is called
-    public internal(set) var modalRideRequestViewController: ModalRideRequestViewController
+    open internal(set) var modalRideRequestViewController: ModalRideRequestViewController
     
     /**
      Creates the RideRequestViewRequestingBehavior with the given presenting view controller.
@@ -86,10 +86,10 @@ extension RideRequestViewRequestingBehavior : RideRequesting {
      - parameter rideParameters: The RideParameters to use for building and prefilling
      the RideRequestView
      */
-    public func requestRide(rideParameters: RideParameters?) {
+    public func requestRide(_ rideParameters: RideParameters?) {
         if let rideParameters = rideParameters {
             modalRideRequestViewController.rideRequestViewController.rideRequestView.rideParameters = rideParameters
         }
-        presentingViewController.presentViewController(modalRideRequestViewController, animated: true, completion: nil)
+        presentingViewController.present(modalRideRequestViewController, animated: true, completion: nil)
     }
 }

--- a/source/UberRides/RideRequestingProtocol.swift
+++ b/source/UberRides/RideRequestingProtocol.swift
@@ -32,5 +32,5 @@
      
      - parameter rideParameters: The RideParameters to use for the ride request
      */
-    @objc func requestRide(rideParameters: RideParameters?)
+    @objc func requestRide(_ rideParameters: RideParameters?)
 }

--- a/source/UberRides/RidesAppDelegate.swift
+++ b/source/UberRides/RidesAppDelegate.swift
@@ -27,26 +27,26 @@
  Designed to mimic methods from your application's AppDelegate and should
  be called inside their corresponding methods
  */
-@objc(UBSDKRidesAppDelegate) public class RidesAppDelegate : NSObject {
+@objc(UBSDKRidesAppDelegate) open class RidesAppDelegate : NSObject {
     
     //MARK: Class variables
     
-    public static let sharedInstance = RidesAppDelegate()
+    open static let sharedInstance = RidesAppDelegate()
     
     //MARK: Public variables
     
-    public var loginManager : LoginManaging?
+    open var loginManager : LoginManaging?
     
     //Mark: NSObject
     
     public override init() {
         super.init()
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(didBecomeActive), name: UIApplicationDidBecomeActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didBecomeActive), name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
     }
     
     deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
+        NotificationCenter.default.removeObserver(self)
     }
     
     //MARK: Public Methods
@@ -67,7 +67,7 @@
      communicate information to the receiving app As passed to the corresponding AppDelegate method
      - returns: true if the URL was intended for the Rides SDK, false otherwise
      */
-    public func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject?) -> Bool {
+    open func application(_ application: UIApplication, openURL url: URL, sourceApplication: String?, annotation: AnyObject?) -> Bool {
         guard let manager = loginManager else {
             return false
         }
@@ -79,22 +79,22 @@
         return urlHandled
     }
     
-    public func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-        guard let options = launchOptions, let launchURL = options[UIApplicationLaunchOptionsURLKey] as? NSURL else {
+    open func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable: Any]?) -> Bool {
+        guard let options = launchOptions, let launchURL = options[UIApplicationLaunchOptionsKey.url] as? URL else {
             return false
         }
         
         let manager = loginManager ?? LoginManager()
-        let sourceApplication = options[UIApplicationLaunchOptionsSourceApplicationKey] as? String
-        let annotation = options[UIApplicationLaunchOptionsAnnotationKey]
-        let urlHandled = manager.application(application, openURL: launchURL, sourceApplication: sourceApplication, annotation: annotation)
+        let sourceApplication = options[UIApplicationLaunchOptionsKey.sourceApplication] as? String
+        let annotation = options[UIApplicationLaunchOptionsKey.annotation]
+        let urlHandled = manager.application(application, openURL: launchURL, sourceApplication: sourceApplication, annotation: annotation as AnyObject?)
         loginManager = nil
         return urlHandled
     }
     
     //MARK: Private Methods
     
-    @objc private func didBecomeActive(notification: NSNotification) {
+    @objc fileprivate func didBecomeActive(_ notification: Notification) {
         if let manager = loginManager {
             manager.applicationDidBecomeActive()
             loginManager = nil

--- a/source/UberRides/TokenManager.swift
+++ b/source/UberRides/TokenManager.swift
@@ -25,12 +25,12 @@
 import Foundation
 
 /// Manager class for saving and deleting AccessTokens. Allows you to manage tokens based on token identifier & keychain access group
-@objc(UBSDKTokenManager) public class TokenManager: NSObject {
+@objc(UBSDKTokenManager) open class TokenManager: NSObject {
 
-    public static let TokenManagerDidSaveTokenNotification = "TokenManagerDidSaveTokenNotification"
-    public static let TokenManagerDidDeleteTokenNotification = "TokenManagerDidDeleteTokenNotification"
+    open static let TokenManagerDidSaveTokenNotification = "TokenManagerDidSaveTokenNotification"
+    open static let TokenManagerDidDeleteTokenNotification = "TokenManagerDidDeleteTokenNotification"
     
-    private static let keychainWrapper = KeychainWrapper()
+    fileprivate static let keychainWrapper = KeychainWrapper()
 
     //MARK: Get
     
@@ -42,7 +42,7 @@ import Foundation
 
      - returns: An AccessToken, or nil if one wasn't found
      */
-    @objc public static func fetchToken(tokenIdentifier: String, accessGroup: String) -> AccessToken? {
+    @objc open static func fetchToken(_ tokenIdentifier: String, accessGroup: String) -> AccessToken? {
         keychainWrapper.setAccessGroup(accessGroup)
         guard let token = keychainWrapper.getObjectForKey(tokenIdentifier) as? AccessToken else {
             return nil
@@ -58,7 +58,7 @@ import Foundation
      
      - returns: An AccessToken, or nil if one wasn't found
      */
-    @objc public static func fetchToken(tokenIdentifier: String) -> AccessToken? {
+    @objc open static func fetchToken(_ tokenIdentifier: String) -> AccessToken? {
         return self.fetchToken(tokenIdentifier,
             accessGroup: Configuration.getDefaultKeychainAccessGroup())
     }
@@ -69,7 +69,7 @@ import Foundation
      
      - returns: An AccessToken, or nil if one wasn't found
      */
-    @objc public static func fetchToken() -> AccessToken? {
+    @objc open static func fetchToken() -> AccessToken? {
         return self.fetchToken(Configuration.getDefaultAccessTokenIdentifier(),
             accessGroup: Configuration.getDefaultKeychainAccessGroup())
     }
@@ -88,11 +88,11 @@ import Foundation
 
      - returns: true if the accessToken was saved successfully, false otherwise
      */
-    @objc public static func saveToken(accessToken: AccessToken, tokenIdentifier: String, accessGroup: String) -> Bool {
+    @objc open static func saveToken(_ accessToken: AccessToken, tokenIdentifier: String, accessGroup: String) -> Bool {
         keychainWrapper.setAccessGroup(accessGroup)
         let success = keychainWrapper.setObject(accessToken, key: tokenIdentifier)
         if success {
-            NSNotificationCenter.defaultCenter().postNotificationName(TokenManagerDidSaveTokenNotification, object: self)
+            NotificationCenter.default.post(name: Notification.Name(rawValue: TokenManagerDidSaveTokenNotification), object: self)
         }
         return success
     }
@@ -108,7 +108,7 @@ import Foundation
      
      - returns: true if the accessToken was saved successfully, false otherwise
      */
-    @objc public static func saveToken(accessToken: AccessToken, tokenIdentifier: String) -> Bool {
+    @objc open static func saveToken(_ accessToken: AccessToken, tokenIdentifier: String) -> Bool {
         return self.saveToken(accessToken, tokenIdentifier: tokenIdentifier, accessGroup: Configuration.getDefaultKeychainAccessGroup())
     }
     
@@ -123,7 +123,7 @@ import Foundation
      
      - returns: true if the accessToken was saved successfully, false otherwise
      */
-    @objc public static func saveToken(accessToken: AccessToken) -> Bool {
+    @objc open static func saveToken(_ accessToken: AccessToken) -> Bool {
         return self.saveToken(accessToken,  tokenIdentifier: Configuration.getDefaultAccessTokenIdentifier(), accessGroup: Configuration.getDefaultKeychainAccessGroup())
     }
     
@@ -138,12 +138,12 @@ import Foundation
 
      - returns: true if the token was deleted, false otherwise
      */
-    @objc public static func deleteToken(tokenIdentifier: String, accessGroup: String) -> Bool {
+    @objc open static func deleteToken(_ tokenIdentifier: String, accessGroup: String) -> Bool {
         keychainWrapper.setAccessGroup(accessGroup)
         deleteCookies()
         let success = keychainWrapper.deleteObjectForKey(tokenIdentifier)
         if success {
-            NSNotificationCenter.defaultCenter().postNotificationName(TokenManagerDidDeleteTokenNotification, object: self)
+            NotificationCenter.default.post(name: Notification.Name(rawValue: TokenManagerDidDeleteTokenNotification), object: self)
         }
         return success
     }
@@ -156,7 +156,7 @@ import Foundation
      
      - returns: true if the token was deleted, false otherwise
      */
-    @objc public static func deleteToken(tokenIdentifier: String) -> Bool {
+    @objc open static func deleteToken(_ tokenIdentifier: String) -> Bool {
         return self.deleteToken(tokenIdentifier, accessGroup: Configuration.getDefaultKeychainAccessGroup())
     }
     
@@ -167,26 +167,26 @@ import Foundation
      
      - returns: true if the token was deleted, false otherwise
      */
-    @objc public static func deleteToken() -> Bool {
+    @objc open static func deleteToken() -> Bool {
         return self.deleteToken(Configuration.getDefaultAccessTokenIdentifier(), accessGroup: Configuration.getDefaultKeychainAccessGroup())
     }
     
     // MARK: Private Interface
     
-    private static func deleteCookies() {
+    fileprivate static func deleteCookies() {
         Configuration.resetProcessPool()
-        var urlsToClear = [NSURL]()
-        if let loginURL = NSURL(string: OAuth.regionHostString(.Default)) {
+        var urlsToClear = [URL]()
+        if let loginURL = URL(string: OAuth.regionHostString(.default)) {
             urlsToClear.append(loginURL)
         }
-        if let loginURL = NSURL(string: OAuth.regionHostString(.China)) {
+        if let loginURL = URL(string: OAuth.regionHostString(.china)) {
             urlsToClear.append(loginURL)
         }
         
-        let sharedCookieStorage = NSHTTPCookieStorage.sharedHTTPCookieStorage()
+        let sharedCookieStorage = HTTPCookieStorage.shared
         
         for url in urlsToClear {
-            if let cookies = sharedCookieStorage.cookiesForURL(url) {
+            if let cookies = sharedCookieStorage.cookies(for: url) {
                 for cookie in cookies {
                     sharedCookieStorage.deleteCookie(cookie)
                 }

--- a/source/UberRides/UberButton.swift
+++ b/source/UberRides/UberButton.swift
@@ -25,7 +25,7 @@
 import UIKit
 
 /// Base class for Uber buttons that sets up colors and some constraints.
-@objc(UBSDKUberButton) public class UberButton: UIButton {
+@objc(UBSDKUberButton) open class UberButton: UIButton {
     let cornerRadius: CGFloat = 8
     let horizontalEdgePadding: CGFloat = 16
     let imageLabelPadding: CGFloat = 8
@@ -34,35 +34,35 @@ import UIKit
     let uberImageView: UIImageView = UIImageView()
     let uberTitleLabel: UILabel = UILabel()
     
-    public var colorStyle: RequestButtonColorStyle = .Black {
+    open var colorStyle: RequestButtonColorStyle = .black {
         didSet {
             colorStyleDidUpdate(colorStyle)
         }
     }
     
-    override public var highlighted: Bool {
+    override open var isHighlighted: Bool {
         didSet {
-            updateColors(highlighted)
+            updateColors(isHighlighted)
         }
     }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
-        colorStyleDidUpdate(.Black)
+        colorStyleDidUpdate(.black)
     }
     
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         setup()
-        colorStyleDidUpdate(.Black)
+        colorStyleDidUpdate(.black)
     }
     
     /**
      Function responsible for the initial setup of the button. 
      Calls addSubviews(), setContent(), and setConstraints()
      */
-    public func setup() {
+    open func setup() {
         addSubviews()
         setContent()
         setConstraints()
@@ -72,7 +72,7 @@ import UIKit
      Function responsible for adding all the subviews to the button. Subclasses
      should override this method and add any necessary subviews.
      */
-    public func addSubviews() {
+    open func addSubviews() {
         addSubview(uberImageView)
         addSubview(uberTitleLabel)
     }
@@ -81,7 +81,7 @@ import UIKit
      Function responsible for updating content on the button. Subclasses should
      override and do any necessary view setup
      */
-    public func setContent() {
+    open func setContent() {
         clipsToBounds = true
         layer.cornerRadius = cornerRadius
     }
@@ -90,7 +90,7 @@ import UIKit
      Function responsible for adding autolayout constriants on the button. Subclasses
      should override and add any additional autolayout constraints
      */
-    public func setConstraints() {
+    open func setConstraints() {
         
         uberTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         uberImageView.translatesAutoresizingMaskIntoConstraints = false
@@ -98,47 +98,47 @@ import UIKit
         let views = ["imageView": uberImageView, "titleLabel": uberTitleLabel]
         let metrics = ["edgePadding": horizontalEdgePadding, "verticalPadding": verticalPadding, "imageLabelPadding": imageLabelPadding]
         
-        let horizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|-edgePadding-[imageView]-imageLabelPadding-[titleLabel]-(edgePadding)-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views)
-        let verticalContraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|-verticalPadding-[imageView]-verticalPadding-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views)
+        let horizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|-edgePadding-[imageView]-imageLabelPadding-[titleLabel]-(edgePadding)-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views)
+        let verticalContraints = NSLayoutConstraint.constraints(withVisualFormat: "V:|-verticalPadding-[imageView]-verticalPadding-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views)
         
         addConstraints(horizontalConstraints)
         addConstraints(verticalContraints)
     }
     
-    override public func sizeThatFits(size: CGSize) -> CGSize {
-        let logoSize = uberImageView.image?.size ?? CGSizeZero
-        let titleSize = uberTitleLabel.intrinsicContentSize()
+    override open func sizeThatFits(_ size: CGSize) -> CGSize {
+        let logoSize = uberImageView.image?.size ?? CGSize.zero
+        let titleSize = uberTitleLabel.intrinsicContentSize
         
         let width: CGFloat = 4*horizontalEdgePadding + imageLabelPadding + logoSize.width + titleSize.width
         let height: CGFloat = 2*verticalPadding + max(logoSize.height, titleSize.height)
         
-        return CGSizeMake(width, height)
+        return CGSize(width: width, height: height)
     }
     
     // Mark: Internal Interface
 
-    func colorStyleDidUpdate(style: RequestButtonColorStyle) {
+    func colorStyleDidUpdate(_ style: RequestButtonColorStyle) {
         switch colorStyle {
-        case .Black:
-            backgroundColor = ColorUtil.colorForUberButtonColor(.UberBlack)
-            uberTitleLabel.textColor = ColorUtil.colorForUberButtonColor(.UberWhite)
-            uberImageView.tintColor = ColorUtil.colorForUberButtonColor(.UberWhite)
-        case .White :
-            backgroundColor = ColorUtil.colorForUberButtonColor(.UberWhite)
-            uberTitleLabel.textColor = ColorUtil.colorForUberButtonColor(.UberBlack)
-            uberImageView.tintColor = ColorUtil.colorForUberButtonColor(.UberBlack)
+        case .black:
+            backgroundColor = ColorUtil.colorForUberButtonColor(.uberBlack)
+            uberTitleLabel.textColor = ColorUtil.colorForUberButtonColor(.uberWhite)
+            uberImageView.tintColor = ColorUtil.colorForUberButtonColor(.uberWhite)
+        case .white :
+            backgroundColor = ColorUtil.colorForUberButtonColor(.uberWhite)
+            uberTitleLabel.textColor = ColorUtil.colorForUberButtonColor(.uberBlack)
+            uberImageView.tintColor = ColorUtil.colorForUberButtonColor(.uberBlack)
         }
     }
     
     // Mark: Private Interface
     
-    private func updateColors(highlighted : Bool) {
+    fileprivate func updateColors(_ highlighted : Bool) {
         var color: UberButtonColor
         switch colorStyle {
-        case .Black:
-            color = highlighted ? .BlackHighlighted : .UberBlack
-        case .White:
-            color = highlighted ? .WhiteHighlighted : .UberWhite
+        case .black:
+            color = highlighted ? .blackHighlighted : .uberBlack
+        case .white:
+            color = highlighted ? .whiteHighlighted : .uberWhite
         }
         backgroundColor = ColorUtil.colorForUberButtonColor(color)
     }

--- a/source/UberRides/Utilities/AuthenticationURLUtility.swift
+++ b/source/UberRides/Utilities/AuthenticationURLUtility.swift
@@ -36,34 +36,34 @@ class AuthenticationURLUtility {
     
     static let sdkValue = "ios"
     
-    static func buildQueryParameters(scopes: [RidesScope]) -> [NSURLQueryItem] {
-        var queryItems = [NSURLQueryItem]()
+    static func buildQueryParameters(_ scopes: [RidesScope]) -> [URLQueryItem] {
+        var queryItems = [URLQueryItem]()
         
-        queryItems.append(NSURLQueryItem(name: appNameKey, value: Configuration.getAppDisplayName()))
-        queryItems.append(NSURLQueryItem(name: callbackURIKey, value: Configuration.getCallbackURIString(.Native)))
-        queryItems.append(NSURLQueryItem(name: clientIDKey, value: Configuration.getClientID()))
-        queryItems.append(NSURLQueryItem(name: loginTypeKey, value: Configuration.regionString))
-        queryItems.append(NSURLQueryItem(name: scopesKey, value: scopes.toRidesScopeString()))
-        queryItems.append(NSURLQueryItem(name: sdkKey, value: sdkValue))
-        queryItems.append(NSURLQueryItem(name: sdkVersionKey, value: Configuration.sdkVersion))
+        queryItems.append(URLQueryItem(name: appNameKey, value: Configuration.getAppDisplayName()))
+        queryItems.append(URLQueryItem(name: callbackURIKey, value: Configuration.getCallbackURIString(.native)))
+        queryItems.append(URLQueryItem(name: clientIDKey, value: Configuration.getClientID()))
+        queryItems.append(URLQueryItem(name: loginTypeKey, value: Configuration.regionString))
+        queryItems.append(URLQueryItem(name: scopesKey, value: scopes.toRidesScopeString()))
+        queryItems.append(URLQueryItem(name: sdkKey, value: sdkValue))
+        queryItems.append(URLQueryItem(name: sdkVersionKey, value: Configuration.sdkVersion))
         
         return queryItems
     }
     
-    static func shouldHandleRedirectURL(URL: NSURL, type: CallbackURIType) -> Bool {
-        guard let redirectURLComponents = NSURLComponents(URL: URL, resolvingAgainstBaseURL: false),
-        expectedURLComponents = NSURLComponents(string: Configuration.getCallbackURIString(type)) else {
+    static func shouldHandleRedirectURL(_ URL: Foundation.URL, type: CallbackURIType) -> Bool {
+        guard let redirectURLComponents = URLComponents(url: URL, resolvingAgainstBaseURL: false),
+        let expectedURLComponents = URLComponents(string: Configuration.getCallbackURIString(type)) else {
             return false
         }
 
-        let isRedirectURL = (redirectURLComponents.scheme?.lowercaseString == expectedURLComponents.scheme?.lowercaseString) &&
-            (redirectURLComponents.host?.lowercaseString == expectedURLComponents.host?.lowercaseString)
+        let isRedirectURL = (redirectURLComponents.scheme?.lowercased() == expectedURLComponents.scheme?.lowercased()) &&
+            (redirectURLComponents.host?.lowercased() == expectedURLComponents.host?.lowercased())
         
         var isLoginError = false
-        if let loginURLComponents = NSURLComponents(string: OAuth.regionHostString()),
-            path = redirectURLComponents.path {
+        if let loginURLComponents = URLComponents(string: OAuth.regionHostString()),
+            let path = redirectURLComponents.path as String? {
             
-            isLoginError = (loginURLComponents.host == redirectURLComponents.host) && path.containsString("errors")
+            isLoginError = (loginURLComponents.host == redirectURLComponents.host) && path.contains("errors")
         }
         
         return isRedirectURL || isLoginError

--- a/source/UberRides/Utilities/RidesUtil.swift
+++ b/source/UberRides/Utilities/RidesUtil.swift
@@ -27,18 +27,18 @@ import Foundation
 import CoreLocation
 
 @objc enum UberButtonColor: Int {
-    case UberBlack
-    case UberWhite
-    case BlackHighlighted
-    case WhiteHighlighted
+    case uberBlack
+    case uberWhite
+    case blackHighlighted
+    case whiteHighlighted
 }
 
 class ColorUtil {
-    static func colorForUberButtonColor(color: UberButtonColor) -> UIColor {
+    static func colorForUberButtonColor(_ color: UberButtonColor) -> UIColor {
         let hexCode = hexCodeFromColor(color)
-        let scanner = NSScanner(string: hexCode)
+        let scanner = Scanner(string: hexCode)
         var color: UInt32 = 0
-        scanner.scanHexInt(&color)
+        scanner.scanHexInt32(&color)
         
         let mask = 0x000000FF
         
@@ -49,28 +49,28 @@ class ColorUtil {
         return UIColor(red: redValue, green: greenValue, blue: blueValue, alpha: 1.0)
     }
     
-    private static func hexCodeFromColor(color: UberButtonColor) -> String {
+    fileprivate static func hexCodeFromColor(_ color: UberButtonColor) -> String {
         switch color {
-        case .UberBlack:
+        case .uberBlack:
             return "000000"
-        case .UberWhite:
+        case .uberWhite:
             return "FFFFFF"
-        case .BlackHighlighted:
+        case .blackHighlighted:
             return "282727"
-        case .WhiteHighlighted:
+        case .whiteHighlighted:
             return "E5E5E4"
         }
     }
 }
 
 class FontUtil {
-    static func loadFontWithName(name: String, familyName: String) -> Bool {
-        if let path = NSBundle(forClass: FontUtil.self).pathForResource(name, ofType: "otf") {
-            if let inData = NSData(contentsOfFile: path) {
+    static func loadFontWithName(_ name: String, familyName: String) -> Bool {
+        if let path = Bundle(for: FontUtil.self).path(forResource: name, ofType: "otf") {
+            if let inData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
                 var error: Unmanaged<CFError>?
-                let cfdata = CFDataCreate(nil, UnsafePointer<UInt8>(inData.bytes), inData.length)
-                if let provider = CGDataProviderCreateWithCFData(cfdata) {
-                    if let font = CGFontCreateWithDataProvider(provider) {
+                let cfdata = CFDataCreate(nil, (inData as NSData).bytes.bindMemory(to: UInt8.self, capacity: inData.count), inData.count)
+                if let provider = CGDataProvider(data: cfdata!) {
+                    if let font = CGFont(provider) as CGFont? {
                         if (CTFontManagerRegisterGraphicsFont(font, &error)) {
                             return true
                         }
@@ -85,8 +85,8 @@ class FontUtil {
 
 class LocalizationUtil {
     static func localizedString(forKey key: String, comment: String) -> String {
-        var localizationBundle = NSBundle(forClass: self)
-        if let frameworkPath = NSBundle.mainBundle().privateFrameworksPath, let frameworkBundle = NSBundle(path: "\(frameworkPath)/UberRides.framework") {
+        var localizationBundle = Bundle(for: self)
+        if let frameworkPath = Bundle.main.privateFrameworksPath, let frameworkBundle = Bundle(path: "\(frameworkPath)/UberRides.framework") {
             localizationBundle = frameworkBundle
         }
         return NSLocalizedString(key, bundle: localizationBundle, comment: comment)
@@ -104,23 +104,23 @@ class OAuthUtil {
      
      - returns: an NSError, who's code contains the RidesAuthenticationErrorType that occured. If none recognized, defaults to InvalidRequest.
      */
-    static func parseAuthenticationErrorFromURL(url: NSURL) -> NSError {
-        let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false)!
+    static func parseAuthenticationErrorFromURL(_ url: URL) -> NSError {
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
         if let params = components.allItems() {
             for param in params {
                 if param.name == "error" {
                     guard let rawValue = param.value, let error = RidesAuthenticationErrorFactory.createRidesAuthenticationError(rawValue: rawValue) else {
-                        return RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .InvalidRequest)
+                        return RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidRequest)
                     }
                     return error
                 }
             }
         }
-        return RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .InvalidRequest)
+        return RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidRequest)
     }
     
-    static func parseRideWidgetErrorFromURL(url: NSURL) -> NSError {
-        let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false)!
+    static func parseRideWidgetErrorFromURL(_ url: URL) -> NSError {
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
         if let fragment = components.fragment {
             components.fragment = nil
             components.query = fragment
@@ -131,13 +131,13 @@ class OAuthUtil {
             }
         }
         
-        return RideRequestViewErrorFactory.errorForType(.Unknown)
+        return RideRequestViewErrorFactory.errorForType(.unknown)
     }
 }
 
 class RequestURLUtil {
     
-    private enum LocationType: String {
+    fileprivate enum LocationType: String {
         case Pickup = "pickup"
         case Dropoff = "dropoff"
     }
@@ -153,44 +153,44 @@ class RequestURLUtil {
     static let formattedAddressKey = "[formatted_address]"
     static let userAgentKey = "user-agent"
     
-    static func buildRequestQueryParameters(rideParameters: RideParameters) -> [NSURLQueryItem] {
+    static func buildRequestQueryParameters(_ rideParameters: RideParameters) -> [URLQueryItem] {
         
-        var queryItems = [NSURLQueryItem]()
-        queryItems.append(NSURLQueryItem(name: RequestURLUtil.actionKey, value: RequestURLUtil.setPickupValue))
-        queryItems.append(NSURLQueryItem(name: RequestURLUtil.clientIDKey, value: Configuration.getClientID()))
+        var queryItems = [URLQueryItem]()
+        queryItems.append(URLQueryItem(name: RequestURLUtil.actionKey, value: RequestURLUtil.setPickupValue))
+        queryItems.append(URLQueryItem(name: RequestURLUtil.clientIDKey, value: Configuration.getClientID()))
         
         if let productID = rideParameters.productID {
-            queryItems.append(NSURLQueryItem(name: RequestURLUtil.productIDKey, value: productID))
+            queryItems.append(URLQueryItem(name: RequestURLUtil.productIDKey, value: productID))
         }
         
         if let location = rideParameters.pickupLocation {
-            queryItems.appendContentsOf(addLocation(LocationType.Pickup, location: location, nickname: rideParameters.pickupNickname, address: rideParameters.pickupAddress))
+            queryItems.append(contentsOf: addLocation(LocationType.Pickup, location: location, nickname: rideParameters.pickupNickname, address: rideParameters.pickupAddress))
         } else {
-            queryItems.append(NSURLQueryItem(name: LocationType.Pickup.rawValue, value: RequestURLUtil.currentLocationValue))
+            queryItems.append(URLQueryItem(name: LocationType.Pickup.rawValue, value: RequestURLUtil.currentLocationValue))
         }
         
         if let location = rideParameters.dropoffLocation {
-            queryItems.appendContentsOf(addLocation(LocationType.Dropoff, location: location, nickname: rideParameters.dropoffNickname, address: rideParameters.dropoffAddress))
+            queryItems.append(contentsOf: addLocation(LocationType.Dropoff, location: location, nickname: rideParameters.dropoffNickname, address: rideParameters.dropoffAddress))
         }
         
-        queryItems.append(NSURLQueryItem(name: RequestURLUtil.userAgentKey, value: rideParameters.userAgent))
+        queryItems.append(URLQueryItem(name: RequestURLUtil.userAgentKey, value: rideParameters.userAgent))
         
         return queryItems
     }
     
-    private static func addLocation(locationType: LocationType, location: CLLocation, nickname: String?, address: String?) -> [NSURLQueryItem] {
-        var queryItems = [NSURLQueryItem]()
+    fileprivate static func addLocation(_ locationType: LocationType, location: CLLocation, nickname: String?, address: String?) -> [URLQueryItem] {
+        var queryItems = [URLQueryItem]()
         
         let locationPrefix = locationType.rawValue
         let latitudeString = "\(location.coordinate.latitude)"
         let longitudeString = "\(location.coordinate.longitude)"
-        queryItems.append(NSURLQueryItem(name: locationPrefix + RequestURLUtil.latitudeKey, value: latitudeString))
-        queryItems.append(NSURLQueryItem(name: locationPrefix + RequestURLUtil.longitudeKey, value: longitudeString))
+        queryItems.append(URLQueryItem(name: locationPrefix + RequestURLUtil.latitudeKey, value: latitudeString))
+        queryItems.append(URLQueryItem(name: locationPrefix + RequestURLUtil.longitudeKey, value: longitudeString))
         if let nickname = nickname {
-            queryItems.append(NSURLQueryItem(name: locationPrefix + RequestURLUtil.nicknameKey, value: nickname))
+            queryItems.append(URLQueryItem(name: locationPrefix + RequestURLUtil.nicknameKey, value: nickname))
         }
         if let address = address {
-            queryItems.append(NSURLQueryItem(name: locationPrefix + RequestURLUtil.formattedAddressKey, value: address))
+            queryItems.append(URLQueryItem(name: locationPrefix + RequestURLUtil.formattedAddressKey, value: address))
         }
         
         return queryItems
@@ -203,7 +203,7 @@ class RequestURLUtil {
  Adds functionality to extract key value pairs (as NSURLQueryItem) from the fragment
  Adds functionality to extract key value pairs (as NSURLQueryItem) from both fragment and query
  */
-extension NSURLComponents
+extension URLComponents
 {
     /**
      Converts key value pairs in the fragment into NSURLQueryItems
@@ -211,7 +211,7 @@ extension NSURLComponents
      then restoring the original value of query
      - returns: An array of NSURLQueryItems, or nil if there was no fragment
      */
-    func fragmentItems() -> [NSURLQueryItem]?
+    mutating func fragmentItems() -> [URLQueryItem]?
     {
         objc_sync_enter(self)
         let holdQuery = self.query
@@ -227,14 +227,14 @@ extension NSURLComponents
      to the NSURLQuery items returned from .queryItems
      - returns: An array of NSURLQueryItems, or nil if there was no fragment and no query
      */
-    func allItems() -> [NSURLQueryItem]?
+    mutating func allItems() -> [URLQueryItem]?
     {
-        var finalItemArray = [NSURLQueryItem]()
+        var finalItemArray = [URLQueryItem]()
         if let queryItems = self.queryItems {
-            finalItemArray.appendContentsOf(queryItems)
+            finalItemArray.append(contentsOf: queryItems)
         }
         if let fragmentItems = self.fragmentItems() {
-            finalItemArray.appendContentsOf(fragmentItems)
+            finalItemArray.append(contentsOf: fragmentItems)
         }
         guard finalItemArray.count > 0 else {
             return nil

--- a/source/UberRidesTests/APIManagerTests.swift
+++ b/source/UberRidesTests/APIManagerTests.swift
@@ -76,7 +76,7 @@ class APIManagerTests: XCTestCase {
      
      - returns: NSURLRequest with URL and HTTPMethod set.
      */
-    func buildRequestForEndpoint(endpoint: UberAPI) -> NSURLRequest {
+    func buildRequestForEndpoint(_ endpoint: UberAPI) -> URLRequest {
         let request = Request(session: nil, endpoint: endpoint)
         request.prepare()
         return request.urlRequest
@@ -233,7 +233,7 @@ class APIManagerTests: XCTestCase {
         
         var dict: NSDictionary?
         do {
-            dict = try NSJSONSerialization.JSONObjectWithData(data, options: .MutableContainers) as? NSDictionary
+            dict = try JSONSerialization.JSONObjectWithData(data, options: .MutableContainers) as? NSDictionary
         } catch {
             XCTAssert(false)
         }
@@ -361,7 +361,7 @@ class APIManagerTests: XCTestCase {
         
         var dictionary: NSDictionary?
         do {
-            dictionary = try NSJSONSerialization.JSONObjectWithData(request.HTTPBody!, options: .MutableContainers) as? NSDictionary
+            dictionary = try JSONSerialization.JSONObjectWithData(request.HTTPBody!, options: .MutableContainers) as? NSDictionary
         } catch {
             XCTAssert(false)
         }
@@ -400,7 +400,7 @@ class APIManagerTests: XCTestCase {
         
         var dict: NSDictionary?
         do {
-            dict = try NSJSONSerialization.JSONObjectWithData(data, options: .MutableContainers) as? NSDictionary
+            dict = try JSONSerialization.JSONObjectWithData(data, options: .MutableContainers) as? NSDictionary
         } catch {
             XCTAssert(false)
         }
@@ -439,7 +439,7 @@ class APIManagerTests: XCTestCase {
         
         var dict: NSDictionary?
         do {
-            dict = try NSJSONSerialization.JSONObjectWithData(data, options: .MutableContainers) as? NSDictionary
+            dict = try JSONSerialization.JSONObjectWithData(data, options: .MutableContainers) as? NSDictionary
         } catch {
             XCTAssert(false)
         }

--- a/source/UberRidesTests/AccessTokenFactoryTests.swift
+++ b/source/UberRidesTests/AccessTokenFactoryTests.swift
@@ -26,14 +26,14 @@ import XCTest
 @testable import UberRides
 
 class AccessTokenFactoryTests: XCTestCase {
-    private let redirectURI = "http://localhost:1234/"
-    private let tokenString = "token"
-    private let refreshTokenString = "refreshToken"
-    private let expirationTime = 10030.23
-    private let allowedScopesString = "profile history"
-    private let errorString = "invalid_parameters"
+    fileprivate let redirectURI = "http://localhost:1234/"
+    fileprivate let tokenString = "token"
+    fileprivate let refreshTokenString = "refreshToken"
+    fileprivate let expirationTime = 10030.23
+    fileprivate let allowedScopesString = "profile history"
+    fileprivate let errorString = "invalid_parameters"
     
-    private let maxExpirationDifference = 2.0
+    fileprivate let maxExpirationDifference = 2.0
     
     override func setUp() {
         super.setUp()
@@ -46,15 +46,15 @@ class AccessTokenFactoryTests: XCTestCase {
     }
 
     func testParseTokenFromURL_withSuccess() {
-        let components = NSURLComponents()
+        var components = URLComponents()
         components.fragment = "access_token=\(tokenString)&refresh_token=\(refreshTokenString)&expires_in=\(expirationTime)&scope=\(allowedScopesString)"
         components.host = redirectURI
-        guard let url = components.URL else {
+        guard let url = components.url else {
             XCTAssert(false)
             return
         }
         do {
-            let expectedExpirationInterval = NSDate().timeIntervalSince1970 + expirationTime
+            let expectedExpirationInterval = Date().timeIntervalSince1970 + expirationTime
             
             let token : AccessToken = try AccessTokenFactory.createAccessTokenFromRedirectURL(url)
             XCTAssertNotNil(token)
@@ -78,10 +78,10 @@ class AccessTokenFactoryTests: XCTestCase {
     }
     
     func testParseTokenFromURL_withError() {
-        let components = NSURLComponents()
+        var components = URLComponents()
         components.fragment = "access_token=\(tokenString)&refresh_token=\(refreshTokenString)&expires_in=\(expirationTime)&scope=\(allowedScopesString)&error=\(errorString)"
         components.host = redirectURI
-        guard let url = components.URL else {
+        guard let url = components.url else {
             XCTAssert(false)
             return
         }
@@ -96,10 +96,10 @@ class AccessTokenFactoryTests: XCTestCase {
     }
     
     func testParseTokenFromURL_withOnlyError() {
-        let components = NSURLComponents()
+        var components = URLComponents()
         components.fragment = "error=\(errorString)"
         components.host = redirectURI
-        guard let url = components.URL else {
+        guard let url = components.url else {
             XCTAssert(false)
             return
         }
@@ -114,10 +114,10 @@ class AccessTokenFactoryTests: XCTestCase {
     }
     
     func testParseTokenFromURL_withPartialParameters() {
-        let components = NSURLComponents()
+        var components = URLComponents()
         components.fragment = "access_token=\(tokenString)"
         components.host = redirectURI
-        guard let url = components.URL else {
+        guard let url = components.url else {
             XCTAssert(false)
             return
         }
@@ -136,11 +136,11 @@ class AccessTokenFactoryTests: XCTestCase {
     }
     
     func testParseTokenFromURL_withFragmentAndQuery_withError() {
-        let components = NSURLComponents()
+        var components = URLComponents()
         components.fragment = "access_token=\(tokenString)"
         components.query = "error=\(errorString)"
         components.host = redirectURI
-        guard let url = components.URL else {
+        guard let url = components.url else {
             XCTAssert(false)
             return
         }
@@ -155,16 +155,16 @@ class AccessTokenFactoryTests: XCTestCase {
     }
     
     func testParseTokenFromURL_withFragmentAndQuery_withSuccess() {
-        let components = NSURLComponents()
+        var components = URLComponents()
         components.fragment = "access_token=\(tokenString)&refresh_token=\(refreshTokenString)"
         components.query = "expires_in=\(expirationTime)&scope=\(allowedScopesString)"
         components.host = redirectURI
-        guard let url = components.URL else {
+        guard let url = components.url else {
             XCTAssert(false)
             return
         }
         do {
-            let expectedExpirationInterval = NSDate().timeIntervalSince1970 + expirationTime
+            let expectedExpirationInterval = Date().timeIntervalSince1970 + expirationTime
             
             let token : AccessToken = try AccessTokenFactory.createAccessTokenFromRedirectURL(url)
             XCTAssertNotNil(token)
@@ -188,10 +188,10 @@ class AccessTokenFactoryTests: XCTestCase {
     }
     
     func testParseTokenFromURL_withInvalidFragment() {
-        let components = NSURLComponents()
+        var components = URLComponents()
         components.fragment = "access_token=\(tokenString)&refresh_token"
         components.host = redirectURI
-        guard let url = components.URL else {
+        guard let url = components.url else {
             XCTAssert(false)
             return
         }

--- a/source/UberRidesTests/AuthenticationDeeplinkTests.swift
+++ b/source/UberRidesTests/AuthenticationDeeplinkTests.swift
@@ -26,14 +26,14 @@ import XCTest
 
 class AuthenticationDeeplinkTests: XCTestCase {
     
-    private var versionNumber: String?
+    fileprivate var versionNumber: String?
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
-        versionNumber = NSBundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
+        Configuration.bundle = Bundle(forClass: type(of: self))
+        versionNumber = Bundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
     }
     
     override func tearDown() {

--- a/source/UberRidesTests/AuthenticationURLUtilityTests.swift
+++ b/source/UberRidesTests/AuthenticationURLUtilityTests.swift
@@ -26,14 +26,14 @@ import XCTest
 
 class AuthenticationURLUtilityTests: XCTestCase {
     
-    private var versionNumber: String?
+    fileprivate var versionNumber: String?
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
-        versionNumber = NSBundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
+        Configuration.bundle = Bundle(forClass: type(of: self))
+        versionNumber = Bundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
     }
     
     override func tearDown() {
@@ -53,13 +53,13 @@ class AuthenticationURLUtilityTests: XCTestCase {
         let expectedSDK = "ios"
         let expectedSDKVersion = versionNumber
         
-        let scopeQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.scopesKey, value: expectedScopes)
-        let clientIDQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.clientIDKey, value: expectedClientID)
-        let appNameQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.appNameKey, value: expectedAppName)
-        let callbackURIQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.callbackURIKey, value: expectedCallbackURI)
-        let loginTypeQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.loginTypeKey, value: expectedLoginType)
-        let sdkQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.sdkKey, value: expectedSDK)
-        let sdkVersionQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.sdkVersionKey, value: expectedSDKVersion)
+        let scopeQueryItem = URLQueryItem(name: AuthenticationURLUtility.scopesKey, value: expectedScopes)
+        let clientIDQueryItem = URLQueryItem(name: AuthenticationURLUtility.clientIDKey, value: expectedClientID)
+        let appNameQueryItem = URLQueryItem(name: AuthenticationURLUtility.appNameKey, value: expectedAppName)
+        let callbackURIQueryItem = URLQueryItem(name: AuthenticationURLUtility.callbackURIKey, value: expectedCallbackURI)
+        let loginTypeQueryItem = URLQueryItem(name: AuthenticationURLUtility.loginTypeKey, value: expectedLoginType)
+        let sdkQueryItem = URLQueryItem(name: AuthenticationURLUtility.sdkKey, value: expectedSDK)
+        let sdkVersionQueryItem = URLQueryItem(name: AuthenticationURLUtility.sdkVersionKey, value: expectedSDKVersion)
         
         let expectedQueryItems = [scopeQueryItem, clientIDQueryItem, appNameQueryItem, callbackURIQueryItem, loginTypeQueryItem, sdkQueryItem, sdkVersionQueryItem]
         let comparisonSet = NSSet(array: expectedQueryItems)
@@ -82,13 +82,13 @@ class AuthenticationURLUtilityTests: XCTestCase {
         let expectedSDK = "ios"
         let expectedSDKVersion = versionNumber
         
-        let scopeQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.scopesKey, value: expectedScopes)
-        let clientIDQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.clientIDKey, value: expectedClientID)
-        let appNameQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.appNameKey, value: expectedAppName)
-        let callbackURIQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.callbackURIKey, value: expectedCallbackURI)
-        let loginTypeQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.loginTypeKey, value: expectedLoginType)
-        let sdkQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.sdkKey, value: expectedSDK)
-        let sdkVersionQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.sdkVersionKey, value: expectedSDKVersion)
+        let scopeQueryItem = URLQueryItem(name: AuthenticationURLUtility.scopesKey, value: expectedScopes)
+        let clientIDQueryItem = URLQueryItem(name: AuthenticationURLUtility.clientIDKey, value: expectedClientID)
+        let appNameQueryItem = URLQueryItem(name: AuthenticationURLUtility.appNameKey, value: expectedAppName)
+        let callbackURIQueryItem = URLQueryItem(name: AuthenticationURLUtility.callbackURIKey, value: expectedCallbackURI)
+        let loginTypeQueryItem = URLQueryItem(name: AuthenticationURLUtility.loginTypeKey, value: expectedLoginType)
+        let sdkQueryItem = URLQueryItem(name: AuthenticationURLUtility.sdkKey, value: expectedSDK)
+        let sdkVersionQueryItem = URLQueryItem(name: AuthenticationURLUtility.sdkVersionKey, value: expectedSDKVersion)
         
         let expectedQueryItems = [scopeQueryItem, clientIDQueryItem, appNameQueryItem, callbackURIQueryItem, loginTypeQueryItem, sdkQueryItem, sdkVersionQueryItem]
         let comparisonSet = NSSet(array: expectedQueryItems)
@@ -113,13 +113,13 @@ class AuthenticationURLUtilityTests: XCTestCase {
         let expectedSDK = "ios"
         let expectedSDKVersion = versionNumber
         
-        let scopeQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.scopesKey, value: expectedScopes)
-        let clientIDQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.clientIDKey, value: expectedClientID)
-        let appNameQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.appNameKey, value: expectedAppName)
-        let callbackURIQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.callbackURIKey, value: expectedCallbackURI)
-        let loginTypeQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.loginTypeKey, value: expectedLoginType)
-        let sdkQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.sdkKey, value: expectedSDK)
-        let sdkVersionQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.sdkVersionKey, value: expectedSDKVersion)
+        let scopeQueryItem = URLQueryItem(name: AuthenticationURLUtility.scopesKey, value: expectedScopes)
+        let clientIDQueryItem = URLQueryItem(name: AuthenticationURLUtility.clientIDKey, value: expectedClientID)
+        let appNameQueryItem = URLQueryItem(name: AuthenticationURLUtility.appNameKey, value: expectedAppName)
+        let callbackURIQueryItem = URLQueryItem(name: AuthenticationURLUtility.callbackURIKey, value: expectedCallbackURI)
+        let loginTypeQueryItem = URLQueryItem(name: AuthenticationURLUtility.loginTypeKey, value: expectedLoginType)
+        let sdkQueryItem = URLQueryItem(name: AuthenticationURLUtility.sdkKey, value: expectedSDK)
+        let sdkVersionQueryItem = URLQueryItem(name: AuthenticationURLUtility.sdkVersionKey, value: expectedSDKVersion)
         
         let expectedQueryItems = [scopeQueryItem, clientIDQueryItem, appNameQueryItem, callbackURIQueryItem, loginTypeQueryItem, sdkQueryItem, sdkVersionQueryItem]
         let comparisonSet = NSSet(array: expectedQueryItems)
@@ -144,13 +144,13 @@ class AuthenticationURLUtilityTests: XCTestCase {
         let expectedSDK = "ios"
         let expectedSDKVersion = versionNumber
         
-        let scopeQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.scopesKey, value: expectedScopes)
-        let clientIDQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.clientIDKey, value: expectedClientID)
-        let appNameQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.appNameKey, value: expectedAppName)
-        let callbackURIQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.callbackURIKey, value: expectedCallbackURI)
-        let loginTypeQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.loginTypeKey, value: expectedLoginType)
-        let sdkQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.sdkKey, value: expectedSDK)
-        let sdkVersionQueryItem = NSURLQueryItem(name: AuthenticationURLUtility.sdkVersionKey, value: expectedSDKVersion)
+        let scopeQueryItem = URLQueryItem(name: AuthenticationURLUtility.scopesKey, value: expectedScopes)
+        let clientIDQueryItem = URLQueryItem(name: AuthenticationURLUtility.clientIDKey, value: expectedClientID)
+        let appNameQueryItem = URLQueryItem(name: AuthenticationURLUtility.appNameKey, value: expectedAppName)
+        let callbackURIQueryItem = URLQueryItem(name: AuthenticationURLUtility.callbackURIKey, value: expectedCallbackURI)
+        let loginTypeQueryItem = URLQueryItem(name: AuthenticationURLUtility.loginTypeKey, value: expectedLoginType)
+        let sdkQueryItem = URLQueryItem(name: AuthenticationURLUtility.sdkKey, value: expectedSDK)
+        let sdkVersionQueryItem = URLQueryItem(name: AuthenticationURLUtility.sdkVersionKey, value: expectedSDKVersion)
         
         let expectedQueryItems = [scopeQueryItem, clientIDQueryItem, appNameQueryItem, callbackURIQueryItem, loginTypeQueryItem, sdkQueryItem, sdkVersionQueryItem]
         let comparisonSet = NSSet(array: expectedQueryItems)
@@ -163,7 +163,7 @@ class AuthenticationURLUtilityTests: XCTestCase {
     
     func testShouldHandleRedirectURL() {
         let testRedirectURLString = "test://handleThis"
-        guard let testRedirectURL = NSURL(string: testRedirectURLString) else {
+        guard let testRedirectURL = URL(string: testRedirectURLString) else {
             XCTFail()
             return
         }

--- a/source/UberRidesTests/BaseAuthenticatorTests.swift
+++ b/source/UberRidesTests/BaseAuthenticatorTests.swift
@@ -26,18 +26,18 @@ import XCTest
 @testable import UberRides
 
 class BaseAuthenticatorTests: XCTestCase {
-    private var expectation: XCTestExpectation!
-    private var accessToken: AccessToken?
-    private var error: NSError?
-    private let timeout: NSTimeInterval = 2
-    private let tokenString = "accessToken1234"
-    private var redirectURI: String = ""
+    fileprivate var expectation: XCTestExpectation!
+    fileprivate var accessToken: AccessToken?
+    fileprivate var error: NSError?
+    fileprivate let timeout: TimeInterval = 2
+    fileprivate let tokenString = "accessToken1234"
+    fileprivate var redirectURI: String = ""
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setSandboxEnabled(true)
         redirectURI = Configuration.getCallbackURIString(.General)
     }
@@ -60,7 +60,7 @@ class BaseAuthenticatorTests: XCTestCase {
     }
     
     func testBaseAuthenticator_handleRedirectFalse_whenURLNil() {
-        let emptyRequest = NSURLRequest()
+        let emptyRequest = URLRequest()
         let baseAuthenticator = BaseAuthenticator(scopes: [])
         XCTAssertFalse(baseAuthenticator.handleRedirectRequest(emptyRequest))
     }
@@ -69,34 +69,34 @@ class BaseAuthenticatorTests: XCTestCase {
         let redirectURLString = "testURI://redirect"
         let notRedirectURLString = "testURI://notRedirect"
         Configuration.setCallbackURIString(redirectURLString, type: .General)
-        guard let notRedirectURL = NSURL(string: notRedirectURLString) else {
+        guard let notRedirectURL = URL(string: notRedirectURLString) else {
             XCTFail()
             return
         }
-        let handleRequest = NSURLRequest(URL: notRedirectURL)
+        let handleRequest = URLRequest(url: notRedirectURL)
         let baseAuthenticator = BaseAuthenticator(scopes: [])
         XCTAssertFalse(baseAuthenticator.handleRedirectRequest(handleRequest))
     }
     
     func testBaseAuthenticator_handleRedirectTrue_whenValidRedirect() {
-        let expectation = expectationWithDescription("Login completion called")
+        let expectation = self.expectation(withDescription: "Login completion called")
         
-        let loginCompletionBlock: ((accessToken: AccessToken?, error: NSError?) -> Void) = { (_,_) in
+        let loginCompletionBlock: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void) = { (_,_) in
             expectation.fulfill()
         }
         
         let redirectURLString = "testURI://redirect?error=server_error"
         Configuration.setCallbackURIString(redirectURLString, type: .General)
-        guard let redirectURL = NSURL(string: redirectURLString) else {
+        guard let redirectURL = URL(string: redirectURLString) else {
             XCTFail()
             return
         }
-        let handleRequest = NSURLRequest(URL: redirectURL)
+        let handleRequest = URLRequest(url: redirectURL)
         let baseAuthenticator = BaseAuthenticator(scopes: [])
         baseAuthenticator.loginCompletion = loginCompletionBlock
         
         XCTAssertTrue(baseAuthenticator.handleRedirectRequest(handleRequest))
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
     }
 }

--- a/source/UberRidesTests/BaseDeeplinkTests.swift
+++ b/source/UberRidesTests/BaseDeeplinkTests.swift
@@ -26,14 +26,14 @@ import XCTest
 
 class BaseDeeplinkTests: XCTestCase {
     
-    private var versionNumber: String?
+    fileprivate var versionNumber: String?
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
-        versionNumber = NSBundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
+        Configuration.bundle = Bundle(forClass: type(of: self))
+        versionNumber = Bundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
     }
     
     override func tearDown() {
@@ -45,14 +45,14 @@ class BaseDeeplinkTests: XCTestCase {
         let testScheme = "testScheme"
         let testDomain = "testDomain"
         let testPath = "/testPath"
-        let testQueryItems = [NSURLQueryItem(name: "test", value: "testing")]
+        let testQueryItems = [URLQueryItem(name: "test", value: "testing")]
         
-        let urlComponents = NSURLComponents()
+        var urlComponents = URLComponents()
         urlComponents.scheme = testScheme
         urlComponents.host = testDomain
         urlComponents.path = testPath
         urlComponents.queryItems = testQueryItems
-        let expectedURL = urlComponents.URL
+        let expectedURL = urlComponents.url
         
         guard let baseDeeplink = BaseDeeplink(scheme: testScheme, domain: testDomain, path: testPath, queryItems: testQueryItems) else {
             XCTFail()

--- a/source/UberRidesTests/ConfigurationTests.swift
+++ b/source/UberRidesTests/ConfigurationTests.swift
@@ -27,23 +27,23 @@ import XCTest
 
 class ConfigurationTests: XCTestCase {
 
-    private let defaultClientID = "testClientID"
-    private let defaultDisplayName = "My Awesome App"
-    private let defaultCallbackString = "testURI://uberConnect"
-    private let defaultGeneralCallbackString = "testURI://uberConnectGeneral"
-    private let defaultAuthorizationCodeCallbackString = "testURI://uberConnectAuthorizationCode"
-    private let defaultImplicitCallbackString = "testURI://uberConnectImplicit"
-    private let defaultNativeCallbackString = "testURI://uberConnectNative"
-    private let defaultServerToken = "testServerToken"
-    private let defaultAccessTokenIdentifier = "RidesAccessTokenKey"
-    private let defaultRegion = Region.Default
-    private let defaultSandbox = false
+    fileprivate let defaultClientID = "testClientID"
+    fileprivate let defaultDisplayName = "My Awesome App"
+    fileprivate let defaultCallbackString = "testURI://uberConnect"
+    fileprivate let defaultGeneralCallbackString = "testURI://uberConnectGeneral"
+    fileprivate let defaultAuthorizationCodeCallbackString = "testURI://uberConnectAuthorizationCode"
+    fileprivate let defaultImplicitCallbackString = "testURI://uberConnectImplicit"
+    fileprivate let defaultNativeCallbackString = "testURI://uberConnectNative"
+    fileprivate let defaultServerToken = "testServerToken"
+    fileprivate let defaultAccessTokenIdentifier = "RidesAccessTokenKey"
+    fileprivate let defaultRegion = Region.Default
+    fileprivate let defaultSandbox = false
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
     }
     
     override func tearDown() {
@@ -84,10 +84,10 @@ class ConfigurationTests: XCTestCase {
         Configuration.restoreDefaults()
         
         XCTAssertEqual(Configuration.plistName, "Info")
-        XCTAssertEqual(Configuration.bundle, NSBundle.mainBundle())
+        XCTAssertEqual(Configuration.bundle, Bundle.mainBundle())
         
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         
         XCTAssertEqual(Configuration.getClientID(), defaultClientID)
         XCTAssertEqual(defaultGeneralCallbackString, Configuration.getCallbackURIString())

--- a/source/UberRidesTests/DeeplinkRequestingBehaviorTests.swift
+++ b/source/UberRidesTests/DeeplinkRequestingBehaviorTests.swift
@@ -26,18 +26,18 @@ import CoreLocation
 
 class DeeplinkRequestingBehaviorTests : XCTestCase {
     
-    private var versionNumber: String?
-    private var expectedDeeplinkUserAgent: String?
-    private var expectedButtonUserAgent: String?
+    fileprivate var versionNumber: String?
+    fileprivate var expectedDeeplinkUserAgent: String?
+    fileprivate var expectedButtonUserAgent: String?
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setClientID(clientID)
         Configuration.setSandboxEnabled(true)
-        versionNumber = NSBundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
+        versionNumber = Bundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
         expectedDeeplinkUserAgent = "rides-ios-v\(versionNumber!)-deeplink"
         expectedButtonUserAgent = "rides-ios-v\(versionNumber!)-button"
     }
@@ -58,7 +58,7 @@ class DeeplinkRequestingBehaviorTests : XCTestCase {
         
         let appStoreDeeplink = requestingBehavior.createAppStoreDeeplink(rideParameters)
         
-        let components = NSURLComponents(URL: appStoreDeeplink.deeplinkURL, resolvingAgainstBaseURL: false)
+        let components = URLComponents(URL: appStoreDeeplink.deeplinkURL, resolvingAgainstBaseURL: false)
         XCTAssertNotNil(components)
         
         XCTAssertEqual(expectedUrlString, appStoreDeeplink.deeplinkURL.absoluteString)
@@ -77,7 +77,7 @@ class DeeplinkRequestingBehaviorTests : XCTestCase {
         
         let appStoreDeeplink = requestingBehavior.createAppStoreDeeplink(rideParameters)
         
-        let components = NSURLComponents(URL: appStoreDeeplink.deeplinkURL, resolvingAgainstBaseURL: false)
+        let components = URLComponents(URL: appStoreDeeplink.deeplinkURL, resolvingAgainstBaseURL: false)
         XCTAssertNotNil(components)
         
         XCTAssertEqual(expectedUrlString, appStoreDeeplink.deeplinkURL.absoluteString)
@@ -87,8 +87,8 @@ class DeeplinkRequestingBehaviorTests : XCTestCase {
     
     func testRequestRideExecutesDeeplink() {
         let rideParameters = RideParametersBuilder().setSource(RideRequestButton.sourceString).build()
-        let expectation = expectationWithDescription("Deeplink executed")
-        let testClosure:((NSURL?) -> (Bool)) = { _ in
+        let expectation = self.expectation(description: "Deeplink executed")
+        let testClosure:((URL?) -> (Bool)) = { _ in
             expectation.fulfill()
             return false
         }
@@ -96,7 +96,7 @@ class DeeplinkRequestingBehaviorTests : XCTestCase {
         
         requestingBehavior.requestRide(rideParameters)
         
-        waitForExpectationsWithTimeout(0.5, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
 }
 

--- a/source/UberRidesTests/LoginButtonTests.swift
+++ b/source/UberRidesTests/LoginButtonTests.swift
@@ -26,13 +26,13 @@ import CoreLocation
 
 class LoginButtonTests : XCTestCase {
     
-    private var keychain: KeychainWrapper?
+    fileprivate var keychain: KeychainWrapper?
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setSandboxEnabled(true)
         keychain = KeychainWrapper()
     }
@@ -54,7 +54,7 @@ class LoginButtonTests : XCTestCase {
         XCTAssertNil(token)
         
         let loginManager = LoginManager(accessTokenIdentifier: identifier, keychainAccessGroup: accessGroup, loginType: .Implicit)
-        let loginButton = LoginButton(frame: CGRectZero, scopes: [], loginManager: loginManager)
+        let loginButton = LoginButton(frame: CGRect.zero, scopes: [], loginManager: loginManager)
         
         XCTAssertEqual(loginButton.buttonState, LoginButtonState.SignedOut)
         
@@ -71,7 +71,7 @@ class LoginButtonTests : XCTestCase {
         keychain?.setObject(token, key: identifier)
         
         let loginManager = LoginManager(accessTokenIdentifier: identifier, keychainAccessGroup: accessGroup, loginType: .Implicit)
-        let loginButton = LoginButton(frame: CGRectZero, scopes: [], loginManager: loginManager)
+        let loginButton = LoginButton(frame: CGRect.zero, scopes: [], loginManager: loginManager)
         
         XCTAssertEqual(loginButton.buttonState, LoginButtonState.SignedIn)
         
@@ -88,13 +88,13 @@ class LoginButtonTests : XCTestCase {
         let token = TokenManager.fetchToken(identifier, accessGroup: accessGroup)
         XCTAssertNil(token)
         
-        let expectation = expectationWithDescription("Expected executeLogin() called")
+        let expectation = self.expectation(description: "Expected executeLogin() called")
         
         let loginManager = LoginManagerPartialMock(accessTokenIdentifier: identifier, keychainAccessGroup: accessGroup, loginType: .Implicit)
         loginManager.executeLoginClosure = {
             expectation.fulfill()
         }
-        let loginButton = LoginButton(frame: CGRectZero, scopes: [.Profile], loginManager: loginManager)
+        let loginButton = LoginButton(frame: CGRect.zero, scopes: [.Profile], loginManager: loginManager)
         
         loginButton.presentingViewController = UIViewController()
         XCTAssertNotNil(loginButton)
@@ -119,7 +119,7 @@ class LoginButtonTests : XCTestCase {
         keychain?.setObject(token, key: identifier)
         
         let loginManager = LoginManager(accessTokenIdentifier: identifier, keychainAccessGroup: accessGroup, loginType: .Implicit)
-        let loginButton = LoginButton(frame: CGRectZero, scopes: [.Profile], loginManager: loginManager)
+        let loginButton = LoginButton(frame: CGRect.zero, scopes: [.Profile], loginManager: loginManager)
         
         loginButton.presentingViewController = UIViewController()
         XCTAssertNotNil(loginButton)

--- a/source/UberRidesTests/LoginManagerTests.swift
+++ b/source/UberRidesTests/LoginManagerTests.swift
@@ -26,13 +26,13 @@ import WebKit
 @testable import UberRides
 
 class LoginManagerTests: XCTestCase {
-    private let timeout: Double = 2
+    fileprivate let timeout: Double = 2
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setSandboxEnabled(true)
     }
     
@@ -42,7 +42,7 @@ class LoginManagerTests: XCTestCase {
     }
     
     func testAuthentictorIsNative_whenLoginWithNativeType() {
-        let expectation = expectationWithDescription("executeLogin called")
+        let expectation = self.expectation(description: "executeLogin called")
         
         let executeLoginClosure: () -> () = {
             expectation.fulfill()
@@ -59,7 +59,7 @@ class LoginManagerTests: XCTestCase {
         XCTAssertEqual(authenticator.callbackURIType, CallbackURIType.Native)
         XCTAssertTrue(loginManagerMock.loggingIn)
         
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        waitForExpectations(timeout: 0.2, handler: nil)
     }
     
     func testRidesAppDelegateContainsManager_afterNativeLogin() {
@@ -83,7 +83,7 @@ class LoginManagerTests: XCTestCase {
     }
     
     func testAuthentictorIsImplicit_whenLoginWithImplicitType() {
-        let expectation = expectationWithDescription("executeLogin called")
+        let expectation = self.expectation(description: "executeLogin called")
         
         let executeLoginClosure: () -> () = {
             expectation.fulfill()
@@ -103,11 +103,11 @@ class LoginManagerTests: XCTestCase {
         XCTAssertEqual(authenticator.callbackURIType, CallbackURIType.Implicit)
         XCTAssertTrue(loginManagerMock.loggingIn)
         
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        waitForExpectations(timeout: 0.2, handler: nil)
     }
     
     func testAuthentictorIsAuthorizationCode_whenLoginWithAuthorizationCodeType() {
-        let expectation = expectationWithDescription("executeLogin called")
+        let expectation = self.expectation(description: "executeLogin called")
         
         let executeLoginClosure: () -> () = {
             expectation.fulfill()
@@ -127,14 +127,14 @@ class LoginManagerTests: XCTestCase {
         XCTAssertEqual(authenticator.callbackURIType, CallbackURIType.AuthorizationCode)
         XCTAssertTrue(loginManagerMock.loggingIn)
         
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        waitForExpectations(timeout: 0.2, handler: nil)
     }
     
     func testLoginFails_whenLoggingIn() {
-        let expectation = expectationWithDescription("loginCompletion called")
+        let expectation = self.expectation(description: "loginCompletion called")
         
         let executeLoginClosure: () -> () = {}
-        let loginCompletion: ((accessToken: AccessToken?, error: NSError?) -> Void) = { token, error in
+        let loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void) = { token, error in
             guard let error = error else {
                 XCTFail()
                 return
@@ -149,14 +149,14 @@ class LoginManagerTests: XCTestCase {
         
         loginManagerMock.login(requestedScopes: [.Profile], presentingViewController: nil, completion: loginCompletion)
         
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        waitForExpectations(timeout: 0.2, handler: nil)
     }
     
     func testLoginFails_whenLoginWithAuthorizationCodeType_whenNoPresentingViewController() {
-        let expectation = expectationWithDescription("loginCompletion called")
+        let expectation = self.expectation(description: "loginCompletion called")
         
         let executeLoginClosure: () -> () = {}
-        let loginCompletion: ((accessToken: AccessToken?, error: NSError?) -> Void) = { token, error in
+        let loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void) = { token, error in
             guard let error = error else {
                 XCTFail()
                 return
@@ -174,14 +174,14 @@ class LoginManagerTests: XCTestCase {
         XCTAssertNil(loginManagerMock.authenticator)
         XCTAssertFalse(loginManagerMock.loggingIn)
         
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        waitForExpectations(timeout: 0.2, handler: nil)
     }
     
     func testLoginFails_whenLoginWithImplicitType_whenNoPresentingViewController() {
-        let expectation = expectationWithDescription("loginCompletion called")
+        let expectation = self.expectation(description: "loginCompletion called")
         
         let executeLoginClosure: () -> () = {}
-        let loginCompletion: ((accessToken: AccessToken?, error: NSError?) -> Void) = { token, error in
+        let loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void) = { token, error in
             guard let error = error else {
                 XCTFail()
                 return
@@ -199,13 +199,13 @@ class LoginManagerTests: XCTestCase {
         XCTAssertNil(loginManagerMock.authenticator)
         XCTAssertFalse(loginManagerMock.loggingIn)
         
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        waitForExpectations(timeout: 0.2, handler: nil)
     }
     
     func testOpenURLFails_whenInvalidSource() {
         let loginManager = LoginManager(loginType: .Native)
-        let testApp = UIApplication.sharedApplication()
-        guard let testURL = NSURL(string: "http://www.google.com") else {
+        let testApp = UIApplication.shared
+        guard let testURL = URL(string: "http://www.google.com") else {
             XCTFail()
             return
         }
@@ -217,8 +217,8 @@ class LoginManagerTests: XCTestCase {
     
     func testOpenURLFails_whenNotNativeType() {
         let loginManager = LoginManager(loginType: .Implicit)
-        let testApp = UIApplication.sharedApplication()
-        guard let testURL = NSURL(string: "http://www.google.com") else {
+        let testApp = UIApplication.shared
+        guard let testURL = URL(string: "http://www.google.com") else {
             XCTFail()
             return
         }
@@ -229,18 +229,18 @@ class LoginManagerTests: XCTestCase {
     }
     
     func testOpenURLSuccess() {
-        let expectation = expectationWithDescription("handleRedirect called")
+        let expectation = self.expectation(description: "handleRedirect called")
         let loginManager = LoginManager(loginType: .Native)
-        let testApp = UIApplication.sharedApplication()
-        guard let testURL = NSURL(string: "http://www.google.com") else {
+        let testApp = UIApplication.shared
+        guard let testURL = URL(string: "http://www.google.com") else {
             XCTFail()
             return
         }
         let testSourceApplication = "com.ubercab.foo"
         let testAnnotation = "annotation"
         
-        let handleRedirectClosure: ((NSURLRequest) -> (Bool)) = { urlRequest in
-            guard let url = urlRequest.URL else {
+        let handleRedirectClosure: ((URLRequest) -> (Bool)) = { urlRequest in
+            guard let url = urlRequest.url else {
                 XCTFail("Redirect URL was nil")
                 return false
             }
@@ -255,16 +255,16 @@ class LoginManagerTests: XCTestCase {
         
         XCTAssertTrue(loginManager.application(testApp, openURL: testURL, sourceApplication: testSourceApplication, annotation: testAnnotation))
         
-        waitForExpectationsWithTimeout(0.2) { _ in
+        waitForExpectations(timeout: 0.2) { _ in
             XCTAssertFalse(loginManager.loggingIn)
             XCTAssertNil(loginManager.authenticator)
         }
     }
     
     func testCancelLoginCalled_whenDidBecomeActive() {
-        let expectation = expectationWithDescription("loginCompletion called")
+        let expectation = self.expectation(description: "loginCompletion called")
         
-        let loginCompletion: ((accessToken: AccessToken?, error: NSError?) -> Void) = { token, error in
+        let loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void) = { token, error in
             guard let error = error else {
                 XCTFail()
                 return
@@ -284,14 +284,14 @@ class LoginManagerTests: XCTestCase {
         XCTAssertNil(loginManager.authenticator)
         XCTAssertFalse(loginManager.loggingIn)
         
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        waitForExpectations(timeout: 0.2, handler: nil)
     }
     
     func testNativeLoginCompletion_whenNotUnavailableError() {
-        let expectation = expectationWithDescription("loginCompletion called")
+        let expectation = self.expectation(description: "loginCompletion called")
         
         let executeLoginClosure: () -> () = {}
-        let loginCompletion: ((accessToken: AccessToken?, error: NSError?) -> Void) = { token, error in
+        let loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void) = { token, error in
             guard let error = error else {
                 XCTFail()
                 return
@@ -308,12 +308,12 @@ class LoginManagerTests: XCTestCase {
         
         loginManagerMock.authenticator?.loginCompletion?(accessToken: nil, error: RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .InvalidRequest))
         
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        waitForExpectations(timeout: 0.2, handler: nil)
     }
     
     func testNativeLoginCompletionDoesFallback_whenUnavailableError_withPrivelegedScopes() {
-        let expectationNative = expectationWithDescription("executeLogin Native called")
-        let expectationAuthorizationCode = expectationWithDescription("executeLogin Authorization Code called")
+        let expectationNative = expectation(description: "executeLogin Native called")
+        let expectationAuthorizationCode = expectation(description: "executeLogin Authorization Code called")
         
         Configuration.setFallbackEnabled(true)
         let scopes = [RidesScope.Request]
@@ -343,8 +343,8 @@ class LoginManagerTests: XCTestCase {
     }
     
     func testNativeLoginCompletionDoesFallback_whenUnavailableError_withGeneralScopes() {
-        let expectationNative = expectationWithDescription("executeLogin Native called")
-        let expectationAuthorizationCode = expectationWithDescription("executeLogin Authorization Code called")
+        let expectationNative = expectation(description: "executeLogin Native called")
+        let expectationAuthorizationCode = expectation(description: "executeLogin Authorization Code called")
         
         let scopes = [RidesScope.Profile]
         
@@ -377,21 +377,21 @@ class LoginManagerTests: XCTestCase {
             
             var dismissClosure: (() -> ())?
             
-            override func dismissViewControllerAnimated(flag: Bool, completion: (() -> Void)?) {
+            override func dismiss(animated flag: Bool, completion: (() -> Void)?) {
                 dismissClosure?()
                 completion?()
             }
         }
         
-        let expectation = expectationWithDescription("loginCompletion called")
-        let dismissExpectation = expectationWithDescription("dissmissViewController called")
+        let expectation = self.expectation(description: "loginCompletion called")
+        let dismissExpectation = self.expectation(description: "dissmissViewController called")
         let viewController = UIViewControllerMock()
     
         let dismissClosure: () -> () = {
             dismissExpectation.fulfill()
         }
         let executeLoginClosure: () -> () = {}
-        let loginCompletion: ((accessToken: AccessToken?, error: NSError?) -> Void) = { token, error in
+        let loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void) = { token, error in
             guard let error = error else {
                 XCTFail()
                 return
@@ -411,6 +411,6 @@ class LoginManagerTests: XCTestCase {
         loginManagerMock.authenticator?.loginCompletion?(accessToken: nil, error: RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .InvalidRequest))
         
         XCTAssertFalse(loginManagerMock.loggingIn)
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        waitForExpectations(timeout: 0.2, handler: nil)
     }
 }

--- a/source/UberRidesTests/ModalViewControllerTests.swift
+++ b/source/UberRidesTests/ModalViewControllerTests.swift
@@ -27,13 +27,13 @@ import XCTest
 
 class ModalViewControllerTests: XCTestCase {
     
-    private let timeout = 2.0
+    fileprivate let timeout = 2.0
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setSandboxEnabled(true)
     }
     
@@ -45,18 +45,18 @@ class ModalViewControllerTests: XCTestCase {
     func testDelegate_willDismiss() {
         @objc class ModalViewControllerDelegateMock : NSObject, ModalViewControllerDelegate {
             var testClosure: () -> ()
-            init(testClosure: () -> ()) {
+            init(testClosure: @escaping () -> ()) {
                 self.testClosure = testClosure
             }
-            @objc func modalViewControllerWillDismiss(modalViewController: ModalViewController) {
+            @objc func modalViewControllerWillDismiss(_ modalViewController: ModalViewController) {
                 testClosure()
             }
-            @objc func modalViewControllerDidDismiss(modalViewController: ModalViewController) {
+            @objc func modalViewControllerDidDismiss(_ modalViewController: ModalViewController) {
                 //intentionally left blank
             }
         }
         
-        let expectation = expectationWithDescription("Test willDismiss() is called")
+        let expectation = self.expectation(description: "Test willDismiss() is called")
         
         let testVC = UIViewController()
         let ridesModal = ModalViewController(childViewController: testVC)
@@ -68,7 +68,7 @@ class ModalViewControllerTests: XCTestCase {
         
         ridesModal.dismiss()
         
-        waitForExpectationsWithTimeout(timeout) { (error) -> Void in
+        waitForExpectations(timeout: timeout) { (error) -> Void in
             XCTAssertNil(error)
         }
     }
@@ -76,18 +76,18 @@ class ModalViewControllerTests: XCTestCase {
     func testDelegate_didDismiss() {
         @objc class ModalViewControllerDelegateMock : NSObject, ModalViewControllerDelegate {
             var testClosure: () -> ()
-            init(testClosure: () -> ()) {
+            init(testClosure: @escaping () -> ()) {
                 self.testClosure = testClosure
             }
-            @objc func modalViewControllerWillDismiss(modalViewController: ModalViewController) {
+            @objc func modalViewControllerWillDismiss(_ modalViewController: ModalViewController) {
                 //intentionally left blank
             }
-            @objc func modalViewControllerDidDismiss(modalViewController: ModalViewController) {
+            @objc func modalViewControllerDidDismiss(_ modalViewController: ModalViewController) {
                 testClosure()
             }
         }
         
-        let expectation = expectationWithDescription("Test willDismiss() is called")
+        let expectation = self.expectation(description: "Test willDismiss() is called")
         
         let testVC = UIViewController()
         let ridesModal = ModalViewController(childViewController: testVC)
@@ -99,7 +99,7 @@ class ModalViewControllerTests: XCTestCase {
         
         ridesModal.viewDidDisappear(false)
         
-        waitForExpectationsWithTimeout(timeout) { (error) -> Void in
+        waitForExpectations(timeout: timeout) { (error) -> Void in
             XCTAssertNil(error)
         }
     }

--- a/source/UberRidesTests/NativeAuthenticatorTests.swift
+++ b/source/UberRidesTests/NativeAuthenticatorTests.swift
@@ -26,18 +26,18 @@ import XCTest
 @testable import UberRides
 
 class NativeAuthenticatorTests: XCTestCase {
-    private var expectation: XCTestExpectation!
-    private var accessToken: AccessToken?
-    private var error: NSError?
-    private let timeout: NSTimeInterval = 2
-    private let tokenString = "accessToken1234"
-    private var redirectURI: String = ""
+    fileprivate var expectation: XCTestExpectation!
+    fileprivate var accessToken: AccessToken?
+    fileprivate var error: NSError?
+    fileprivate let timeout: TimeInterval = 2
+    fileprivate let tokenString = "accessToken1234"
+    fileprivate var redirectURI: String = ""
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setSandboxEnabled(true)
         redirectURI = Configuration.getCallbackURIString(.Native)
     }
@@ -54,8 +54,8 @@ class NativeAuthenticatorTests: XCTestCase {
     }
     
     func testNativeAuthenticator_deeplinkExecutedOnLogin() {
-        let expectation = self.expectationWithDescription("Execute should be called")
-        let executeClosure:((NSError?) -> ())? -> () = { _ in
+        let expectation = self.expectation(withDescription: "Execute should be called")
+        let executeClosure:(((NSError?) -> ())?) -> () = { _ in
             expectation.fulfill()
         }
         let nativeAuthenticator = NativeAuthenticator(scopes: [])
@@ -66,12 +66,12 @@ class NativeAuthenticatorTests: XCTestCase {
         
         nativeAuthenticator.login()
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testNativeAuthenticator_loginCompletionCalled_whenExecuteFails() {
-        let expectation = self.expectationWithDescription("Execute should be called")
-        let loginCompletion: ((accessToken: AccessToken?, error: NSError?) -> Void) = { (_,_) in
+        let expectation = self.expectation(withDescription: "Execute should be called")
+        let loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void) = { (_,_) in
             expectation.fulfill()
         }
         let nativeAuthenticator = NativeAuthenticator(scopes: [])
@@ -84,6 +84,6 @@ class NativeAuthenticatorTests: XCTestCase {
         
         nativeAuthenticator.login()
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
     }
 }

--- a/source/UberRidesTests/OAuthTests.swift
+++ b/source/UberRidesTests/OAuthTests.swift
@@ -29,15 +29,15 @@ class OAuthTests: XCTestCase {
     var expectation: XCTestExpectation!
     var accessToken: AccessToken?
     var error: NSError?
-    let timeout: NSTimeInterval = 2
+    let timeout: TimeInterval = 2
     let tokenString = "accessToken1234"
-    private var redirectURI: String = ""
+    fileprivate var redirectURI: String = ""
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setSandboxEnabled(true)
         redirectURI = Configuration.getCallbackURIString()
     }
@@ -52,16 +52,16 @@ class OAuthTests: XCTestCase {
      Test for parsing successful access token retrieval.
      */
     func testParseAccessTokenFromRedirect() {
-        expectation = expectationWithDescription("success access token")
+        expectation = self.expectation(withDescription: "success access token")
         redirectURI = Configuration.getCallbackURIString(.Implicit)
         let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
-        let url = NSURL(string: "\(redirectURI)#access_token=\(tokenString)")
-        loginView.webView.loadRequest(NSURLRequest(URL: url!))
+        let url = URL(string: "\(redirectURI)#access_token=\(tokenString)")
+        loginView.webView.loadRequest(URLRequest(URL: url!))
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if error != nil {
                 print("Error: \(error)")
             }
@@ -75,16 +75,16 @@ class OAuthTests: XCTestCase {
      Test for empty access token string (this should never happen though).
      */
     func testParseEmptyAccessTokenFromRedirect() {
-        expectation = expectationWithDescription("empty access token")
+        expectation = self.expectation(withDescription: "empty access token")
         redirectURI = Configuration.getCallbackURIString(.Implicit)
         let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
-        let url = NSURL(string: "\(redirectURI)#access_token=")
-        loginView.webView.loadRequest(NSURLRequest(URL: url!))
+        let url = URL(string: "\(redirectURI)#access_token=")
+        loginView.webView.loadRequest(URLRequest(URL: url!))
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if error != nil {
                 print("Error: \(error)")
                 return
@@ -99,16 +99,16 @@ class OAuthTests: XCTestCase {
      Test error mapping when redirect URI doesn't match what's expected for client ID.
      */
     func testMismatchingRedirectError() {
-        expectation = expectationWithDescription("errors")
+        expectation = self.expectation(withDescription: "errors")
         redirectURI = Configuration.getCallbackURIString(.Implicit)
         let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
-        let url = NSURL(string: "\(redirectURI)/errors?error=mismatching_redirect_uri")
-        loginView.webView.loadRequest(NSURLRequest(URL: url!))
+        let url = URL(string: "\(redirectURI)/errors?error=mismatching_redirect_uri")
+        loginView.webView.loadRequest(URLRequest(URL: url!))
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if error != nil {
                 print("Error: \(error)")
                 return
@@ -124,16 +124,16 @@ class OAuthTests: XCTestCase {
      Test error mapping when redirect URI is invalid.
      */
     func testInvalidRedirectError() {
-        expectation = expectationWithDescription("errors")
+        expectation = self.expectation(withDescription: "errors")
         redirectURI = Configuration.getCallbackURIString(.Implicit)
         let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
-        let url = NSURL(string: "\(redirectURI)/errors?error=invalid_redirect_uri")
-        loginView.webView.loadRequest(NSURLRequest(URL: url!))
+        let url = URL(string: "\(redirectURI)/errors?error=invalid_redirect_uri")
+        loginView.webView.loadRequest(URLRequest(URL: url!))
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if error != nil {
                 print("Error: \(error)")
                 return
@@ -149,16 +149,16 @@ class OAuthTests: XCTestCase {
      Test error mapping when client ID is invalid.
      */
     func testInvalidClientIDError() {
-        expectation = expectationWithDescription("errors")
+        expectation = self.expectation(withDescription: "errors")
         redirectURI = Configuration.getCallbackURIString(.Implicit)
         let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
-        let url = NSURL(string: "\(redirectURI)/errors?error=invalid_client_id")
-        loginView.webView.loadRequest(NSURLRequest(URL: url!))
+        let url = URL(string: "\(redirectURI)/errors?error=invalid_client_id")
+        loginView.webView.loadRequest(URLRequest(URL: url!))
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if error != nil {
                 print("Error: \(error)")
                 return
@@ -174,16 +174,16 @@ class OAuthTests: XCTestCase {
      Test error mapping when scope provided is invalid.
      */
     func testInvalidScopeError() {
-        expectation = expectationWithDescription("errors")
+        expectation = self.expectation(withDescription: "errors")
         redirectURI = Configuration.getCallbackURIString(.Implicit)
         let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
-        let url = NSURL(string: "\(redirectURI)/errors?error=invalid_scope")
-        loginView.webView.loadRequest(NSURLRequest(URL: url!))
+        let url = URL(string: "\(redirectURI)/errors?error=invalid_scope")
+        loginView.webView.loadRequest(URLRequest(URL: url!))
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if error != nil {
                 print("Error: \(error)")
                 return
@@ -199,16 +199,16 @@ class OAuthTests: XCTestCase {
      Test error mapping when parameters are generally invalid.
      */
     func testInvalidParametersError() {
-        expectation = expectationWithDescription("errors")
+        expectation = self.expectation(withDescription: "errors")
         redirectURI = Configuration.getCallbackURIString(.Implicit)
         let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
-        let url = NSURL(string: "\(redirectURI)/errors?error=invalid_parameters")
-        loginView.webView.loadRequest(NSURLRequest(URL: url!))
+        let url = URL(string: "\(redirectURI)/errors?error=invalid_parameters")
+        loginView.webView.loadRequest(URLRequest(URL: url!))
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if error != nil {
                 print("Error: \(error)")
                 return
@@ -224,16 +224,16 @@ class OAuthTests: XCTestCase {
      Test error mapping when server error is encountered.
      */
     func testServerError() {
-        expectation = expectationWithDescription("errors")
+        expectation = self.expectation(withDescription: "errors")
         redirectURI = Configuration.getCallbackURIString(.Implicit)
         let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
-        let url = NSURL(string: "\(redirectURI)/errors?error=server_error")
-        loginView.webView.loadRequest(NSURLRequest(URL: url!))
+        let url = URL(string: "\(redirectURI)/errors?error=server_error")
+        loginView.webView.loadRequest(URLRequest(URL: url!))
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if error != nil {
                 print("Error: \(error)")
                 return
@@ -279,7 +279,7 @@ class OAuthTests: XCTestCase {
      Test saving a duplicate key with different value and verify that value is updated.
      */
     func testSaveDuplicateObjectInKeychain() {
-        guard let token = tokenFixture(), newToken = tokenFixture("newTokenString") else {
+        guard let token = tokenFixture(), let newToken = tokenFixture("newTokenString") else {
             XCTAssert(false)
             return
         }
@@ -311,7 +311,7 @@ class OAuthTests: XCTestCase {
         let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: scopes)
         
         var params = [String: String]()
-        let queryItems: [NSURLQueryItem] = implicitGrantBehavior.endpoint.query
+        let queryItems: [URLQueryItem] = implicitGrantBehavior.endpoint.query
         
         for query in queryItems {
             params[query.name] = query.value!
@@ -325,7 +325,7 @@ class OAuthTests: XCTestCase {
     
     func testImplicitGrantRedirect_shouldReturnFalse_forNonRedirectUrlRequest() {
         redirectURI = Configuration.getCallbackURIString(.Implicit)
-        let request = NSURLRequest(URL: NSURL(string: "test://notRedirect")!)
+        let request = URLRequest(url: URL(string: "test://notRedirect")!)
         let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
         implicitGrantBehavior.loginCompletion = { accessToken, error in
             XCTAssert(false)
@@ -336,7 +336,7 @@ class OAuthTests: XCTestCase {
     
     func testAuthorizationCodeGrantRedirect_shouldReturnFalse_forNonRedirectUrlRequest() {
         redirectURI = Configuration.getCallbackURIString(.AuthorizationCode)
-        let request = NSURLRequest(URL: NSURL(string: "test://notRedirect")!)
+        let request = URLRequest(url: URL(string: "test://notRedirect")!)
         let authorizationCodeGrantAuthenticator = AuthorizationCodeGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile], state: "state")
         authorizationCodeGrantAuthenticator.loginCompletion = { accessToken, error in
             XCTAssert(false)
@@ -348,12 +348,12 @@ class OAuthTests: XCTestCase {
     func testImplicitGrantRedirect_shouldReturnTrue_forCorrectRedirectRequest() {
         redirectURI = Configuration.getCallbackURIString(.Implicit)
         let tokenString = "accessToken1234"
-        guard let url = NSURL(string: "\(redirectURI)#access_token=\(tokenString)") else {
+        guard let url = URL(string: "\(redirectURI)#access_token=\(tokenString)") else {
             XCTFail()
             return
         }
-        let request = NSURLRequest(URL: url)
-        let expectation = expectationWithDescription("call login completion")
+        let request = URLRequest(url: url)
+        let expectation = self.expectation(withDescription: "call login completion")
         let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
         implicitGrantBehavior.loginCompletion = { accessToken, error in
             XCTAssertNil(error)
@@ -364,16 +364,16 @@ class OAuthTests: XCTestCase {
         let result = implicitGrantBehavior.handleRedirectRequest(request)
         XCTAssertTrue(result)
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
     
     func testAuthorizationCodeGrantRedirect_shouldReturnTrue_forCorrectRedirectRequest() {
         redirectURI = Configuration.getCallbackURIString(.AuthorizationCode)
-        let request = NSURLRequest(URL: NSURL(string: redirectURI)!)
-        let loginCompletionExpectation = expectationWithDescription("call login completion")
-        let executeLoginExpectation = expectationWithDescription("execute login")
+        let request = URLRequest(url: URL(string: redirectURI)!)
+        let loginCompletionExpectation = self.expectation(withDescription: "call login completion")
+        let executeLoginExpectation = self.expectation(withDescription: "execute login")
         let authorizationCodeGrantAuthenticator = AuthorizationCodeGrantAuthenticatorMock(presentingViewController: UIViewController(), scopes: [.Profile], state: "state", expectation: executeLoginExpectation)
         authorizationCodeGrantAuthenticator.loginCompletion = { accessToken, error in
             XCTAssertNil(error)
@@ -383,25 +383,25 @@ class OAuthTests: XCTestCase {
         let result = authorizationCodeGrantAuthenticator.handleRedirectRequest(request)
         XCTAssertTrue(result)
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
     
     func testAuthorizationCodeGrantRedirect_shouldReturnTrue_forCorrectRedirectRequest_withErrorParameter() {
         redirectURI = Configuration.getCallbackURIString(.AuthorizationCode)
-        guard let urlComponents = NSURLComponents(string: redirectURI) else {
+        guard let urlComponents = URLComponents(string: redirectURI) else {
             XCTFail()
             return
         }
-        let errorQueryItem = NSURLQueryItem(name: "error", value: "server_error")
+        let errorQueryItem = URLQueryItem(name: "error", value: "server_error")
         urlComponents.queryItems = [errorQueryItem]
-        guard let requestURL = urlComponents.URL else {
+        guard let requestURL = urlComponents.url else {
             XCTFail()
             return
         }
-        let request = NSURLRequest(URL: requestURL)
-        let loginCompletionExpectation = expectationWithDescription("call login completion")
+        let request = URLRequest(url: requestURL)
+        let loginCompletionExpectation = self.expectation(withDescription: "call login completion")
         let authorizationCodeGrantAuthenticator = AuthorizationCodeGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
         authorizationCodeGrantAuthenticator.loginCompletion = { accessToken, error in
             if let error = error {
@@ -415,15 +415,15 @@ class OAuthTests: XCTestCase {
         let result = authorizationCodeGrantAuthenticator.handleRedirectRequest(request)
         XCTAssertTrue(result)
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
     
     func testImplicitGrantRedirect_shouldReturnError_forEmptyAccessToken() {
         redirectURI = Configuration.getCallbackURIString(.Implicit)
-        let request = NSURLRequest(URL: NSURL(string: "\(redirectURI)?error=mismatching_redirect_uri")!)
-        let expectation = expectationWithDescription("call login completion with error")
+        let request = URLRequest(url: URL(string: "\(redirectURI)?error=mismatching_redirect_uri")!)
+        let expectation = self.expectation(withDescription: "call login completion with error")
         let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
         implicitGrantBehavior.loginCompletion = { accessToken, error in
             XCTAssertNil(accessToken)
@@ -439,36 +439,36 @@ class OAuthTests: XCTestCase {
         let result = implicitGrantBehavior.handleRedirectRequest(request)
         XCTAssertTrue(result)
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
     
     func testImplicitGrantLogin_showsLogin() {
         redirectURI = Configuration.getCallbackURIString(.Implicit)
-        let expectation = expectationWithDescription("present login")
+        let expectation = self.expectation(withDescription: "present login")
     
         let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewControllerMock(expectation: expectation), scopes: [.Profile])
         implicitGrantBehavior.login()
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
     
     func testAuthorizationCodeGrantLogin_showsLogin() {
         redirectURI = Configuration.getCallbackURIString(.AuthorizationCode)
-        let expectation = expectationWithDescription("present login")
+        let expectation = self.expectation(withDescription: "present login")
         
         let implicitGrantBehavior = AuthorizationCodeGrantAuthenticator(presentingViewController: UIViewControllerMock(expectation: expectation), scopes: [.Profile], state: "state")
         implicitGrantBehavior.login()
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
     
-    func loginCompletion() -> ((accessToken: AccessToken?, error: NSError?) -> Void) {
+    func loginCompletion() -> ((_ accessToken: AccessToken?, _ error: NSError?) -> Void) {
         return { token, error in
             self.accessToken = token
             self.error = error
@@ -487,7 +487,7 @@ private class AuthorizationCodeGrantAuthenticatorMock: AuthorizationCodeGrantAut
         super.init(presentingViewController: presentingViewController, scopes: scopes, state: state)
     }
     
-    override func executeRedirect(request: NSURLRequest) {
+    override func executeRedirect(_ request: URLRequest) {
         self.expectation.fulfill()
     }
 }
@@ -504,18 +504,18 @@ private class UIViewControllerMock : UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func presentViewController(viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
         self.expectation.fulfill()
         return
     }
 }
 
-func tokenFixture(accessToken: String = "token") -> AccessToken?
+func tokenFixture(_ accessToken: String = "token") -> AccessToken?
 {
     var jsonDictionary = [String : AnyObject]()
     jsonDictionary["access_token"] = accessToken
-    jsonDictionary["refresh_token"] = "refresh"
-    jsonDictionary["expires_in"] = "10030.23"
-    jsonDictionary["scope"] = "profile history"
+    jsonDictionary["refresh_token"] = "refresh" as AnyObject?
+    jsonDictionary["expires_in"] = "10030.23" as AnyObject?
+    jsonDictionary["scope"] = "profile history" as AnyObject?
     return AccessToken(JSON: jsonDictionary)
 }

--- a/source/UberRidesTests/OauthEndpointTests.swift
+++ b/source/UberRidesTests/OauthEndpointTests.swift
@@ -34,7 +34,7 @@ class OauthEndpointTests: XCTestCase {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
     }
     
     override func tearDown() {

--- a/source/UberRidesTests/ObjectMappingTests.swift
+++ b/source/UberRidesTests/ObjectMappingTests.swift
@@ -43,10 +43,10 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping result of GET /v1/product/{product_id} endpoint.
      */
     func testGetProduct() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("getproductid", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding: NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "getproductid", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue)!
                 let product = ModelMapper<UberProduct>().mapFromJSON(JSONString)
                 XCTAssertNotNil(product)
                 XCTAssertEqual(product!.productID, "d4abaae7-f4d6-4152-91cc-77523e8165a4")
@@ -78,13 +78,13 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping of malformed result of GET /v1/products endpoint.
      */
     func testGetProductBadJSON() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("getproductid", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                var JSONString = NSString(data: jsonData, encoding: NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "getproductid", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                var JSONString = NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue)!
                 
                 // Represent some bad JSON
-                JSONString = JSONString.stringByReplacingOccurrencesOfString("[", withString: "")
+                JSONString = JSONString.replacingOccurrences(of: "[", with: "") as NSString
                 
                 let product = ModelMapper<UberProducts>().mapFromJSON(JSONString)
                 XCTAssertNil(product)
@@ -96,10 +96,10 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping result of GET /v1/products/{product_id} endpoint.
      */
     func testGetAllProducts() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("getproducts", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding: NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "getproducts", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue)!
                 let products = ModelMapper<UberProducts>().mapFromJSON(JSONString)
                 XCTAssertNotNil(products)
                 XCTAssertNotNil(products!.list)
@@ -117,13 +117,13 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping of malformed result of GET /v1/products endpoint.
      */
     func testGetAllProductsBadJSON() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("getproducts", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                var JSONString = NSString(data: jsonData, encoding: NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "getproducts", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                var JSONString = NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue)!
                 
                 // Represent some bad JSON
-                JSONString = JSONString.stringByReplacingOccurrencesOfString("[", withString: "")
+                JSONString = JSONString.replacingOccurrences(of: "[", with: "") as NSString
                 
                 let products = ModelMapper<UberProducts>().mapFromJSON(JSONString)
                 XCTAssertNil(products)
@@ -135,10 +135,10 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping result of GET /v1/estimates/time
      */
     func testGetTimeEstimates() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("gettimeestimates", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding: NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "gettimeestimates", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue)!
                 let timeEstimates = ModelMapper<TimeEstimates>().mapFromJSON(JSONString)
                 XCTAssertNotNil(timeEstimates)
                 XCTAssertNotNil(timeEstimates!.list)
@@ -159,13 +159,13 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping of malformed result of GET /v1/estimates/time
      */
     func testGetTimeEstimatesBadJSON() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("gettimeestimates", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                var JSONString = NSString(data: jsonData, encoding: NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "gettimeestimates", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                var JSONString = NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue)!
                 
                 // Represent some bad JSON
-                JSONString = JSONString.stringByReplacingOccurrencesOfString("[", withString: "")
+                JSONString = JSONString.replacingOccurrences(of: "[", with: "") as NSString
                 
                 let timeEstimates = ModelMapper<TimeEstimates>().mapFromJSON(JSONString)
                 XCTAssertNil(timeEstimates)
@@ -177,10 +177,10 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping result of GET /v1/estimates/price endpoint.
      */
     func testGetPriceEstimates() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("getpriceestimates", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding: NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "getpriceestimates", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue)!
                 let priceEstimates = ModelMapper<PriceEstimates>().mapFromJSON(JSONString)
                 XCTAssertNotNil(priceEstimates)
                 XCTAssertNotNil(priceEstimates!.list)
@@ -204,13 +204,13 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping of malformed result of GET /v1/estimates/price endpoint.
      */
     func testGetPriceEstimatesBadJSON() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("getpriceestimates", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                var JSONString = NSString(data: jsonData, encoding: NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "getpriceestimates", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                var JSONString = NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue)!
                 
                 // Represent some bad JSON
-                JSONString = JSONString.stringByReplacingOccurrencesOfString("[", withString: "")
+                JSONString = JSONString.replacingOccurrences(of: "[", with: "") as NSString
                 
                 let priceEstimates = ModelMapper<PriceEstimates>().mapFromJSON(JSONString)
                 XCTAssertNil(priceEstimates)
@@ -222,10 +222,10 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping result of GET /v1.2/history
      */
     func testGetTripHistory() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("gethistory", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding: NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "gethistory", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue)!
                 let userActivity = ModelMapper<TripHistory>().mapFromJSON(JSONString)
                 XCTAssertNotNil(userActivity)
                 XCTAssertNotNil(userActivity!.history)
@@ -237,9 +237,9 @@ class ObjectMappingTests: XCTestCase {
                 XCTAssertEqual(history.count, 1)
                 XCTAssertEqual(history[0].status, RideStatus.Completed)
                 XCTAssertEqual(history[0].distance, 1.64691465)
-                XCTAssertEqual(history[0].requestTime, NSDate(timeIntervalSince1970: 1428876188))
-                XCTAssertEqual(history[0].startTime, NSDate(timeIntervalSince1970: 1428876374))
-                XCTAssertEqual(history[0].endTime, NSDate(timeIntervalSince1970: 1428876927))
+                XCTAssertEqual(history[0].requestTime, Date(timeIntervalSince1970: 1428876188))
+                XCTAssertEqual(history[0].startTime, Date(timeIntervalSince1970: 1428876374))
+                XCTAssertEqual(history[0].endTime, Date(timeIntervalSince1970: 1428876927))
                 XCTAssertEqual(history[0].requestID, "37d57a99-2647-4114-9dd2-c43bccf4c30b")
                 XCTAssertEqual(history[0].productID, "a1111c8c-c720-46c3-8534-2fcdd730040d")
                 
@@ -257,13 +257,13 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping of malformed result of GET /v1.2/history endpoint.
      */
     func testGetHistoryBadJSON() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("gethistory", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                var JSONString = NSString(data: jsonData, encoding: NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "gethistory", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                var JSONString = NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue)!
                 
                 // Represent some bad JSON
-                JSONString = JSONString.stringByReplacingOccurrencesOfString("[", withString: "")
+                JSONString = JSONString.replacingOccurrences(of: "[", with: "") as NSString
                 
                 let userActivity = ModelMapper<TripHistory>().mapFromJSON(JSONString)
                 XCTAssertNil(userActivity)
@@ -275,10 +275,10 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping result of GET /v1/me endpoint.
      */
     func testGetUserProfile() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("getme", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding:  NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "getme", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding:  String.Encoding.utf8.rawValue)!
                 let userProfile = ModelMapper<UserProfile>().mapFromJSON(JSONString)
                 XCTAssertNotNil(userProfile)
                 XCTAssertEqual(userProfile!.firstName, "Uber")
@@ -295,11 +295,11 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping of malformed result of GET /v1/me endpoint.
      */
     func testGetUserProfileBadJSON() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("getme", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                var JSONString = NSString(data: jsonData, encoding: NSUTF8StringEncoding)!
-                JSONString = JSONString.stringByReplacingOccurrencesOfString("{", withString: "")
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "getme", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                var JSONString = NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue)!
+                JSONString = JSONString.replacingOccurrences(of: "{", with: "") as NSString
                 
                 let userProfile = ModelMapper<UserProfile>().mapFromJSON(JSONString)
                 XCTAssertNil(userProfile)
@@ -311,10 +311,10 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping result of POST /v1/requests
      */
     func testPostRequest() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("postrequests", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding:  NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "postrequests", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding:  String.Encoding.utf8.rawValue)!
                 guard let trip = ModelMapper<Ride>().mapFromJSON(JSONString) else {
                     XCTAssert(false)
                     return
@@ -336,10 +336,10 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping result of GET /v1/requests/current or /v1/requests/{request_id}
      */
     func testGetRequest() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("getrequest", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding:  NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "getrequest", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding:  String.Encoding.utf8.rawValue)!
                 guard let trip = ModelMapper<Ride>().mapFromJSON(JSONString) else {
                     XCTAssert(false)
                     return
@@ -384,10 +384,10 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping of POST /v1/requests/estimate endpoint.
      */
     func testGetRequestEstimate() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("requestestimate", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding:  NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "requestestimate", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding:  String.Encoding.utf8.rawValue)!
                 let estimate = ModelMapper<RideEstimate>().mapFromJSON(JSONString)
                 XCTAssertNotNil(estimate)
                 XCTAssertEqual(estimate!.pickupEstimate, 2)
@@ -405,10 +405,10 @@ class ObjectMappingTests: XCTestCase {
     }
     
     func testGetRequestEstimateNoCars() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("RequestEstimateNoCars", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding:  NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "RequestEstimateNoCars", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding:  String.Encoding.utf8.rawValue)!
                 let estimate = ModelMapper<RideEstimate>().mapFromJSON(JSONString)
                 XCTAssertNotNil(estimate)
                 XCTAssertEqual(estimate!.pickupEstimate, -1)
@@ -429,10 +429,10 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping of GET v1/places/{place_id} endpoint
      */
     func testGetPlace() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("place", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding:  NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "place", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding:  String.Encoding.utf8.rawValue)!
                 guard let place = ModelMapper<Place>().mapFromJSON(JSONString) else {
                     XCTAssert(false)
                     return
@@ -450,10 +450,10 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping of GET /v1/payment-methods endpoint.
      */
     func testGetPaymentMethods() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("getpaymentmethods", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding:  NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "getpaymentmethods", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding:  String.Encoding.utf8.rawValue)!
                 guard let paymentMethods = ModelMapper<PaymentMethods>().mapFromJSON(JSONString) else {
                     XCTAssert(false)
                     return
@@ -493,10 +493,10 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping of GET /v1/requests/{request_id}/receipt endpoint.
      */
     func testGetRideReceipt() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("ridereceipt", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding:  NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "ridereceipt", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding:  String.Encoding.utf8.rawValue)!
                 guard let receipt = ModelMapper<RideReceipt>().mapFromJSON(JSONString) else {
                     XCTAssert(false)
                     return
@@ -562,10 +562,10 @@ class ObjectMappingTests: XCTestCase {
     }
     
     func testGetRideReceipt_withNullSurge_withTotalOwed() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("RideReceiptNullSurgeTotalOwed", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding:  NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "RideReceiptNullSurgeTotalOwed", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding:  String.Encoding.utf8.rawValue)!
                 guard let receipt = ModelMapper<RideReceipt>().mapFromJSON(JSONString) else {
                     XCTAssert(false)
                     return
@@ -627,11 +627,11 @@ class ObjectMappingTests: XCTestCase {
      Test bad JSON for GET /v1/reqeuests/{request_id}/receipt
      */
     func testGetRideReceiptBadJSON() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("ridereceipt", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                var JSONString = NSString(data: jsonData, encoding:  NSUTF8StringEncoding)!
-                JSONString = JSONString.stringByReplacingOccurrencesOfString("[", withString: "")
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "ridereceipt", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                var JSONString = NSString(data: jsonData, encoding:  String.Encoding.utf8.rawValue)!
+                JSONString = JSONString.replacingOccurrences(of: "[", with: "") as NSString
                 let receipt = ModelMapper<RideReceipt>().mapFromJSON(JSONString)
                 XCTAssertNil(receipt)
                 return
@@ -645,10 +645,10 @@ class ObjectMappingTests: XCTestCase {
      Tests mapping of GET /v1/requests/{request_id}/map endpoint.
      */
     func testGetRideMap() {
-        let bundle = NSBundle(forClass: ObjectMappingTests.self)
-        if let path = bundle.pathForResource("ridemap", ofType: "json") {
-            if let jsonData = NSData(contentsOfFile: path) {
-                let JSONString = NSString(data: jsonData, encoding:  NSUTF8StringEncoding)!
+        let bundle = Bundle(for: ObjectMappingTests.self)
+        if let path = bundle.path(forResource: "ridemap", ofType: "json") {
+            if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                let JSONString = NSString(data: jsonData, encoding:  String.Encoding.utf8.rawValue)!
                 guard let map = ModelMapper<RideMap>().mapFromJSON(JSONString) else {
                     XCTAssert(false)
                     return

--- a/source/UberRidesTests/RefreshEndpointTests.swift
+++ b/source/UberRidesTests/RefreshEndpointTests.swift
@@ -28,14 +28,14 @@ import OHHTTPStubs
 
 class RefreshEndpointTests: XCTestCase {
     var client: RidesClient!
-    var headers: [NSObject: AnyObject]!
+    var headers: [AnyHashable: Any]!
     let timeout: Double = 1
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setSandboxEnabled(true)
         headers = ["Content-Type": "application/json"]
         client = RidesClient()
@@ -52,11 +52,11 @@ class RefreshEndpointTests: XCTestCase {
      */
     func test200Response() {
         stub(isHost("login.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("refresh.json", self.dynamicType)!, statusCode:200, headers:self.headers)
+            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("refresh.json", type(of: self))!, statusCode:200, headers:self.headers)
         }
         let refreshToken = "ThisIsRefresh"
         let clientID = Configuration.getClientID()
-        let expectation = expectationWithDescription("200 success response")
+        let expectation = self.expectation(description: "200 success response")
         let endpoint = OAuth.Refresh(clientID: clientID, refreshToken: refreshToken)
         let request = Request(session: client.session, endpoint: endpoint)
 
@@ -69,15 +69,15 @@ class RefreshEndpointTests: XCTestCase {
 
         XCTAssertEqual(request.urlRequest.HTTPMethod, "POST")
 
-        guard let bodyData = request.urlRequest.HTTPBody, dataString = String(data: bodyData, encoding: NSUTF8StringEncoding) else {
+        guard let bodyData = request.urlRequest.HTTPBody, let dataString = String(data: bodyData, encoding: String.Encoding.utf8) else {
             XCTFail("Missing HTTP Body!")
             return
         }
-        let components = NSURLComponents()
+        let components = URLComponents()
         components.query = dataString
 
-        let expectedClientID = NSURLQueryItem(name: "client_id", value: clientID)
-        let expectedRefreshToken = NSURLQueryItem(name: "refresh_token", value: refreshToken)
+        let expectedClientID = URLQueryItem(name: "client_id", value: clientID)
+        let expectedRefreshToken = URLQueryItem(name: "refresh_token", value: refreshToken)
 
         guard let queryItems = components.queryItems else {
             XCTFail("Invalid HTTP Body!")
@@ -89,7 +89,7 @@ class RefreshEndpointTests: XCTestCase {
 
 
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -109,7 +109,7 @@ class RefreshEndpointTests: XCTestCase {
         }
         
         let refreshToken = "ThisIsRefresh"
-        let expectation = expectationWithDescription("400 error response")
+        let expectation = self.expectation(description: "400 error response")
         let endpoint = OAuth.Refresh(clientID: clientID, refreshToken: refreshToken)
         let request = Request(session: client.session, endpoint: endpoint)
         request.execute({ response in
@@ -119,7 +119,7 @@ class RefreshEndpointTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -133,10 +133,10 @@ class RefreshEndpointTests: XCTestCase {
     func test200Response_inChina() {
         Configuration.setRegion(.China)
         stub(isHost("login.uber.com.cn")) { _ in
-            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("refresh.json", self.dynamicType)!, statusCode:200, headers:self.headers)
+            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("refresh.json", type(of: self))!, statusCode:200, headers:self.headers)
         }
         let refreshToken = "ThisIsRefresh"
-        let expectation = expectationWithDescription("200 success response")
+        let expectation = self.expectation(description: "200 success response")
         let endpoint = OAuth.Refresh(clientID: clientID, refreshToken: refreshToken)
         let request = Request(session: client.session, endpoint: endpoint)
         request.execute({ response in
@@ -146,7 +146,7 @@ class RefreshEndpointTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -167,7 +167,7 @@ class RefreshEndpointTests: XCTestCase {
         }
         
         let refreshToken = "ThisIsRefresh"
-        let expectation = expectationWithDescription("400 error response")
+        let expectation = self.expectation(description: "400 error response")
         let endpoint = OAuth.Refresh(clientID: clientID, refreshToken: refreshToken)
         let request = Request(session: client.session, endpoint: endpoint)
         request.execute({ response in
@@ -177,7 +177,7 @@ class RefreshEndpointTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }

--- a/source/UberRidesTests/RequestDeeplinkTests.swift
+++ b/source/UberRidesTests/RequestDeeplinkTests.swift
@@ -59,19 +59,19 @@ struct ExpectedDeeplink {
 }
 
 class UberRidesDeeplinkTests: XCTestCase {
-    private var versionNumber: String?
-    private var expectedDeeplinkUserAgent: String?
-    private var expectedButtonUserAgent: String?
+    fileprivate var versionNumber: String?
+    fileprivate var expectedDeeplinkUserAgent: String?
+    fileprivate var expectedButtonUserAgent: String?
     let timeout: Double = 2
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setClientID(clientID)
         Configuration.setSandboxEnabled(true)
-        versionNumber = NSBundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
+        versionNumber = Bundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
         expectedDeeplinkUserAgent = "rides-ios-v\(versionNumber!)-deeplink"
         expectedButtonUserAgent = "rides-ios-v\(versionNumber!)-button"
     }
@@ -90,7 +90,7 @@ class UberRidesDeeplinkTests: XCTestCase {
         
         XCTAssertTrue(uri.containsString(ExpectedDeeplink.uberScheme))
         
-        let components = NSURLComponents(string: uri)
+        let components = URLComponents(string: uri)
         XCTAssertEqual(components?.queryItems?.count, 4)
         
         let query = components?.query
@@ -108,7 +108,7 @@ class UberRidesDeeplinkTests: XCTestCase {
         let rideParams = RideParametersBuilder().setPickupLocation(location).build()
         let deeplink = RequestDeeplink(rideParameters: rideParams)
         
-        let components = NSURLComponents(URL: deeplink.deeplinkURL, resolvingAgainstBaseURL: false)
+        let components = URLComponents(URL: deeplink.deeplinkURL, resolvingAgainstBaseURL: false)
         XCTAssertEqual(components?.queryItems?.count, 5)
         
         let query = components?.query
@@ -127,7 +127,7 @@ class UberRidesDeeplinkTests: XCTestCase {
         let rideParams = RideParametersBuilder().setPickupLocation(location, nickname: pickupNickname, address: pickupAddress).build()
         let deeplink = RequestDeeplink(rideParameters: rideParams)
         
-        let components = NSURLComponents(URL: deeplink.deeplinkURL, resolvingAgainstBaseURL: false)
+        let components = URLComponents(URL: deeplink.deeplinkURL, resolvingAgainstBaseURL: false)
         XCTAssertEqual(components?.queryItems?.count, 7)
         
         let query = components?.query
@@ -148,7 +148,7 @@ class UberRidesDeeplinkTests: XCTestCase {
         let rideParams = RideParametersBuilder().setDropoffLocation(location).build()
         let deeplink = RequestDeeplink(rideParameters: rideParams)
         
-        let components = NSURLComponents(URL: deeplink.deeplinkURL, resolvingAgainstBaseURL: false)
+        let components = URLComponents(URL: deeplink.deeplinkURL, resolvingAgainstBaseURL: false)
         XCTAssertEqual(components?.queryItems?.count, 6)
         
         let query = components?.query
@@ -170,7 +170,7 @@ class UberRidesDeeplinkTests: XCTestCase {
             .setDropoffLocation(dropoffLocation, nickname: dropoffNickname, address: dropoffAddress).build()
         let deeplink = RequestDeeplink(rideParameters: rideParams)
         
-        let components = NSURLComponents(URL: deeplink.deeplinkURL, resolvingAgainstBaseURL: false)
+        let components = URLComponents(URL: deeplink.deeplinkURL, resolvingAgainstBaseURL: false)
         XCTAssertEqual(components?.queryItems?.count, 12)
         
         let query = components?.query
@@ -189,10 +189,10 @@ class UberRidesDeeplinkTests: XCTestCase {
     }
     
     func testDeeplinkDefaultSource() {
-        let expectation = expectationWithDescription("Test Deeplink source parameter")
-        let expectationClosure: (NSURL?) -> (Bool) = { url in
+        let expectation = self.expectation(description: "Test Deeplink source parameter")
+        let expectationClosure: (URL?) -> (Bool) = { url in
             expectation.fulfill()
-            guard let url = url, let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false), let items = components.queryItems else {
+            guard let url = url, let components = URLComponents(url: url, resolvingAgainstBaseURL: false), let items = components.queryItems else {
                 XCTAssert(false)
                 return false
             }
@@ -215,7 +215,7 @@ class UberRidesDeeplinkTests: XCTestCase {
         
         deeplink.execute()
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }

--- a/source/UberRidesTests/RequestLayerTests.swift
+++ b/source/UberRidesTests/RequestLayerTests.swift
@@ -28,14 +28,14 @@ import OHHTTPStubs
 
 class RequestLayerTests: XCTestCase {
     var client: RidesClient!
-    var headers: [NSObject: AnyObject]!
+    var headers: [AnyHashable: Any]!
     let timeout: Double = 10
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setSandboxEnabled(true)
         headers = ["Content-Type": "application/json"]
         client = RidesClient()
@@ -52,10 +52,10 @@ class RequestLayerTests: XCTestCase {
      */
     func test200Response() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("getproductid.json", self.dynamicType)!, statusCode:200, headers:self.headers)
+            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("getproductid.json", type(of: self))!, statusCode:200, headers:self.headers)
         }
         
-        let expectation = expectationWithDescription("200 success response")
+        let expectation = self.expectation(description: "200 success response")
         let endpoint = Products.GetProduct(productID: productID)
         let request = Request(session: client.session, endpoint: endpoint)
         request.execute({ response in
@@ -65,7 +65,7 @@ class RequestLayerTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -85,7 +85,7 @@ class RequestLayerTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: json, statusCode: 401, headers: self.headers)
         }
         
-        let expectation = expectationWithDescription("401 error response")
+        let expectation = self.expectation(description: "401 error response")
         let endpoint = Products.GetProduct(productID: productID)
         let request = Request(session: client.session, endpoint: endpoint)
         request.execute({ response in
@@ -99,7 +99,7 @@ class RequestLayerTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -116,7 +116,7 @@ class RequestLayerTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: json, statusCode: 409, headers: self.headers)
         }
         
-        let expectation = expectationWithDescription("409 error response")
+        let expectation = self.expectation(description: "409 error response")
         let endpoint = Products.GetProduct(productID: productID)
         let request = Request(session: client.session, endpoint: endpoint)
         request.execute({ response in
@@ -132,7 +132,7 @@ class RequestLayerTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -153,7 +153,7 @@ class RequestLayerTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: json, statusCode: 422, headers: self.headers)
         }
         
-        let expectation = expectationWithDescription("422 error response")
+        let expectation = self.expectation(description: "422 error response")
         let endpoint = Products.GetProduct(productID: productID)
         let request = Request(session: client.session, endpoint: endpoint)
         request.execute({ response in
@@ -171,7 +171,7 @@ class RequestLayerTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -192,7 +192,7 @@ class RequestLayerTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: json, statusCode: 422, headers: self.headers)
         }
         
-        let expectation = expectationWithDescription("422 error response")
+        let expectation = self.expectation(description: "422 error response")
         let endpoint = Products.GetProduct(productID: productID)
         let request = Request(session: client.session, endpoint: endpoint)
         request.execute({ response in
@@ -212,7 +212,7 @@ class RequestLayerTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -232,7 +232,7 @@ class RequestLayerTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: json, statusCode: 409, headers: self.headers)
         }
         
-        let expectation = expectationWithDescription("422 error response")
+        let expectation = self.expectation(description: "422 error response")
         let endpoint = Products.GetProduct(productID: productID)
         let request = Request(session: client.session, endpoint: endpoint)
         request.execute({ response in
@@ -250,7 +250,7 @@ class RequestLayerTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -270,7 +270,7 @@ class RequestLayerTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: json, statusCode: 500, headers: self.headers)
         }
         
-        let expectation = expectationWithDescription("500 error response")
+        let expectation = self.expectation(description: "500 error response")
         let endpoint = Products.GetProduct(productID: productID)
         let request = Request(session: client.session, endpoint: endpoint)
         request.execute({ response in
@@ -284,7 +284,7 @@ class RequestLayerTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -304,7 +304,7 @@ class RequestLayerTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: json, statusCode: 503, headers: self.headers)
         }
         
-        let expectation = expectationWithDescription("503 error response")
+        let expectation = self.expectation(description: "503 error response")
         let endpoint = Products.GetProduct(productID: productID)
         let request = Request(session: client.session, endpoint: endpoint)
         request.execute({ response in
@@ -318,7 +318,7 @@ class RequestLayerTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -335,7 +335,7 @@ class RequestLayerTests: XCTestCase {
             return OHHTTPStubsResponse(error:notConnectedError)
         }
         
-        let expectation = expectationWithDescription("No network error response")
+        let expectation = self.expectation(description: "No network error response")
         let endpoint = Products.GetProduct(productID: productID)
         let request = Request(session: client.session, endpoint: endpoint)
         request.execute({ response in
@@ -349,7 +349,7 @@ class RequestLayerTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }

--- a/source/UberRidesTests/RequestURLUtilTests.swift
+++ b/source/UberRidesTests/RequestURLUtilTests.swift
@@ -27,15 +27,15 @@ import CoreLocation
 
 class RequestURLUtilTests: XCTestCase {
     
-    private var versionNumber: String?
-    private var baseUserAgent: String?
+    fileprivate var versionNumber: String?
+    fileprivate var baseUserAgent: String?
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
-        versionNumber = NSBundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
+        Configuration.bundle = Bundle(forClass: type(of: self))
+        versionNumber = Bundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
         baseUserAgent = "rides-ios-v\(versionNumber!)"
     }
     
@@ -46,10 +46,10 @@ class RequestURLUtilTests: XCTestCase {
     
     func testCreateQueryParameters_withDefaultRideParameters() {
         let parameters = RideParametersBuilder().build()
-        let locationQueryItem = NSURLQueryItem(name: "pickup", value: "my_location")
-        let actionQueryItem = NSURLQueryItem(name: "action", value: "setPickup")
-        let clientIdQueryItem = NSURLQueryItem(name: "client_id", value: "testClientID")
-        let userAgentQueryItem = NSURLQueryItem(name: "user-agent", value: baseUserAgent)
+        let locationQueryItem = URLQueryItem(name: "pickup", value: "my_location")
+        let actionQueryItem = URLQueryItem(name: "action", value: "setPickup")
+        let clientIdQueryItem = URLQueryItem(name: "client_id", value: "testClientID")
+        let userAgentQueryItem = URLQueryItem(name: "user-agent", value: baseUserAgent)
         let expectedQueryParameters = [clientIdQueryItem, actionQueryItem, locationQueryItem, userAgentQueryItem]
         let comparisonSet = NSSet(array: expectedQueryParameters)
         
@@ -71,20 +71,20 @@ class RequestURLUtilTests: XCTestCase {
         let testSource = "test source"
         let expectedUserAgent = "\(baseUserAgent!)-\(testSource)"
         
-        let pickupLatitudeQueryItem = NSURLQueryItem(name: "pickup[latitude]", value: "\(testPickupLocation.coordinate.latitude)")
-        let pickupLongitudeQueryItem = NSURLQueryItem(name: "pickup[longitude]", value: "\(testPickupLocation.coordinate.longitude)")
-        let pickupNicknameQueryItem = NSURLQueryItem(name: "pickup[nickname]", value: testPickupNickname)
-        let pickupAddressQueryItem = NSURLQueryItem(name: "pickup[formatted_address]", value: testPickupAddress)
+        let pickupLatitudeQueryItem = URLQueryItem(name: "pickup[latitude]", value: "\(testPickupLocation.coordinate.latitude)")
+        let pickupLongitudeQueryItem = URLQueryItem(name: "pickup[longitude]", value: "\(testPickupLocation.coordinate.longitude)")
+        let pickupNicknameQueryItem = URLQueryItem(name: "pickup[nickname]", value: testPickupNickname)
+        let pickupAddressQueryItem = URLQueryItem(name: "pickup[formatted_address]", value: testPickupAddress)
         
-        let dropoffLatitudeQueryItem = NSURLQueryItem(name: "dropoff[latitude]", value: "\(testDropoffLocation.coordinate.latitude)")
-        let dropoffLongitudeQueryItem = NSURLQueryItem(name: "dropoff[longitude]", value: "\(testDropoffLocation.coordinate.longitude)")
-        let dropoffNicknameQueryItem = NSURLQueryItem(name: "dropoff[nickname]", value: testDropoffNickname)
-        let dropoffAddressQueryItem = NSURLQueryItem(name: "dropoff[formatted_address]", value: testDropoffAddress)
+        let dropoffLatitudeQueryItem = URLQueryItem(name: "dropoff[latitude]", value: "\(testDropoffLocation.coordinate.latitude)")
+        let dropoffLongitudeQueryItem = URLQueryItem(name: "dropoff[longitude]", value: "\(testDropoffLocation.coordinate.longitude)")
+        let dropoffNicknameQueryItem = URLQueryItem(name: "dropoff[nickname]", value: testDropoffNickname)
+        let dropoffAddressQueryItem = URLQueryItem(name: "dropoff[formatted_address]", value: testDropoffAddress)
         
-        let productIdQueryItem = NSURLQueryItem(name: "product_id", value: testProductID)
-        let clientIdQueryItem = NSURLQueryItem(name: "client_id", value: "testClientID")
-        let userAgentQueryItem = NSURLQueryItem(name: "user-agent", value: expectedUserAgent)
-        let actionQueryItem = NSURLQueryItem(name: "action", value: "setPickup")
+        let productIdQueryItem = URLQueryItem(name: "product_id", value: testProductID)
+        let clientIdQueryItem = URLQueryItem(name: "client_id", value: "testClientID")
+        let userAgentQueryItem = URLQueryItem(name: "user-agent", value: expectedUserAgent)
+        let actionQueryItem = URLQueryItem(name: "action", value: "setPickup")
         
         let expectedQueryParameters = [pickupLatitudeQueryItem, pickupLongitudeQueryItem, pickupNicknameQueryItem, pickupAddressQueryItem,
                                        dropoffLatitudeQueryItem, dropoffLongitudeQueryItem, dropoffNicknameQueryItem, dropoffAddressQueryItem,
@@ -114,18 +114,18 @@ class RequestURLUtilTests: XCTestCase {
         let testSource = "test source"
         let expectedUserAgent = "\(baseUserAgent!)-\(testSource)"
         
-        let pickupLatitudeQueryItem = NSURLQueryItem(name: "pickup[latitude]", value: "\(testPickupLocation.coordinate.latitude)")
-        let pickupLongitudeQueryItem = NSURLQueryItem(name: "pickup[longitude]", value: "\(testPickupLocation.coordinate.longitude)")
-        let pickupAddressQueryItem = NSURLQueryItem(name: "pickup[formatted_address]", value: testPickupAddress)
+        let pickupLatitudeQueryItem = URLQueryItem(name: "pickup[latitude]", value: "\(testPickupLocation.coordinate.latitude)")
+        let pickupLongitudeQueryItem = URLQueryItem(name: "pickup[longitude]", value: "\(testPickupLocation.coordinate.longitude)")
+        let pickupAddressQueryItem = URLQueryItem(name: "pickup[formatted_address]", value: testPickupAddress)
         
-        let dropoffLatitudeQueryItem = NSURLQueryItem(name: "dropoff[latitude]", value: "\(testDropoffLocation.coordinate.latitude)")
-        let dropoffLongitudeQueryItem = NSURLQueryItem(name: "dropoff[longitude]", value: "\(testDropoffLocation.coordinate.longitude)")
-        let dropoffAddressQueryItem = NSURLQueryItem(name: "dropoff[formatted_address]", value: testDropoffAddress)
+        let dropoffLatitudeQueryItem = URLQueryItem(name: "dropoff[latitude]", value: "\(testDropoffLocation.coordinate.latitude)")
+        let dropoffLongitudeQueryItem = URLQueryItem(name: "dropoff[longitude]", value: "\(testDropoffLocation.coordinate.longitude)")
+        let dropoffAddressQueryItem = URLQueryItem(name: "dropoff[formatted_address]", value: testDropoffAddress)
         
-        let productIdQueryItem = NSURLQueryItem(name: "product_id", value: testProductID)
-        let clientIdQueryItem = NSURLQueryItem(name: "client_id", value: "testClientID")
-        let userAgentQueryItem = NSURLQueryItem(name: "user-agent", value: expectedUserAgent)
-        let actionQueryItem = NSURLQueryItem(name: "action", value: "setPickup")
+        let productIdQueryItem = URLQueryItem(name: "product_id", value: testProductID)
+        let clientIdQueryItem = URLQueryItem(name: "client_id", value: "testClientID")
+        let userAgentQueryItem = URLQueryItem(name: "user-agent", value: expectedUserAgent)
+        let actionQueryItem = URLQueryItem(name: "action", value: "setPickup")
         
         let expectedQueryParameters = [pickupLatitudeQueryItem, pickupLongitudeQueryItem, pickupAddressQueryItem,
                                        dropoffLatitudeQueryItem, dropoffLongitudeQueryItem, dropoffAddressQueryItem,
@@ -155,18 +155,18 @@ class RequestURLUtilTests: XCTestCase {
         let testSource = "test source"
         let expectedUserAgent = "\(baseUserAgent!)-\(testSource)"
         
-        let pickupLatitudeQueryItem = NSURLQueryItem(name: "pickup[latitude]", value: "\(testPickupLocation.coordinate.latitude)")
-        let pickupLongitudeQueryItem = NSURLQueryItem(name: "pickup[longitude]", value: "\(testPickupLocation.coordinate.longitude)")
-        let pickupNicknameQueryItem = NSURLQueryItem(name: "pickup[nickname]", value: testPickupNickname)
+        let pickupLatitudeQueryItem = URLQueryItem(name: "pickup[latitude]", value: "\(testPickupLocation.coordinate.latitude)")
+        let pickupLongitudeQueryItem = URLQueryItem(name: "pickup[longitude]", value: "\(testPickupLocation.coordinate.longitude)")
+        let pickupNicknameQueryItem = URLQueryItem(name: "pickup[nickname]", value: testPickupNickname)
         
-        let dropoffLatitudeQueryItem = NSURLQueryItem(name: "dropoff[latitude]", value: "\(testDropoffLocation.coordinate.latitude)")
-        let dropoffLongitudeQueryItem = NSURLQueryItem(name: "dropoff[longitude]", value: "\(testDropoffLocation.coordinate.longitude)")
-        let dropoffNicknameQueryItem = NSURLQueryItem(name: "dropoff[nickname]", value: testDropoffNickname)
+        let dropoffLatitudeQueryItem = URLQueryItem(name: "dropoff[latitude]", value: "\(testDropoffLocation.coordinate.latitude)")
+        let dropoffLongitudeQueryItem = URLQueryItem(name: "dropoff[longitude]", value: "\(testDropoffLocation.coordinate.longitude)")
+        let dropoffNicknameQueryItem = URLQueryItem(name: "dropoff[nickname]", value: testDropoffNickname)
         
-        let productIdQueryItem = NSURLQueryItem(name: "product_id", value: testProductID)
-        let clientIdQueryItem = NSURLQueryItem(name: "client_id", value: "testClientID")
-        let userAgentQueryItem = NSURLQueryItem(name: "user-agent", value: expectedUserAgent)
-        let actionQueryItem = NSURLQueryItem(name: "action", value: "setPickup")
+        let productIdQueryItem = URLQueryItem(name: "product_id", value: testProductID)
+        let clientIdQueryItem = URLQueryItem(name: "client_id", value: "testClientID")
+        let userAgentQueryItem = URLQueryItem(name: "user-agent", value: expectedUserAgent)
+        let actionQueryItem = URLQueryItem(name: "action", value: "setPickup")
         
         let expectedQueryParameters = [pickupLatitudeQueryItem, pickupLongitudeQueryItem, pickupNicknameQueryItem,
                                        dropoffLatitudeQueryItem, dropoffLongitudeQueryItem, dropoffNicknameQueryItem,
@@ -195,15 +195,15 @@ class RequestURLUtilTests: XCTestCase {
         let testSource = "test source"
         let expectedUserAgent = "\(baseUserAgent!)-\(testSource)"
         
-        let pickupLatitudeQueryItem = NSURLQueryItem(name: "pickup[latitude]", value: "\(testPickupLocation.coordinate.latitude)")
-        let pickupLongitudeQueryItem = NSURLQueryItem(name: "pickup[longitude]", value: "\(testPickupLocation.coordinate.longitude)")
-        let pickupNicknameQueryItem = NSURLQueryItem(name: "pickup[nickname]", value: testPickupNickname)
-        let pickupAddressQueryItem = NSURLQueryItem(name: "pickup[formatted_address]", value: testPickupAddress)
+        let pickupLatitudeQueryItem = URLQueryItem(name: "pickup[latitude]", value: "\(testPickupLocation.coordinate.latitude)")
+        let pickupLongitudeQueryItem = URLQueryItem(name: "pickup[longitude]", value: "\(testPickupLocation.coordinate.longitude)")
+        let pickupNicknameQueryItem = URLQueryItem(name: "pickup[nickname]", value: testPickupNickname)
+        let pickupAddressQueryItem = URLQueryItem(name: "pickup[formatted_address]", value: testPickupAddress)
         
-        let productIdQueryItem = NSURLQueryItem(name: "product_id", value: testProductID)
-        let clientIdQueryItem = NSURLQueryItem(name: "client_id", value: "testClientID")
-        let userAgentQueryItem = NSURLQueryItem(name: "user-agent", value: expectedUserAgent)
-        let actionQueryItem = NSURLQueryItem(name: "action", value: "setPickup")
+        let productIdQueryItem = URLQueryItem(name: "product_id", value: testProductID)
+        let clientIdQueryItem = URLQueryItem(name: "client_id", value: "testClientID")
+        let userAgentQueryItem = URLQueryItem(name: "user-agent", value: expectedUserAgent)
+        let actionQueryItem = URLQueryItem(name: "action", value: "setPickup")
         
         let expectedQueryParameters = [pickupLatitudeQueryItem, pickupLongitudeQueryItem, pickupNicknameQueryItem, pickupAddressQueryItem,
                                        productIdQueryItem, clientIdQueryItem, userAgentQueryItem, actionQueryItem]

--- a/source/UberRidesTests/RideParametersTest.swift
+++ b/source/UberRidesTests/RideParametersTest.swift
@@ -25,15 +25,15 @@ import MapKit
 @testable import UberRides
 
 class RideParametersTest: XCTestCase {
-    private var versionNumber: String?
-    private var baseUserAgent: String?
+    fileprivate var versionNumber: String?
+    fileprivate var baseUserAgent: String?
     
-    private var builder: RideParametersBuilder = RideParametersBuilder()
+    fileprivate var builder: RideParametersBuilder = RideParametersBuilder()
     
     override func setUp() {
         super.setUp()
         builder = RideParametersBuilder()
-        versionNumber = NSBundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
+        versionNumber = Bundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
         baseUserAgent = "rides-ios-v\(versionNumber!)"
     }
     

--- a/source/UberRidesTests/RideRequestViewControllerTests.swift
+++ b/source/UberRidesTests/RideRequestViewControllerTests.swift
@@ -26,13 +26,13 @@ import WebKit
 @testable import UberRides
 
 class RideRequestViewControllerTests: XCTestCase {
-    private let timeout: Double = 2
+    fileprivate let timeout: Double = 2
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setSandboxEnabled(true)
     }
     
@@ -345,9 +345,9 @@ class RideRequestViewControllerTests: XCTestCase {
     func testRequestUsesCorrectSource_whenPresented() {
         var expectation = false
         
-        let expectationClosure: (NSURLRequest) -> () = { request in
+        let expectationClosure: (URLRequest) -> () = { request in
             expectation = true
-            guard let url = request.URL, let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false), let items = components.queryItems else {
+            guard let url = request.url, let components = URLComponents(url: url, resolvingAgainstBaseURL: false), let items = components.queryItems else {
                 XCTAssert(false)
                 return
             }
@@ -375,7 +375,7 @@ class RideRequestViewControllerTests: XCTestCase {
         let rideRequestVC = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
         XCTAssertNotNil(rideRequestVC.view)
         
-        let webViewMock = WebViewMock(frame: CGRectZero, configuration: WKWebViewConfiguration(), testClosure: expectationClosure)
+        let webViewMock = WebViewMock(frame: CGRect.zero, configuration: WKWebViewConfiguration(), testClosure: expectationClosure)
         rideRequestVC.rideRequestView.webView = webViewMock
         
         rideRequestVC.load()
@@ -431,7 +431,7 @@ class RideRequestViewControllerTests: XCTestCase {
         
         let presentViewControllerClosure: ((UIViewController, Bool, (() -> Void)?) -> ()) = { (viewController, flag, completion) in
             expectation = true
-            XCTAssertTrue(viewController.dynamicType == UIAlertController.self)
+            XCTAssertTrue(type(of: viewController) == UIAlertController.self)
         }
         let testIdentifier = "testAccessTokenIdentifier"
         let testToken = AccessToken(JSON: ["access_token" : "testTokenString"])
@@ -485,7 +485,7 @@ class RideRequestViewControllerTests: XCTestCase {
         
         let presentViewControllerClosure: ((UIViewController, Bool, (() -> Void)?) -> ()) = { (viewController, flag, completion) in
             expectation = true
-            XCTAssertTrue(viewController.dynamicType == UIAlertController.self)
+            XCTAssertTrue(type(of: viewController) == UIAlertController.self)
         }
         
         let testIdentifier = "testAccessTokenIdentifier"

--- a/source/UberRidesTests/RideRequestViewRequestingBehaviorTests.swift
+++ b/source/UberRidesTests/RideRequestViewRequestingBehaviorTests.swift
@@ -30,7 +30,7 @@ class RideRequestViewRequestingBehaviorTests : XCTestCase {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setSandboxEnabled(true)
     }
     
@@ -54,7 +54,7 @@ class RideRequestViewRequestingBehaviorTests : XCTestCase {
     
     func testRideParametersUpdated() {
         class UIViewControllerMock : UIViewController {
-            override func presentViewController(viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
+            override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
                 return
             }
         }
@@ -73,7 +73,7 @@ class RideRequestViewRequestingBehaviorTests : XCTestCase {
     func testPresentModal() {
         class UIViewControllerMock : UIViewController {
             let testClosure: (UIViewController) -> ()
-            private init(testClosure: (UIViewController) -> ()) {
+            fileprivate init(testClosure: @escaping (UIViewController) -> ()) {
                 self.testClosure = testClosure
                 super.init(nibName: nil, bundle: nil)
             }
@@ -82,13 +82,13 @@ class RideRequestViewRequestingBehaviorTests : XCTestCase {
                 fatalError("init(coder:) has not been implemented")
             }
             
-            override func presentViewController(viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
+            override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
                 self.testClosure(viewControllerToPresent)
                 return
             }
         }
         
-        let expectation = expectationWithDescription("ModalRideViewController is presented")
+        let expectation = self.expectation(description: "ModalRideViewController is presented")
         let expectationClosure: (UIViewController) -> () = { viewController in
             XCTAssertTrue(viewController.isKindOfClass(ModalRideRequestViewController))
             expectation.fulfill()
@@ -98,7 +98,7 @@ class RideRequestViewRequestingBehaviorTests : XCTestCase {
         let initialLoginManger = LoginManager(loginType: .Native)
         let behavior = RideRequestViewRequestingBehavior(presentingViewController: baseVC, loginManager: initialLoginManger)
         behavior.requestRide(RideParametersBuilder().build())
-        waitForExpectationsWithTimeout(2.0) {error in
+        waitForExpectations(timeout: 2.0) {error in
             XCTAssertNil(error)
         }
     }

--- a/source/UberRidesTests/RidesAppDelegateTests.swift
+++ b/source/UberRidesTests/RidesAppDelegateTests.swift
@@ -26,18 +26,18 @@ import CoreLocation
 
 class RidesAppDelegateTests : XCTestCase {
     
-    private var versionNumber: String?
-    private var expectedDeeplinkUserAgent: String?
-    private var expectedButtonUserAgent: String?
+    fileprivate var versionNumber: String?
+    fileprivate var expectedDeeplinkUserAgent: String?
+    fileprivate var expectedButtonUserAgent: String?
     
     override func setUp() {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setClientID(clientID)
         Configuration.setSandboxEnabled(true)
-        versionNumber = NSBundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
+        versionNumber = Bundle(forClass: RideParameters.self).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
         expectedDeeplinkUserAgent = "rides-ios-v\(versionNumber!)-deeplink"
         expectedButtonUserAgent = "rides-ios-v\(versionNumber!)-button"
     }
@@ -51,8 +51,8 @@ class RidesAppDelegateTests : XCTestCase {
     func testOpenUrlReturnsFalse_whenNoLoginManager() {
         let appDelegate = RidesAppDelegate.sharedInstance
         
-        let testApp = UIApplication.sharedApplication()
-        guard let url = NSURL(string: "http://www.google.com") else {
+        let testApp = UIApplication.shared
+        guard let url = URL(string: "http://www.google.com") else {
             XCTFail()
             return
         }
@@ -61,18 +61,18 @@ class RidesAppDelegateTests : XCTestCase {
     }
     
     func testOpenUrlReturnsTrue_callsOpenURLOnLoginManager() {
-        let expectation = expectationWithDescription("open URL called")
+        let expectation = self.expectation(description: "open URL called")
         let appDelegate = RidesAppDelegate.sharedInstance
         let loginManagerMock = LoginManagingProtocolMock()
-        let testApp = UIApplication.sharedApplication()
-        guard let testURL = NSURL(string: "http://www.google.com") else {
+        let testApp = UIApplication.shared
+        guard let testURL = URL(string: "http://www.google.com") else {
             XCTFail()
             return
         }
         let testSourceApplication = "testSource"
         let testAnnotation = "annotation"
         
-        let urlClosure: ((UIApplication, NSURL, String?, AnyObject?) -> Bool) = { application, url, source, annotation in
+        let urlClosure: ((UIApplication, URL, String?, AnyObject?) -> Bool) = { application, url, source, annotation in
             XCTAssertEqual(application, testApp)
             XCTAssertEqual(url, testURL)
             XCTAssertEqual(source, testSourceApplication)
@@ -85,32 +85,32 @@ class RidesAppDelegateTests : XCTestCase {
         appDelegate.loginManager = loginManagerMock
         XCTAssertTrue(appDelegate.application(testApp, openURL: testURL, sourceApplication: testSourceApplication, annotation: testAnnotation))
         XCTAssertNil(appDelegate.loginManager)
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        waitForExpectations(timeout: 0.2, handler: nil)
     }
     
     func testDidFinishLaunchingReturnsFalse_whenNoLaunchOptions() {
         let appDelegate = RidesAppDelegate.sharedInstance
-        let testApp = UIApplication.sharedApplication()
+        let testApp = UIApplication.shared
         XCTAssertFalse(appDelegate.application(testApp, didFinishLaunchingWithOptions: nil))
     }
     
     func testDidFinishLaunchingCallsOpenURL_whenLaunchURL() {
-        let expectation = expectationWithDescription("open URL called")
+        let expectation = self.expectation(description: "open URL called")
         let appDelegate = RidesAppDelegate.sharedInstance
-        let testApp = UIApplication.sharedApplication()
+        let testApp = UIApplication.shared
         let loginManagerMock = LoginManagingProtocolMock()
-        guard let testURL = NSURL(string: "http://www.google.com") else {
+        guard let testURL = URL(string: "http://www.google.com") else {
             XCTFail()
             return
         }
         let testSourceApplication = "testSource"
         let testAnnotation = "annotation"
         var launchOptions = [String: AnyObject]()
-        launchOptions[UIApplicationLaunchOptionsURLKey] = testURL
-        launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] = testSourceApplication
-        launchOptions[UIApplicationLaunchOptionsAnnotationKey] = testAnnotation
+        launchOptions[UIApplicationLaunchOptionsKey.url] = testURL
+        launchOptions[UIApplicationLaunchOptionsKey.sourceApplication] = testSourceApplication
+        launchOptions[UIApplicationLaunchOptionsKey.annotation] = testAnnotation
         
-        let urlClosure: ((UIApplication, NSURL, String?, AnyObject?) -> Bool) = { application, url, source, annotation in
+        let urlClosure: ((UIApplication, URL, String?, AnyObject?) -> Bool) = { application, url, source, annotation in
             XCTAssertEqual(application, testApp)
             XCTAssertEqual(url, testURL)
             XCTAssertEqual(source, testSourceApplication)
@@ -123,11 +123,11 @@ class RidesAppDelegateTests : XCTestCase {
         appDelegate.loginManager = loginManagerMock
         XCTAssertTrue(appDelegate.application(testApp, didFinishLaunchingWithOptions: launchOptions))
         XCTAssertNil(appDelegate.loginManager)
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        waitForExpectations(timeout: 0.2, handler: nil)
     }
     
     func testDidBecomeActiveCallsLoginManager_whenDidBecomeActiveNotification() {
-        let expectation = expectationWithDescription("didBecomeActive called")
+        let expectation = self.expectation(description: "didBecomeActive called")
         let appDelegate = RidesAppDelegate.sharedInstance
         let loginManagerMock = LoginManagingProtocolMock()
         
@@ -138,7 +138,7 @@ class RidesAppDelegateTests : XCTestCase {
         loginManagerMock.didBecomeActiveClosure = didBecomeActiveClosure
         appDelegate.loginManager = loginManagerMock
         
-        NSNotificationCenter.defaultCenter().postNotificationName(UIApplicationDidBecomeActiveNotification, object: nil)
+        NotificationCenter.default.post(name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
         
         waitForExpectationsWithTimeout(0.2) { _ in
             XCTAssertNil(appDelegate.loginManager)

--- a/source/UberRidesTests/RidesClientTests.swift
+++ b/source/UberRidesTests/RidesClientTests.swift
@@ -35,7 +35,7 @@ class RidesClientTests: XCTestCase {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfoNoServerToken"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         Configuration.setClientID(clientID)
         Configuration.setServerToken(nil)
         Configuration.setSandboxEnabled(true)
@@ -64,10 +64,10 @@ class RidesClientTests: XCTestCase {
      */
     func testGetCheapestProduct() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("getproducts.json", self.dynamicType)!, statusCode:200, headers:nil)
+            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("getproducts.json", type(of: self))!, statusCode:200, headers:nil)
         }
         
-        let expectation = expectationWithDescription("get cheapest product")
+        let expectation = self.expectation(description: "get cheapest product")
         let location = CLLocation(latitude: pickupLat, longitude: pickupLong)
         client.fetchCheapestProduct(pickupLocation: location, completion: { ridesProduct, response in
             XCTAssertNotNil(ridesProduct)
@@ -76,7 +76,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -88,10 +88,10 @@ class RidesClientTests: XCTestCase {
      */
     func testGetProducts() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("getproducts.json", self.dynamicType)!, statusCode:200, headers:nil)
+            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("getproducts.json", type(of: self))!, statusCode:200, headers:nil)
         }
         
-        let expectation = expectationWithDescription("get all products")
+        let expectation = self.expectation(description: "get all products")
         let location = CLLocation(latitude: pickupLat, longitude: pickupLong)
         client.fetchProducts(pickupLocation: location, completion: { products, response in
             
@@ -105,7 +105,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -117,10 +117,10 @@ class RidesClientTests: XCTestCase {
      */
     func testGetProductByID() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("getproductid.json", self.dynamicType)!, statusCode:200, headers:nil)
+            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("getproductid.json", type(of: self))!, statusCode:200, headers:nil)
         }
         
-        let expectation = expectationWithDescription("get product by id")
+        let expectation = self.expectation(description: "get product by id")
         
         client.fetchProduct(productID, completion: { product, response in
             
@@ -131,7 +131,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -143,10 +143,10 @@ class RidesClientTests: XCTestCase {
      */
     func testGetTimeEstimates() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("gettimeestimates.json", self.dynamicType)!, statusCode:200, headers:nil)
+            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("gettimeestimates.json", type(of: self))!, statusCode:200, headers:nil)
         }
         
-        let expectation = expectationWithDescription("get time estimates")
+        let expectation = self.expectation(description: "get time estimates")
         let location = CLLocation(latitude: pickupLat, longitude: pickupLong)
         client.fetchTimeEstimates(pickupLocation: location, completion:{ timeEstimates, response in
             
@@ -159,7 +159,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -171,10 +171,10 @@ class RidesClientTests: XCTestCase {
      */
     func testGetPriceEstimates() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("getpriceestimates.json", self.dynamicType)!, statusCode:200, headers:nil)
+            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("getpriceestimates.json", type(of: self))!, statusCode:200, headers:nil)
         }
         
-        let expectation = expectationWithDescription("get price estimates")
+        let expectation = self.expectation(description: "get price estimates")
         let pickupLocation = CLLocation(latitude: pickupLat, longitude: pickupLong)
         let dropoffLocation = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
         client.fetchPriceEstimates(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation, completion:{ priceEstimates, response in
@@ -188,7 +188,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -200,10 +200,10 @@ class RidesClientTests: XCTestCase {
      */
     func testGetHistory() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("gethistory.json", self.dynamicType)!, statusCode:200, headers:nil)
+            return OHHTTPStubsResponse(fileAtPath:OHPathForFile("gethistory.json", type(of: self))!, statusCode:200, headers:nil)
         }
         
-        let expectation = expectationWithDescription("get user history")
+        let expectation = self.expectation(description: "get user history")
     
         client.fetchTripHistory(completion: { userActivity, response in
             XCTAssertNotNil(userActivity)
@@ -214,7 +214,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -226,10 +226,10 @@ class RidesClientTests: XCTestCase {
      */
     func testGetUserProfile() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("getme.json", self.dynamicType)!, statusCode: 200, headers: nil)
+            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("getme.json", type(of: self))!, statusCode: 200, headers: nil)
         }
         
-        let expectation = expectationWithDescription("get user profile")
+        let expectation = self.expectation(description: "get user profile")
         
         client.fetchUserProfile({ profile, error in
             XCTAssertNotNil(profile)
@@ -239,7 +239,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -251,10 +251,10 @@ class RidesClientTests: XCTestCase {
      */
     func testMakeRideRequest() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("postrequests.json", self.dynamicType)!, statusCode: 200, headers: nil)
+            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("postrequests.json", type(of: self))!, statusCode: 200, headers: nil)
         }
         
-        let expectation = expectationWithDescription("make ride request")
+        let expectation = self.expectation(description: "make ride request")
         
         let rideParameters = RideParametersBuilder().setPickupPlaceID("home").build()
         client.requestRide(rideParameters, completion: { ride, response in
@@ -266,7 +266,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -278,10 +278,10 @@ class RidesClientTests: XCTestCase {
      */
     func testGetCurrentRide() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("getrequest.json", self.dynamicType)!, statusCode: 200, headers: nil)
+            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("getrequest.json", type(of: self))!, statusCode: 200, headers: nil)
         }
         
-        let expectation = expectationWithDescription("get current ride")
+        let expectation = self.expectation(description: "get current ride")
         
         client.fetchCurrentRide({ ride, response in
             XCTAssertNotNil(ride)
@@ -291,7 +291,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -303,10 +303,10 @@ class RidesClientTests: XCTestCase {
      */
     func testGetRideByID() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("getrequest.json", self.dynamicType)!, statusCode: 200, headers: nil)
+            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("getrequest.json", type(of: self))!, statusCode: 200, headers: nil)
         }
         
-        let expectation = expectationWithDescription("get ride by ID")
+        let expectation = self.expectation(description: "get ride by ID")
         
         client.fetchRideDetails("someID", completion: { ride, response in
             XCTAssertNotNil(ride)
@@ -316,7 +316,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -328,10 +328,10 @@ class RidesClientTests: XCTestCase {
      */
     func testGetRequestEstimate() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("requestestimate.json", self.dynamicType)!, statusCode: 200, headers: nil)
+            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("requestestimate.json", type(of: self))!, statusCode: 200, headers: nil)
         }
         
-        let expectation = expectationWithDescription("get request estimate")
+        let expectation = self.expectation(description: "get request estimate")
         let rideParams = RideParametersBuilder().setPickupPlaceID("home").build()
         
         client.fetchRideRequestEstimate(rideParams, completion:{ estimate, error in
@@ -341,7 +341,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -350,10 +350,10 @@ class RidesClientTests: XCTestCase {
     
     func testGetPlace() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("place.json", self.dynamicType)!, statusCode: 200, headers: nil)
+            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("place.json", type(of: self))!, statusCode: 200, headers: nil)
         }
         
-        let expectation = expectationWithDescription("get place")
+        let expectation = self.expectation(description: "get place")
         let testPlace = Place.Home
         
         client.fetchPlace(testPlace, completion: { place, response in
@@ -366,7 +366,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -382,7 +382,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: obj, statusCode: 404, headers: nil)
         }
         
-        let expectation = expectationWithDescription("get place not found error")
+        let expectation = self.expectation(description: "get place not found error")
         let testPlace = "gym"
         
         client.fetchPlace(testPlace, completion: { place, response in
@@ -400,7 +400,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -416,7 +416,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: obj, statusCode: 401, headers: nil)
         }
         
-        let expectation = expectationWithDescription("get place not found error")
+        let expectation = self.expectation(description: "get place not found error")
         let testPlace = Place.Home
         
         client.fetchPlace(testPlace, completion: { place, response in
@@ -434,7 +434,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -446,7 +446,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: [], statusCode: 204, headers: nil)
         }
         
-        let expectation = expectationWithDescription("update ride")
+        let expectation = self.expectation(description: "update ride")
         let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
         client.updateRideDetails("requestID1234", rideParameters: params, completion: { response in
             XCTAssertNil(response.error)
@@ -454,7 +454,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -464,7 +464,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: ["code":"unauthorized", "title":"Invalid OAuth 2.0 credentials provided."], statusCode: 401, headers: nil)
         }
         
-        let expectation = expectationWithDescription("update ride")
+        let expectation = self.expectation(description: "update ride")
         let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
         client.updateRideDetails("requestID1234", rideParameters: params, completion: { response in
             guard let error = response.error else {
@@ -478,7 +478,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -488,7 +488,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: ["code":"not_found", "title":"The provided request ID doesn't exist."], statusCode: 404, headers: nil)
         }
         
-        let expectation = expectationWithDescription("update ride")
+        let expectation = self.expectation(description: "update ride")
         let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
         client.updateRideDetails("requestID1234", rideParameters: params, completion: { response in
             guard let error = response.error else {
@@ -502,7 +502,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -512,7 +512,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: ["code":"validation_failed", "title": "The input failed invalidation."], statusCode: 422, headers: nil)
         }
         
-        let expectation = expectationWithDescription("update ride")
+        let expectation = self.expectation(description: "update ride")
         let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
         client.updateRideDetails("requestID1234", rideParameters: params, completion: { response in
             guard let error = response.error else {
@@ -526,7 +526,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -536,7 +536,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: [], statusCode: 204, headers: nil)
         }
         
-        let expectation = expectationWithDescription("update ride")
+        let expectation = self.expectation(description: "update ride")
         let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
         client.updateCurrentRide(params, completion: { response in
             XCTAssertNil(response.error)
@@ -544,7 +544,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -554,7 +554,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: ["code":"unauthorized", "title":"Invalid OAuth 2.0 credentials provided."], statusCode: 401, headers: nil)
         }
         
-        let expectation = expectationWithDescription("update ride")
+        let expectation = self.expectation(description: "update ride")
         let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
         client.updateCurrentRide(params, completion: { response in
             guard let error = response.error else {
@@ -568,7 +568,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -578,7 +578,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: ["code":"forbidden", "title":"Forbidden."], statusCode: 403, headers: nil)
         }
         
-        let expectation = expectationWithDescription("update ride")
+        let expectation = self.expectation(description: "update ride")
         let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
         client.updateCurrentRide(params, completion: { response in
             guard let error = response.error else {
@@ -592,7 +592,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -602,7 +602,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: ["code":"no_current_trip", "title":"User is not currently on a trip."], statusCode: 404, headers: nil)
         }
         
-        let expectation = expectationWithDescription("update ride")
+        let expectation = self.expectation(description: "update ride")
         let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
         client.updateCurrentRide(params, completion: { response in
             guard let error = response.error else {
@@ -616,7 +616,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -626,7 +626,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: ["code":"validation_failed", "title":"The input failed invalidation."], statusCode: 422, headers: nil)
         }
         
-        let expectation = expectationWithDescription("update ride")
+        let expectation = self.expectation(description: "update ride")
         let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
         client.updateCurrentRide(params, completion: { response in
             guard let error = response.error else {
@@ -640,7 +640,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -650,14 +650,14 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: [], statusCode: 204, headers: nil)
         }
         
-        let expectation = expectationWithDescription("delete ride")
+        let expectation = self.expectation(description: "delete ride")
         client.cancelRide("requestID1234", completion: { response in
             XCTAssertNil(response.error)
             XCTAssertEqual(response.statusCode, 204)
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -667,14 +667,14 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: [], statusCode: 204, headers: nil)
         }
         
-        let expectation = expectationWithDescription("delete ride")
+        let expectation = self.expectation(description: "delete ride")
         client.cancelCurrentRide({ response in
             XCTAssertNil(response.error)
             XCTAssertEqual(response.statusCode, 204)
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -684,7 +684,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: ["code":"unauthorized", "title":"Invalid OAuth 2.0 Credentials provided."], statusCode: 401, headers: nil)
         }
         
-        let expectation = expectationWithDescription("update ride")
+        let expectation = self.expectation(description: "update ride")
         client.cancelCurrentRide({ response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -697,7 +697,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -707,7 +707,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: ["code":"forbidden", "title":"Forbidden"], statusCode: 403, headers: nil)
         }
         
-        let expectation = expectationWithDescription("update ride")
+        let expectation = self.expectation(description: "update ride")
         client.cancelCurrentRide({ response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -720,7 +720,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -730,7 +730,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: ["code":"no_current_trip", "title":"User is not currently on a trip."], statusCode: 404, headers: nil)
         }
         
-        let expectation = expectationWithDescription("update ride")
+        let expectation = self.expectation(description: "update ride")
         client.cancelCurrentRide({ response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -743,7 +743,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -753,10 +753,10 @@ class RidesClientTests: XCTestCase {
      */
     func testGetPaymentMethods() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("getpaymentmethods.json", self.dynamicType)!, statusCode: 200, headers: nil)
+            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("getpaymentmethods.json", type(of: self))!, statusCode: 200, headers: nil)
         }
         
-        let expectation = expectationWithDescription("get payment methods")
+        let expectation = self.expectation(description: "get payment methods")
         client.fetchPaymentMethods({ methods, lastUsed, response in
             guard let lastUsed = lastUsed else {
                 XCTAssert(false)
@@ -769,7 +769,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler:{ error in
+        waitForExpectations(timeout: timeout, handler:{ error in
             if let error = error {
                 print("Error: \(error.localizedDescription)")
             }
@@ -778,10 +778,10 @@ class RidesClientTests: XCTestCase {
     
     func testGetRideReceipt() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("ridereceipt.json", self.dynamicType)!, statusCode: 200, headers: nil)
+            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("ridereceipt.json", type(of: self))!, statusCode: 200, headers: nil)
         }
         
-        let expectation = expectationWithDescription("ride receipt")
+        let expectation = self.expectation(description: "ride receipt")
         client.fetchRideReceipt("requestID1234", completion: { receipt, response in
             guard let receipt = receipt else {
                 XCTAssert(false)
@@ -794,17 +794,17 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
     
     func testGetRideMap() {
         stub(isHost("sandbox-api.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("ridemap.json", self.dynamicType)!, statusCode: 200, headers: nil)
+            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("ridemap.json", type(of: self))!, statusCode: 200, headers: nil)
         }
         
-        let expectation = expectationWithDescription("ride map")
+        let expectation = self.expectation(description: "ride map")
         client.fetchRideMap("requestID1234", completion: { map, response in
             guard let map = map else {
                 XCTAssert(false)
@@ -818,7 +818,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -828,7 +828,7 @@ class RidesClientTests: XCTestCase {
             return OHHTTPStubsResponse(JSONObject: ["code":"no_current_trip", "title":"User is not currently on a trip."], statusCode: 404, headers: nil)
         }
         
-        let expectation = expectationWithDescription("ride map")
+        let expectation = self.expectation(description: "ride map")
         client.fetchRideMap("requestID1234", completion: { map, response in
             XCTAssertNil(map)
             
@@ -844,21 +844,21 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
     
     func testRefreshToken() {
         stub(isHost("login.uber.com")) { _ in
-            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("refresh.json", self.dynamicType)!, statusCode: 200, headers: nil)
+            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("refresh.json", type(of: self))!, statusCode: 200, headers: nil)
         }
         let refreshToken = "thisIsRefresh"
         let expectedScopeString = "request all_trips profile ride_widgets history places history_lite"
         let expectedScopes = expectedScopeString.toRidesScopesArray()
         let expectedScopeSet = Set(expectedScopes)
         
-        let expectation = expectationWithDescription("Refresh token completion")
+        let expectation = self.expectation(description: "Refresh token completion")
         client.refreshAccessToken(refreshToken, completion: { accessToken, response in
             guard let accessToken = accessToken, let scopes = accessToken.grantedScopes else {
                 XCTAssert(false)
@@ -875,7 +875,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }
@@ -886,7 +886,7 @@ class RidesClientTests: XCTestCase {
         }
         let refreshToken = "thisIsRefresh"
 
-        let expectation = expectationWithDescription("Refresh token completion")
+        let expectation = self.expectation(description: "Refresh token completion")
         client.refreshAccessToken(refreshToken, completion: { accessToken, response in
             XCTAssertNil(accessToken)
             
@@ -900,7 +900,7 @@ class RidesClientTests: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectationsWithTimeout(timeout, handler: { error in
+        waitForExpectations(timeout: timeout, handler: { error in
             XCTAssertNil(error)
         })
     }

--- a/source/UberRidesTests/RidesMocks.swift
+++ b/source/UberRidesTests/RidesMocks.swift
@@ -90,7 +90,7 @@ class RideRequestViewControllerMock : RideRequestViewController {
         }
     }
     
-    override func presentViewController(viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
+    override func presentViewController(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
         if let presentViewControllerClosure = presentViewControllerClosure {
             presentViewControllerClosure(viewControllerToPresent, flag, completion)
         } else {
@@ -145,7 +145,7 @@ class OAuthViewControllerMock : OAuthViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func presentViewController(viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
+    override func presentViewController(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
         if let presentViewControllerClosure = presentViewControllerClosure {
             presentViewControllerClosure(viewControllerToPresent, flag, completion)
         } else {
@@ -155,26 +155,30 @@ class OAuthViewControllerMock : OAuthViewController {
 }
 
 class WebViewMock : WKWebView {
-    var testClosure: ((NSURLRequest) -> ())?
-    init(frame: CGRect, configuration: WKWebViewConfiguration, testClosure: ((NSURLRequest) -> ())?) {
+    var testClosure: ((URLRequest) -> ())?
+    init(frame: CGRect, configuration: WKWebViewConfiguration, testClosure: ((URLRequest) -> ())?) {
         self.testClosure = testClosure
         super.init(frame: frame, configuration: configuration)
     }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
-    override func loadRequest(request: NSURLRequest) -> WKNavigation? {
+    override func load(_ request: URLRequest) -> WKNavigation? {
         testClosure?(request)
         return nil
     }
 }
 
 class RequestDeeplinkMock : RequestDeeplink {
-    var testClosure: ((NSURL?) -> (Bool))?
-    init(rideParameters: RideParameters, testClosure: ((NSURL?) -> (Bool))?) {
+    var testClosure: ((URL?) -> (Bool))?
+    init(rideParameters: RideParameters, testClosure: ((URL?) -> (Bool))?) {
         self.testClosure = testClosure
         super.init(rideParameters: rideParameters)
     }
     
-    override func execute(completion: ((NSError?) -> ())? = nil) {
+    override func execute(_ completion: ((NSError?) -> ())? = nil) {
         guard let testClosure = testClosure else {
             completion?(nil)
             return
@@ -184,13 +188,13 @@ class RequestDeeplinkMock : RequestDeeplink {
 }
 
 class DeeplinkRequestingBehaviorMock : DeeplinkRequestingBehavior {
-    var testClosure: ((NSURL?) -> (Bool))?
-    init(testClosure: ((NSURL?) -> (Bool))?) {
+    var testClosure: ((URL?) -> (Bool))?
+    init(testClosure: ((URL?) -> (Bool))?) {
         self.testClosure = testClosure
         super.init()
     }
     
-    override func createDeeplink(rideParameters: RideParameters) -> RequestDeeplink {
+    override func createDeeplink(_ rideParameters: RideParameters) -> RequestDeeplink {
         return RequestDeeplinkMock(rideParameters: rideParameters, testClosure: testClosure)
     }
 }
@@ -200,7 +204,7 @@ class DeeplinkRequestingBehaviorMock : DeeplinkRequestingBehavior {
     init(testClosure: (RideRequestViewController, NSError) -> ()) {
         self.testClosure = testClosure
     }
-    @objc func rideRequestViewController(rideRequestViewController: RideRequestViewController, didReceiveError error: NSError) {
+    @objc func rideRequestViewController(_ rideRequestViewController: RideRequestViewController, didReceiveError error: NSError) {
         self.testClosure(rideRequestViewController, error)
     }
 }
@@ -209,12 +213,12 @@ class DeeplinkRequestingBehaviorMock : DeeplinkRequestingBehavior {
     
     let deeplinkingObject: Deeplinking
     
-    var executeClosure: (((NSError?) -> ())? -> ())?
+    var executeClosure: ((((NSError?) -> ())?) -> ())?
     var backingScheme: String?
     var backingDomain: String?
     var backingPath: String?
-    var backingQueryItems: [NSURLQueryItem]?
-    var backingDeeplinkURL: NSURL?
+    var backingQueryItems: [URLQueryItem]?
+    var backingDeeplinkURL: URL?
     
     var overrideExecute: Bool = false
     var overrideExecuteValue: NSError? = nil
@@ -246,7 +250,7 @@ class DeeplinkRequestingBehaviorMock : DeeplinkRequestingBehavior {
         }
     }
     
-    var queryItems: [NSURLQueryItem]? {
+    var queryItems: [URLQueryItem]? {
         get {
             return backingQueryItems ?? deeplinkingObject.queryItems
         }
@@ -255,7 +259,7 @@ class DeeplinkRequestingBehaviorMock : DeeplinkRequestingBehavior {
         }
     }
     
-    var deeplinkURL: NSURL {
+    var deeplinkURL: URL {
         get {
             return backingDeeplinkURL ?? deeplinkingObject.deeplinkURL
         }
@@ -264,7 +268,7 @@ class DeeplinkRequestingBehaviorMock : DeeplinkRequestingBehavior {
         }
     }
 
-    @objc func execute(completion: ((NSError?) -> ())?) {
+    @objc func execute(_ completion: ((NSError?) -> ())?) {
         if let closure = executeClosure {
             closure(completion)
         } else if overrideExecute {
@@ -282,8 +286,8 @@ class DeeplinkRequestingBehaviorMock : DeeplinkRequestingBehavior {
 
 @objc class LoginManagingProtocolMock : NSObject, LoginManaging {
     
-    var loginClosure: (([RidesScope], UIViewController?, ((accessToken: AccessToken?, error: NSError?) -> Void)?) -> Void)?
-    var openURLClosure: ((UIApplication, NSURL, String?, AnyObject?) -> Bool)?
+    var loginClosure: (([RidesScope], UIViewController?, ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?) -> Void)?
+    var openURLClosure: ((UIApplication, URL, String?, AnyObject?) -> Bool)?
     var didBecomeActiveClosure: (() -> ())?
 
     var backingManager: LoginManaging?
@@ -293,7 +297,7 @@ class DeeplinkRequestingBehaviorMock : DeeplinkRequestingBehavior {
         super.init()
     }
     
-    func login(requestedScopes scopes: [RidesScope], presentingViewController: UIViewController?, completion: ((accessToken: AccessToken?, error: NSError?) -> Void)?) {
+    func login(requestedScopes scopes: [RidesScope], presentingViewController: UIViewController?, completion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?) {
         if let closure = loginClosure {
             closure(scopes, presentingViewController, completion)
         } else if let manager = backingManager {
@@ -301,7 +305,7 @@ class DeeplinkRequestingBehaviorMock : DeeplinkRequestingBehavior {
         }
     }
     
-    func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject?) -> Bool {
+    func application(_ application: UIApplication, openURL url: URL, sourceApplication: String?, annotation: AnyObject?) -> Bool {
         if let closure = openURLClosure {
             return closure(application, url, sourceApplication, annotation)
         } else if let manager = backingManager {
@@ -320,7 +324,7 @@ class DeeplinkRequestingBehaviorMock : DeeplinkRequestingBehavior {
     }
 }
 
-@objc class LoginManagerPartialMock : LoginManager {
+class LoginManagerPartialMock : LoginManager {
     
     var executeLoginClosure: (() -> ())?
     
@@ -333,11 +337,11 @@ class DeeplinkRequestingBehaviorMock : DeeplinkRequestingBehavior {
     }
 }
 
-@objc class NativeAuthenticatorPartialMock : NativeAuthenticator {
+class NativeAuthenticatorPartialMock : NativeAuthenticator {
     
-    var handleRedirectClosure: ((NSURLRequest) -> (Bool))?
+    var handleRedirectClosure: ((URLRequest) -> (Bool))?
     
-    override func handleRedirectRequest(request: NSURLRequest) -> Bool {
+    override func handleRedirectRequest(_ request: URLRequest) -> Bool {
         if let closure = handleRedirectClosure {
             return closure(request)
         } else {

--- a/source/UberRidesTests/TokenManagerTests.swift
+++ b/source/UberRidesTests/TokenManagerTests.swift
@@ -27,13 +27,13 @@ import XCTest
 
 class TokenManagerTests: XCTestCase {
     
-    private var notificationFired = false
-    private var keychain: KeychainWrapper?
+    fileprivate var notificationFired = false
+    fileprivate var keychain: KeychainWrapper?
     
     override func setUp() {
         super.setUp()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
         keychain = KeychainWrapper()
         notificationFired = false
     }
@@ -71,11 +71,11 @@ class TokenManagerTests: XCTestCase {
         
         let token = getTestToken()
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(handleTokenManagerNotifications), name: TokenManager.TokenManagerDidSaveTokenNotification, object: nil)
+        NotificationCenter.defaultCenter().addObserver(self, selector: #selector(handleTokenManagerNotifications), name: TokenManager.TokenManagerDidSaveTokenNotification, object: nil)
         
         XCTAssertTrue(TokenManager.saveToken(token, tokenIdentifier:identifier, accessGroup: accessGroup))
         
-        NSNotificationCenter.defaultCenter().removeObserver(self)
+        NotificationCenter.default.removeObserver(self)
         
         keychain?.setAccessGroup(accessGroup)
         guard let actualToken = keychain?.getObjectForKey(identifier) as? AccessToken else {
@@ -150,11 +150,11 @@ class TokenManagerTests: XCTestCase {
         keychain?.setAccessGroup(accessGroup)
         keychain?.setObject(token, key: identifier)
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(handleTokenManagerNotifications), name: TokenManager.TokenManagerDidDeleteTokenNotification, object: nil)
+        NotificationCenter.defaultCenter().addObserver(self, selector: #selector(handleTokenManagerNotifications), name: TokenManager.TokenManagerDidDeleteTokenNotification, object: nil)
         
         XCTAssertTrue(TokenManager.deleteToken(identifier, accessGroup: accessGroup))
         
-        NSNotificationCenter.defaultCenter().removeObserver(self)
+        NotificationCenter.default.removeObserver(self)
         
         XCTAssertTrue(notificationFired)
         
@@ -169,22 +169,22 @@ class TokenManagerTests: XCTestCase {
     func testDelete_nonExistent_doesNotFireNotification() {
         let identifier = "there.is.no.token.named.this.123412wfdasd3o"
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(handleTokenManagerNotifications), name: TokenManager.TokenManagerDidDeleteTokenNotification, object: nil)
+        NotificationCenter.defaultCenter().addObserver(self, selector: #selector(handleTokenManagerNotifications), name: TokenManager.TokenManagerDidDeleteTokenNotification, object: nil)
         
         XCTAssertFalse(TokenManager.deleteToken(identifier))
         
-        NSNotificationCenter.defaultCenter().removeObserver(self)
+        NotificationCenter.default.removeObserver(self)
         
         XCTAssertFalse(notificationFired)
     }
     
     func testCookiesCleared_whenTokenDeleted() {
-        guard let usUrl = NSURL(string: "https://login.uber.com"), let chinaURL = NSURL(string: "https://login.uber.com.cn")  else {
+        guard let usUrl = URL(string: "https://login.uber.com"), let chinaURL = URL(string: "https://login.uber.com.cn")  else {
             XCTAssertFalse(false)
             return
         }
         
-        let cookieStorage = NSHTTPCookieStorage.sharedHTTPCookieStorage()
+        let cookieStorage = HTTPCookieStorage.shared
         
         if let cookies = cookieStorage.cookies {
             for cookie in cookies {
@@ -193,12 +193,12 @@ class TokenManagerTests: XCTestCase {
         }
         
         
-        cookieStorage.setCookies(createTestUSCookies(), forURL: usUrl, mainDocumentURL: nil)
-        cookieStorage.setCookies(createTestChinaCookies(), forURL: chinaURL, mainDocumentURL: nil)
-        NSUserDefaults.standardUserDefaults().synchronize()
+        cookieStorage.setCookies(createTestUSCookies(), for: usUrl, mainDocumentURL: nil)
+        cookieStorage.setCookies(createTestChinaCookies(), for: chinaURL, mainDocumentURL: nil)
+        UserDefaults.standard.synchronize()
         XCTAssertEqual(cookieStorage.cookies?.count, 4)
-        XCTAssertEqual(cookieStorage.cookiesForURL(usUrl)?.count, 2)
-        XCTAssertEqual(cookieStorage.cookiesForURL(chinaURL)?.count, 2)
+        XCTAssertEqual(cookieStorage.cookies(for: usUrl)?.count, 2)
+        XCTAssertEqual(cookieStorage.cookies(for: chinaURL)?.count, 2)
         
         let identifier = "testIdentifier"
         let accessGroup = "testAccessGroup"
@@ -217,7 +217,7 @@ class TokenManagerTests: XCTestCase {
             return
         }
         
-        let testCookieStorage = NSHTTPCookieStorage.sharedHTTPCookieStorage()
+        let testCookieStorage = HTTPCookieStorage.shared
         XCTAssertEqual(testCookieStorage.cookies?.count, 0)
         
     }
@@ -230,34 +230,34 @@ class TokenManagerTests: XCTestCase {
         return AccessToken(JSON: tokenData)
     }
             
-    func createTestUSCookies() -> [NSHTTPCookie] {
-        let secureUSCookie = NSHTTPCookie(properties: [NSHTTPCookieDomain: ".uber.com",
-            NSHTTPCookiePath : "/",
-            NSHTTPCookieName : "us_login_secure",
-            NSHTTPCookieValue : "some_value",
-            NSHTTPCookieSecure : true])
-        let unsecureUSCookie = NSHTTPCookie(properties: [NSHTTPCookieDomain: ".uber.com",
-            NSHTTPCookiePath : "/",
-            NSHTTPCookieName : "us_login_unecure",
-            NSHTTPCookieValue : "some_value",
-            NSHTTPCookieSecure : false])
+    func createTestUSCookies() -> [HTTPCookie] {
+        let secureUSCookie = HTTPCookie(properties: [HTTPCookiePropertyKey.domain: ".uber.com",
+            HTTPCookiePropertyKey.path : "/",
+            HTTPCookiePropertyKey.name : "us_login_secure",
+            HTTPCookiePropertyKey.value : "some_value",
+            HTTPCookiePropertyKey.secure : true])
+        let unsecureUSCookie = HTTPCookie(properties: [HTTPCookiePropertyKey.domain: ".uber.com",
+            HTTPCookiePropertyKey.path : "/",
+            HTTPCookiePropertyKey.name : "us_login_unecure",
+            HTTPCookiePropertyKey.value : "some_value",
+            HTTPCookiePropertyKey.secure : false])
         if let secureUSCookie = secureUSCookie, let unsecureUSCookie = unsecureUSCookie {
             return [secureUSCookie, unsecureUSCookie]
         }
         return []
     }
     
-    func createTestChinaCookies() -> [NSHTTPCookie] {
-        let secureChinaCookie = NSHTTPCookie(properties: [NSHTTPCookieDomain : ".uber.com.cn",
-            NSHTTPCookiePath : "/",
-            NSHTTPCookieName : "cn_login_secure",
-            NSHTTPCookieValue : "some_value",
-            NSHTTPCookieSecure : true])
-        let unsecureChinaCookie  = NSHTTPCookie(properties: [NSHTTPCookieDomain : ".uber.com.cn",
-            NSHTTPCookiePath : "/",
-            NSHTTPCookieName : "cn_login_unsecure",
-            NSHTTPCookieValue : "some_value",
-            NSHTTPCookieSecure : false])
+    func createTestChinaCookies() -> [HTTPCookie] {
+        let secureChinaCookie = HTTPCookie(properties: [HTTPCookiePropertyKey.domain : ".uber.com.cn",
+            HTTPCookiePropertyKey.path : "/",
+            HTTPCookiePropertyKey.name : "cn_login_secure",
+            HTTPCookiePropertyKey.value : "some_value",
+            HTTPCookiePropertyKey.secure : true])
+        let unsecureChinaCookie  = HTTPCookie(properties: [HTTPCookiePropertyKey.domain : ".uber.com.cn",
+            HTTPCookiePropertyKey.path : "/",
+            HTTPCookiePropertyKey.name : "cn_login_unsecure",
+            HTTPCookiePropertyKey.value : "some_value",
+            HTTPCookiePropertyKey.secure : false])
         if let secureChinaCookie = secureChinaCookie, let unsecureChinaCookie = unsecureChinaCookie {
             return [secureChinaCookie, unsecureChinaCookie]
         }

--- a/source/UberRidesTests/UberRidesTests.swift
+++ b/source/UberRidesTests/UberRidesTests.swift
@@ -45,7 +45,7 @@ class UberRidesTests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock {
+        self.measure {
             // Put the code you want to measure the time of here.
         }
     }

--- a/source/UberRidesTests/WidgetsEndpointTests.swift
+++ b/source/UberRidesTests/WidgetsEndpointTests.swift
@@ -32,7 +32,7 @@ class WidgetsEndpointTests: XCTestCase {
         super.setUp()
         Configuration.restoreDefaults()
         Configuration.plistName = "testInfo"
-        Configuration.bundle = NSBundle(forClass: self.dynamicType)
+        Configuration.bundle = Bundle(forClass: type(of: self))
     }
     
     override func tearDown() {


### PR DESCRIPTION
Ran the conversion to Swift 3.0 against a current project using the UberRides Cocoapod. Starting point was the swift-3-dev branch.

Updated ObjectMapper spec to ~> 2.0 to have the Swift 3 version of the dependency.

Objects with type Mappable were updated to to require the named parameter and not '_' in order to match specifications in the current version of ObjectMapper

After porting the source code, the project in this repo and test files were converted in Xcode to Swift 3.0 but not built/tested
