### PR TITLE
Fix RideScope not mapping for all cases

### DIFF
--- a/source/UberRides/Model/RidesScope.swift
+++ b/source/UberRides/Model/RidesScope.swift
@@ -173,6 +173,12 @@ class RidesScopeFactory : NSObject {
             return .Profile
         case RidesScopeType.RideWidgets.toString():
             return .RideWidgets
+        case RidesScopeType.AllTrips.toString():
+            return .AllTrips
+        case RidesScopeType.Request.toString():
+            return .Request
+        case RidesScopeType.RequestReceipt.toString():
+            return .RequestReceipt
         default:
             return nil
         }

--- a/source/UberRidesTests/RidesScopeFactoryTests.swift
+++ b/source/UberRidesTests/RidesScopeFactoryTests.swift
@@ -30,6 +30,9 @@ class RidesScopeFactoryTests: XCTestCase {
         RidesScopeType.HistoryLite : RidesScopeType.HistoryLite.toString(),
         RidesScopeType.Places : RidesScopeType.Places.toString(),
         RidesScopeType.RideWidgets : RidesScopeType.RideWidgets.toString(),
+        RidesScopeType.AllTrips : RidesScopeType.AllTrips.toString(),
+        RidesScopeType.Request : RidesScopeType.Request.toString(),
+        RidesScopeType.RequestReceipt : RidesScopeType.RequestReceipt.toString(),
     ]
     
     func testCreateRidesScopeByRidesScopeType() {


### PR DESCRIPTION
This seems to be a bug for missing out all the scope cases. 