### PR TITLE
Swifty APIs (Pt 2)

### DIFF
--- a/source/UberRides/Model/RideParameters.swift
+++ b/source/UberRides/Model/RideParameters.swift
@@ -63,15 +63,15 @@ import MapKit
     /// The source to use for attributing the ride
     public var source: String?
 
-    convenience override init() {
+    convenience public override init() {
         self.init(pickupLocation: nil, dropoffLocation: nil, pickupPlaceID: nil, dropoffPlaceID: nil)
     }
 
-    convenience init(pickupLocation: CLLocation?, dropoffLocation: CLLocation?) {
+    convenience public init(pickupLocation: CLLocation?, dropoffLocation: CLLocation?) {
         self.init(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation, pickupPlaceID: nil, dropoffPlaceID: nil)
     }
 
-    convenience init(pickupPlaceID: String?, dropoffPlaceID: String?) {
+    convenience public init(pickupPlaceID: String?, dropoffPlaceID: String?) {
         self.init(pickupLocation: nil, dropoffLocation: nil, pickupPlaceID: pickupPlaceID, dropoffPlaceID: dropoffPlaceID)
     }
 

--- a/source/UberRides/Model/RideParameters.swift
+++ b/source/UberRides/Model/RideParameters.swift
@@ -24,23 +24,20 @@
 
 import MapKit
 
-/// Object to represent the parameters needed to request a ride. Should be built using a RideParametersBuilder
+/// Object to represent the parameters needed to request a ride.
 @objc(UBSDKRideParameters) public class RideParameters : NSObject {
     
-    /// True if the pickup location should use the device's current location, false if a location has been set
-    public let useCurrentLocationForPickup: Bool
-    
     /// ProductID to use for the ride
-    public let productID: String?
+    public var productID: String?
     
     /// The pickup location to use for the ride
     public let pickupLocation: CLLocation?
-    
+
     /// The nickname of the pickup location of the ride
-    public let pickupNickname: String?
+    public var pickupNickname: String?
     
     /// The address of the pickup location of the ride
-    public let pickupAddress: String?
+    public var pickupAddress: String?
     
     /// This is the name of an Uber saved place. Only “home” or “work” is acceptable.
     public let pickupPlaceID: String?
@@ -49,20 +46,47 @@ import MapKit
     public let dropoffLocation: CLLocation?
     
     /// The nickname of the dropoff location for the ride
-    public let dropoffNickname: String?
+    public var dropoffNickname: String?
     
     /// The adress of the dropoff location of the ride
-    public let dropoffAddress: String?
+    public var dropoffAddress: String?
     
     /// This is the name of an Uber saved place. Only “home” or “work” is acceptable.
     public let dropoffPlaceID: String?
     
     /// The unique identifier of the payment method selected by a user.
-    public let paymentMethod: String?
+    public var paymentMethod: String?
     
     /// The unique identifier of the surge session for a user.
-    public let surgeConfirmationID: String?
-    
+    public var surgeConfirmationID: String?
+
+    /// The source to use for attributing the ride
+    public var source: String?
+
+    convenience override init() {
+        self.init(pickupLocation: nil, dropoffLocation: nil, pickupPlaceID: nil, dropoffPlaceID: nil)
+    }
+
+    convenience init(pickupLocation: CLLocation?, dropoffLocation: CLLocation?) {
+        self.init(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation, pickupPlaceID: nil, dropoffPlaceID: nil)
+    }
+
+    convenience init(pickupPlaceID: String?, dropoffPlaceID: String?) {
+        self.init(pickupLocation: nil, dropoffLocation: nil, pickupPlaceID: pickupPlaceID, dropoffPlaceID: dropoffPlaceID)
+    }
+
+    private init(pickupLocation: CLLocation?,
+                 dropoffLocation: CLLocation?,
+                 pickupPlaceID: String?,
+                 dropoffPlaceID: String?) {
+        self.pickupLocation = pickupLocation
+        self.dropoffLocation = dropoffLocation
+        self.pickupPlaceID = pickupPlaceID
+        self.dropoffPlaceID = dropoffPlaceID
+
+        super.init()
+    }
+
     var userAgent: String {
         var userAgentString: String = ""
         if let versionNumber: String = Bundle(for: type(of: self)).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String {
@@ -73,310 +97,4 @@ import MapKit
         }
         return userAgentString
     }
-    
-    var source: String?
-    
-    fileprivate init(dropoffAddress: String?,
-        dropoffLocation: CLLocation?,
-        dropoffNickname: String?,
-        dropoffPlaceID: String?,
-        paymentMethod: String?,
-        pickupAddress: String?,
-        pickupLocation: CLLocation?,
-        pickupNickname: String?,
-        pickupPlaceID: String?,
-        productID: String?,
-        source: String?,
-        surgeConfirmationID: String?,
-        useCurrentLocationForPickup: Bool) {
-        
-            self.useCurrentLocationForPickup = useCurrentLocationForPickup
-            self.productID = productID
-            self.pickupLocation = pickupLocation
-            self.pickupNickname = pickupNickname
-            self.pickupAddress = pickupAddress
-            self.pickupPlaceID = pickupPlaceID
-            self.dropoffLocation = dropoffLocation
-            self.dropoffNickname = dropoffNickname
-            self.dropoffAddress = dropoffAddress
-            self.dropoffPlaceID = dropoffPlaceID
-            self.paymentMethod = paymentMethod
-            self.surgeConfirmationID = surgeConfirmationID
-            self.source = source
-    }
-    
-}
-
-/// Builder for a RideParameters object.
-@objc(UBSDKRideParametersBuilder) open class RideParametersBuilder : NSObject {
-    
-    private var useCurrentLocationForPickup: Bool
-    private var productID: String?
-    private var pickupLocation: CLLocation?
-    private var pickupNickname: String?
-    private var pickupAddress: String?
-    private var pickupPlaceID: String?
-    private var dropoffLocation: CLLocation?
-    private var dropoffNickname: String?
-    private var dropoffAddress: String?
-    private var dropoffPlaceID: String?
-    private var paymentMethod: String?
-    private var surgeConfirmationID: String?
-    private var source: String?
-    
-    @objc public convenience override init() {
-        self.init(rideParameters: nil)
-    }
-    
-    @objc public init(rideParameters: RideParameters?) {
-        if let rideParameters = rideParameters {
-            useCurrentLocationForPickup = rideParameters.useCurrentLocationForPickup
-            productID = rideParameters.productID
-            pickupLocation = rideParameters.pickupLocation
-            pickupNickname = rideParameters.pickupNickname
-            pickupAddress = rideParameters.pickupAddress
-            pickupPlaceID = rideParameters.pickupPlaceID
-            dropoffLocation = rideParameters.dropoffLocation
-            dropoffNickname =  rideParameters.dropoffNickname
-            dropoffAddress = rideParameters.dropoffAddress
-            dropoffPlaceID = rideParameters.dropoffPlaceID
-            paymentMethod = rideParameters.paymentMethod
-            surgeConfirmationID = rideParameters.surgeConfirmationID
-            
-            source = rideParameters.source
-        } else {
-            useCurrentLocationForPickup = true
-        }
-    }
-    
-    /**
-     Set the product ID for the ride parameters.
-     
-     - parameter productID: The unique ID of the product being requested.
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    open func setProductID(_ productID: String) -> RideParametersBuilder {
-        self.productID = productID
-        
-        return self
-    }
-    
-    /**
-     Sets the builder to use your current location for pickup. Will clear any set
-     pickupLocation, pickupNickname, and pickupAddress.
-     */
-    open func setPickupToCurrentLocation() -> RideParametersBuilder {
-        useCurrentLocationForPickup = true
-        pickupLocation = nil
-        pickupNickname = nil
-        pickupAddress = nil
-        
-        return self
-    }
-    
-    /**
-     Sets the builder to use the given place ID as the pickup location. This will remove any existing pickup location.
-     Please note that place IDs are not supported for RequestDeeplink.
-     
-     - parameter placeID: the place ID of the pickup location - either "home" or "work".
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    open func setPickupPlaceID(_ placeID: String) -> RideParametersBuilder {
-        useCurrentLocationForPickup = false
-        pickupPlaceID = placeID
-        pickupLocation = nil
-        pickupNickname = nil
-        pickupAddress = nil
-        
-        return self
-    }
-    
-    /**
-     Set pickup location information for the ride parameters.
-     
-     - parameter location: CLLocation of pickup.
-     - parameter nickname: Optional nickname of pickup location.
-     - parameter address:  Optional address of pickup location.
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    open func setPickupLocation(_ location: CLLocation, nickname: String?, address: String?) -> RideParametersBuilder {
-        useCurrentLocationForPickup = false
-        pickupLocation = location
-        pickupNickname = nickname
-        pickupAddress = address
-        
-        return self
-    }
-    
-    /**
-     Set pickup location information for the ride parameters.
-     
-     - parameter location: CLLocation of pickup.
-     - parameter address:  Optional address of pickup location.
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    open func setPickupLocation(_ location: CLLocation, address: String?) -> RideParametersBuilder {
-        return self.setPickupLocation(location, nickname: nil, address: address)
-    }
-    
-    /**
-     Set pickup location information for the ride parameters.
-     
-     - parameter location: CLLocation of pickup.
-     - parameter nickname: Optional nickname of pickup location.
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    open func setPickupLocation(_ location: CLLocation, nickname: String?) -> RideParametersBuilder {
-        return self.setPickupLocation(location, nickname: nickname, address: nil)
-    }
-    
-    /**
-     Set pickup location information for the ride parameters.
-     
-     - parameter location: CLLocation of pickup.
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    open func setPickupLocation(_ location: CLLocation) -> RideParametersBuilder {
-        return self.setPickupLocation(location, nickname: nil, address: nil)
-    }
-    
-    /**
-     Set dropoff location information for the ride parameters.
-     
-     - parameter location: CLLocation of dropoff.
-     - parameter nickname: Optional nickname of dropoff location.
-     - parameter address:  Optional address of dropoff location.
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    open func setDropoffLocation(_ location: CLLocation, nickname: String?, address: String?) -> RideParametersBuilder {
-        dropoffLocation = location
-        dropoffNickname = nickname
-        dropoffAddress = address
-        
-        return self
-    }
-    
-    /**
-     Set dropoff location information for the ride parameters.
-     
-     - parameter location: CLLocation of dropoff.
-     - parameter address:  Optional address of dropoff location.
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    open func setDropoffLocation(_ location: CLLocation, address: String?) -> RideParametersBuilder {
-        return self.setDropoffLocation(location, nickname: nil, address: address)
-    }
-    
-    /**
-     Set dropoff location information for the ride parameters.
-     
-     - parameter location: CLLocation of dropoff.
-     - parameter nickname: Optional nickname of dropoff location.
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    open func setDropoffLocation(_ location: CLLocation, nickname: String?) -> RideParametersBuilder {
-        return self.setDropoffLocation(location, nickname: nickname, address: nil)
-    }
-    
-    /**
-     Set dropoff location information for the ride parameters.
-     
-     - parameter location: CLLocation of dropoff.
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    open func setDropoffLocation(_ location: CLLocation) -> RideParametersBuilder {
-        return self.setDropoffLocation(location, nickname: nil, address: nil)
-    }
-    
-    /**
-     Sets the builder to use the given place ID as the dropoff location. This will remove any existing dropoff location.
-     Please note that place IDs are not supported for RequestDeeplink and the Ride Request Widget.
-     
-     - parameter placeID: the place ID of the dropoff location - either "home" or "work".
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    open func setDropoffPlaceID(_ placeID: String) -> RideParametersBuilder {
-        dropoffPlaceID = placeID
-        dropoffLocation = nil
-        dropoffNickname = nil
-        dropoffAddress = nil
-        
-        return self
-    }
-    
-    /**
-     Sets the builder to use the given payment method for the user. 
-     If set, the trip will be requested using this payment method.
-     If not set, the trip will be requested using the user’s last used payment method.
-     Please note that payment methods are not supported for RequestDeeplink and the Ride Request Widget.
-     
-     - parameter method: unique identifier of payment method.
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    open func setPaymentMethod(_ method: String) -> RideParametersBuilder {
-        paymentMethod = method
-        
-        return self
-    }
-    
-    /**
-     Sets the builder to use the surge confirmation ID for making ride requests that have surge.
-     Please note surge confirmation is not supported for RequestDeeplink and the Ride Request Widget.
-     
-     - parameter surgeConfirmation: the unique identifier of the surge session for a user.
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    open func setSurgeConfirmationID(_ surgeConfirmation: String) -> RideParametersBuilder {
-        surgeConfirmationID = surgeConfirmation
-        
-        return self
-    }
-    
-    /**
-     Set the source to use for attributing the ride
-     
-     - parameter source: The source string to use
-     
-     - returns: RideParametersBuilder to continue chaining.
-     */
-    func setSource(_ source: String?) -> RideParametersBuilder {
-        self.source = source
-        
-        return self
-    }
-    
-    /**
-     Build the ride parameter object.
-     
-     - returns: An initialized RideParameters object
-     */
-    open func build() -> RideParameters {
-        return RideParameters(dropoffAddress: dropoffAddress,
-            dropoffLocation: dropoffLocation,
-            dropoffNickname: dropoffNickname,
-            dropoffPlaceID: dropoffPlaceID,
-            paymentMethod: paymentMethod,
-            pickupAddress: pickupAddress,
-            pickupLocation: pickupLocation,
-            pickupNickname: pickupNickname,
-            pickupPlaceID: pickupPlaceID,
-            productID: productID,
-            source: source,
-            surgeConfirmationID: surgeConfirmationID,
-            useCurrentLocationForPickup: useCurrentLocationForPickup)
-    }
-    
 }

--- a/source/UberRides/RequestDeeplink.swift
+++ b/source/UberRides/RequestDeeplink.swift
@@ -36,7 +36,7 @@ import UIKit
     
     static let sourceString = "deeplink"
     
-    @objc public init(rideParameters: RideParameters = RideParametersBuilder().build()) {
+    @objc public init(rideParameters: RideParameters = RideParameters()) {
         parameters = rideParameters
         clientID = Configuration.shared.clientID
         

--- a/source/UberRides/RideRequestButton.swift
+++ b/source/UberRides/RideRequestButton.swift
@@ -73,7 +73,7 @@ import CoreLocation
      */
     required public init?(coder aDecoder: NSCoder) {
         requestBehavior = DeeplinkRequestingBehavior()
-        rideParameters = RideParametersBuilder().build()
+        rideParameters = RideParameters()
         super.init(coder: aDecoder)
     }
     
@@ -116,7 +116,7 @@ import CoreLocation
      - returns: An initialized RideRequestButton
      */
     @objc public convenience init(client: RidesClient) {
-        self.init(client: client, rideParameters: RideParametersBuilder().build(), requestingBehavior: DeeplinkRequestingBehavior())
+        self.init(client: client, rideParameters: RideParameters(), requestingBehavior: DeeplinkRequestingBehavior())
     }
     
     /**
@@ -142,7 +142,7 @@ import CoreLocation
      - returns: An initialized RideRequestButton
      */
     @objc public convenience init(requestingBehavior: RideRequesting) {
-        self.init(client: RidesClient(), rideParameters: RideParametersBuilder().build(), requestingBehavior: requestingBehavior)
+        self.init(client: RidesClient(), rideParameters: RideParameters(), requestingBehavior: requestingBehavior)
     }
     
     //Mark: UberButton
@@ -156,7 +156,7 @@ import CoreLocation
      - returns: An initialized RideRequestButton
      */
     @objc public convenience init() {
-        self.init(client: RidesClient(), rideParameters: RideParametersBuilder().build(), requestingBehavior: DeeplinkRequestingBehavior())
+        self.init(client: RidesClient(), rideParameters: RideParameters(), requestingBehavior: DeeplinkRequestingBehavior())
     }
     
     /**

--- a/source/UberRides/RideRequestView.swift
+++ b/source/UberRides/RideRequestView.swift
@@ -109,7 +109,7 @@ import CoreLocation
      - returns: An initialized RideRequestView
      */
     @objc public convenience override init(frame: CGRect) {
-        self.init(rideParameters: RideParametersBuilder().build(), accessToken: TokenManager.fetchToken(), frame: frame)
+        self.init(rideParameters: RideParameters(), accessToken: TokenManager.fetchToken(), frame: frame)
     }
     
     /**
@@ -121,11 +121,11 @@ import CoreLocation
      - returns: An initialized RideRequestView
      */
     @objc public convenience init() {
-        self.init(rideParameters: RideParametersBuilder().build(), accessToken: TokenManager.fetchToken(), frame: CGRect.zero)
+        self.init(rideParameters: RideParameters(), accessToken: TokenManager.fetchToken(), frame: CGRect.zero)
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        rideParameters = RideParametersBuilder().build()
+        rideParameters = RideParameters()
         let configuration = WKWebViewConfiguration()
         configuration.processPool = Configuration.shared.processPool
         webView = WKWebView(frame: CGRect.zero, configuration: configuration)

--- a/source/UberRides/RideRequestViewController.swift
+++ b/source/UberRides/RideRequestViewController.swift
@@ -78,10 +78,9 @@ import MapKit
         keychainAccessGroup = loginManager.keychainAccessGroup
         
         super.init(coder: aDecoder)
-        
-        var builder = RideParametersBuilder()
-        builder = builder.setSource(RideRequestViewController.sourceString)
-        let defaultRideParameters = builder.build()
+
+        let defaultRideParameters = RideParameters()
+        defaultRideParameters.source = RideRequestViewController.sourceString
         
         rideRequestView.rideParameters = defaultRideParameters
     }

--- a/source/UberRides/RideRequestViewRequestingBehavior.swift
+++ b/source/UberRides/RideRequestViewRequestingBehavior.swift
@@ -58,7 +58,7 @@
      */
     @objc public init(presentingViewController: UIViewController, loginManager: LoginManager) {
         self.presentingViewController = presentingViewController
-        let rideRequestViewController = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManager)
+        let rideRequestViewController = RideRequestViewController(rideParameters: RideParameters(), loginManager: loginManager)
         modalRideRequestViewController = ModalRideRequestViewController(rideRequestViewController: rideRequestViewController)
     }
     

--- a/source/UberRidesTests/APIManagerTests.swift
+++ b/source/UberRidesTests/APIManagerTests.swift
@@ -219,13 +219,14 @@ class APIManagerTests: XCTestCase {
     func testRequestBuilderAllParameters() {
         let pickupLocation = CLLocation(latitude: pickupLat, longitude: pickupLong)
         let dropoffLocation = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParameters = RideParametersBuilder()
-            .setPickupLocation(pickupLocation, nickname: pickupNickname, address: pickupAddress)
-            .setDropoffLocation(dropoffLocation, nickname: dropoffNickname, address: dropoffAddress)
-            .setProductID(productID)
-            .setSurgeConfirmationID(surgeConfirm)
-            .setPaymentMethod(paymentMethod)
-            .build()
+        let rideParameters = RideParameters(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation)
+        rideParameters.pickupNickname = pickupNickname
+        rideParameters.pickupAddress = pickupAddress
+        rideParameters.dropoffNickname = dropoffNickname
+        rideParameters.dropoffAddress = dropoffAddress
+        rideParameters.productID = productID
+        rideParameters.surgeConfirmationID = surgeConfirm
+        rideParameters.paymentMethod = paymentMethod
         
         guard let data = RideRequestDataBuilder(rideParameters: rideParameters).build() else {
             XCTAssert(false)
@@ -260,7 +261,8 @@ class APIManagerTests: XCTestCase {
      Test the POST /v1/requests endpoint.
      */
     func testPostRequest() {
-        let rideParameters = RideParametersBuilder().setPickupPlaceID("home").setProductID(productID).build()
+        let rideParameters = RideParameters(pickupPlaceID: "home", dropoffPlaceID: nil)
+        rideParameters.productID = productID
         let request = buildRequestForEndpoint(Requests.make(rideParameters: rideParameters))
         XCTAssertEqual(request.httpMethod, Method.post.rawValue)
         if let url = request.url {
@@ -302,8 +304,8 @@ class APIManagerTests: XCTestCase {
      Tests the POST /v1/requests/estimate endpoint.
      */
     func testPostRequestEstimate() {
-        let rideParams = RideParametersBuilder().setPickupPlaceID("home").build()
-        let request = buildRequestForEndpoint(Requests.estimate(rideParameters: rideParams))
+        let rideParameters = RideParameters(pickupPlaceID: "home", dropoffPlaceID: nil)
+        let request = buildRequestForEndpoint(Requests.estimate(rideParameters: rideParameters))
         XCTAssertEqual(request.httpMethod, "POST")
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.PostRequestEstimate)
@@ -379,7 +381,7 @@ class APIManagerTests: XCTestCase {
      Tests the PATCH /v1/requests/curent endpoint.
      */
     func testPatchCurrentRequest() {
-        let rideParams = RideParametersBuilder().setPickupPlaceID(Place.Home).build()
+        let rideParams = RideParameters(pickupPlaceID: Place.Home, dropoffPlaceID: nil)
         let request = buildRequestForEndpoint(Requests.patchCurrent(rideParameters: rideParams))
         XCTAssertEqual(request.httpMethod, "PATCH")
         if let url = request.url {
@@ -418,7 +420,7 @@ class APIManagerTests: XCTestCase {
      Tests the PATCH /v1/requests/{request_id} endpoint.
      */
     func testPatchRequestByID() {
-        let rideParams = RideParametersBuilder().setPickupPlaceID(Place.Home).build()
+        let rideParams = RideParameters(pickupPlaceID: Place.Home, dropoffPlaceID: nil)
         let request = buildRequestForEndpoint(Requests.patchRequest(requestID: requestID, rideParameters: rideParams))
         XCTAssertEqual(request.httpMethod, "PATCH")
         if let url = request.url {

--- a/source/UberRidesTests/DeeplinkRequestingBehaviorTests.swift
+++ b/source/UberRidesTests/DeeplinkRequestingBehaviorTests.swift
@@ -52,8 +52,9 @@ class DeeplinkRequestingBehaviorTests : XCTestCase {
      */
     func testCreateAppStoreDeeplinkWithButtonSource() {
         let expectedUrlString = "https://m.uber.com/sign-up?client_id=\(clientID)&user-agent=\(expectedButtonUserAgent!)"
-        
-        let rideParameters = RideParametersBuilder().setSource(RideRequestButton.sourceString).build()
+
+        let rideParameters = RideParameters()
+        rideParameters.source = RideRequestButton.sourceString
         let requestingBehavior = DeeplinkRequestingBehavior()
         
         let appStoreDeeplink = requestingBehavior.createAppStoreDeeplink(rideParameters: rideParameters)
@@ -71,8 +72,9 @@ class DeeplinkRequestingBehaviorTests : XCTestCase {
      */
     func testCreateURLWithDeeplinkSource() {
         let expectedUrlString = "https://m.uber.com/sign-up?client_id=\(clientID)&user-agent=\(expectedDeeplinkUserAgent!)"
-        
-        let rideParameters = RideParametersBuilder().setSource(RequestDeeplink.sourceString).build()
+
+        let rideParameters = RideParameters()
+        rideParameters.source = RequestDeeplink.sourceString
         let requestingBehavior = DeeplinkRequestingBehavior()
         
         let appStoreDeeplink = requestingBehavior.createAppStoreDeeplink(rideParameters: rideParameters)
@@ -86,7 +88,8 @@ class DeeplinkRequestingBehaviorTests : XCTestCase {
     }
     
     func testRequestRideExecutesDeeplink() {
-        let rideParameters = RideParametersBuilder().setSource(RideRequestButton.sourceString).build()
+        let rideParameters = RideParameters()
+        rideParameters.source = RideRequestButton.sourceString
         let expectation = self.expectation(description: "Deeplink executed")
         let testClosure:((URL?) -> (Bool)) = { _ in
             expectation.fulfill()

--- a/source/UberRidesTests/RequestButtonTests.swift
+++ b/source/UberRidesTests/RequestButtonTests.swift
@@ -90,10 +90,10 @@ class RequestButtonTests: XCTestCase {
         }
         let baseViewController = UIViewControllerMock()
         let requestBehavior = RideRequestViewRequestingBehavior(presentingViewController: baseViewController)
-        let button = RideRequestButton(rideParameters: RideParametersBuilder().build(), requestingBehavior: requestBehavior)
+        let button = RideRequestButton(rideParameters: RideParameters(), requestingBehavior: requestBehavior)
     
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier)
-        let rideRequestVC = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
+        let rideRequestVC = RideRequestViewController(rideParameters: RideParameters(), loginManager: loginManger)
         XCTAssertNotNil(rideRequestVC.view)
         
         let webViewMock = WebViewMock(frame: CGRect.zero, configuration: WKWebViewConfiguration(), testClosure: expectationClosure)
@@ -135,7 +135,7 @@ class RequestButtonTests: XCTestCase {
         }
         
         let requestBehavior = DeeplinkRequestingBehaviorMock(testClosure: expectationClosure)
-        let button = RideRequestButton(rideParameters: RideParametersBuilder().build(), requestingBehavior: requestBehavior)
+        let button = RideRequestButton(rideParameters: RideParameters(), requestingBehavior: requestBehavior)
     
         button.uberButtonTapped(button)
         
@@ -148,7 +148,8 @@ class RequestButtonTests: XCTestCase {
      Test that product ID is set on metadata.
      */
     func testSetProductID() {
-        let rideParams = RideParametersBuilder().setProductID(productID).build()
+        let rideParams = RideParameters()
+        rideParams.productID = productID
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.loadRideInformation()
         XCTAssertEqual(button.metadata.productID, productID)
@@ -159,7 +160,7 @@ class RequestButtonTests: XCTestCase {
      */
     func testSetPickupLocation() {
         let location = CLLocation(latitude: pickupLat, longitude: pickupLong)
-        let rideParams = RideParametersBuilder().setPickupLocation(location).build()
+        let rideParams = RideParameters(pickupLocation: location, dropoffLocation: nil)
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.loadRideInformation()
         XCTAssertEqual(button.metadata.pickupLatitude, pickupLat)
@@ -171,7 +172,7 @@ class RequestButtonTests: XCTestCase {
      */
     func testSetDropoffLocation() {
         let location = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParams = RideParametersBuilder().setDropoffLocation(location).build()
+        let rideParams = RideParameters(pickupLocation: nil, dropoffLocation: location)
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.loadRideInformation()
         XCTAssertEqual(button.metadata.dropoffLatitude, dropoffLat)
@@ -189,7 +190,8 @@ class RequestButtonTests: XCTestCase {
         expectation = expectation(description: "information loaded")
         
         let location = CLLocation(latitude: dropoffLat, longitude: pickupLong)
-        let rideParams = RideParametersBuilder().setPickupLocation(location).setProductID(productID).build()
+        let rideParams = RideParameters(pickupLocation: location, dropoffLocation: nil)
+        rideParams.productID = productID
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.delegate = self
         button.loadRideInformation()
@@ -219,7 +221,8 @@ class RequestButtonTests: XCTestCase {
         expectation = expectation(description: "information loaded")
         let pickupLocation = CLLocation(latitude: pickupLat, longitude: pickupLong)
         let dropoffLocation = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParams = RideParametersBuilder().setProductID(productID).setPickupLocation(pickupLocation).setDropoffLocation(dropoffLocation).build()
+        let rideParams = RideParameters(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation)
+        rideParams.productID = productID
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.delegate = self
         button.loadRideInformation()
@@ -247,7 +250,8 @@ class RequestButtonTests: XCTestCase {
         errorExpectation = expectation(description: "price estimate error")
         let pickupLocation = CLLocation(latitude: pickupLat, longitude: pickupLong)
         let dropoffLocation = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParams = RideParametersBuilder().setProductID(productID).setPickupLocation(pickupLocation).setDropoffLocation(dropoffLocation).build()
+        let rideParams = RideParameters(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation)
+        rideParams.productID = productID
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.delegate = self
         button.loadRideInformation()
@@ -276,7 +280,8 @@ class RequestButtonTests: XCTestCase {
         errorExpectation = expectation(description: "time estimate error")
         let pickupLocation = CLLocation(latitude: pickupLat, longitude: pickupLong)
         let dropoffLocation = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParams = RideParametersBuilder().setProductID(productID).setPickupLocation(pickupLocation).setDropoffLocation(dropoffLocation).build()
+        let rideParams = RideParameters(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation)
+        rideParams.productID = productID
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.delegate = self
         button.loadRideInformation()
@@ -306,7 +311,8 @@ class RequestButtonTests: XCTestCase {
 
         let pickupLocation = CLLocation(latitude: pickupLat, longitude: pickupLong)
         let dropoffLocation = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParams = RideParametersBuilder().setProductID(productID).setPickupLocation(pickupLocation).setDropoffLocation(dropoffLocation).build()
+        let rideParams = RideParameters(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation)
+        rideParams.productID = productID
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.delegate = self
         button.loadRideInformation()
@@ -333,7 +339,8 @@ class RequestButtonTests: XCTestCase {
         expectation = expectation(description: "information loaded")
         let pickupLocation = CLLocation(latitude: pickupLat, longitude: pickupLong)
         let dropoffLocation = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParams = RideParametersBuilder().setProductID(productID).setPickupLocation(pickupLocation).setDropoffLocation(dropoffLocation).build()
+        let rideParams = RideParameters(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation)
+        rideParams.productID = productID
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.delegate = self
         button.loadRideInformation()
@@ -360,7 +367,8 @@ class RequestButtonTests: XCTestCase {
         expectation = expectation(description: "information loaded")
         let pickupLocation = CLLocation(latitude: pickupLat, longitude: pickupLong)
         let dropoffLocation = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParams = RideParametersBuilder().setProductID(productID).setPickupLocation(pickupLocation).setDropoffLocation(dropoffLocation).build()
+        let rideParams = RideParameters(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation)
+        rideParams.productID = productID
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.delegate = self
         button.loadRideInformation()
@@ -376,7 +384,8 @@ class RequestButtonTests: XCTestCase {
         errorExpectation = expectation(description: "Expected to receive 422 error")
         let pickupLocation = CLLocation(latitude: pickupLat, longitude: pickupLong)
         let dropoffLocation = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParams = RideParametersBuilder().setProductID(productID).setPickupLocation(pickupLocation).setDropoffLocation(dropoffLocation).build()
+        let rideParams = RideParameters(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation)
+        rideParams.productID = productID
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.delegate = self
         button.client = nil
@@ -396,7 +405,8 @@ class RequestButtonTests: XCTestCase {
     func testMissingPickupTriggersErrorDelegate() {
         errorExpectation = expectation(description: "Expected to receive 422 error")
         let dropoffLocation = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParams = RideParametersBuilder().setProductID(productID).setDropoffLocation(dropoffLocation).build()
+        let rideParams = RideParameters(pickupLocation: nil, dropoffLocation: dropoffLocation)
+        rideParams.productID = productID
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.delegate = self
         button.loadRideInformation()
@@ -415,7 +425,8 @@ class RequestButtonTests: XCTestCase {
     func testUseCurrentLocationTriggersErrorDelegate() {
         errorExpectation = expectation(description: "Expected to receive 422 error")
         let dropoffLocation = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParams = RideParametersBuilder().setProductID(productID).setDropoffLocation(dropoffLocation).setPickupToCurrentLocation().build()
+        let rideParams = RideParameters(pickupLocation: nil, dropoffLocation: dropoffLocation)
+        rideParams.productID = productID
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.delegate = self
         button.loadRideInformation()
@@ -437,7 +448,7 @@ class RequestButtonTests: XCTestCase {
     func testMetadataSimpleWithNoProductID() {
         let pickupLocation = CLLocation(latitude: pickupLat, longitude: pickupLong)
         let dropoffLocation = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParams = RideParametersBuilder().setPickupLocation(pickupLocation).setDropoffLocation(dropoffLocation).build()
+        let rideParams = RideParameters(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation)
         button = RideRequestButton(client: client, rideParameters:rideParams, requestingBehavior: DeeplinkRequestingBehavior())
         button.loadRideInformation()
         

--- a/source/UberRidesTests/RequestDeeplinkTests.swift
+++ b/source/UberRidesTests/RequestDeeplinkTests.swift
@@ -105,7 +105,7 @@ class UberRidesDeeplinkTests: XCTestCase {
      */
     func testBuildDeeplinkWithPickupLatLng() {
         let location = CLLocation(latitude: pickupLat, longitude: pickupLong)
-        let rideParams = RideParametersBuilder().setPickupLocation(location).build()
+        let rideParams = RideParameters(pickupLocation: location, dropoffLocation: nil)
         let deeplink = RequestDeeplink(rideParameters: rideParams)
         
         let components = URLComponents(url: deeplink.deeplinkURL, resolvingAgainstBaseURL: false)
@@ -124,7 +124,9 @@ class UberRidesDeeplinkTests: XCTestCase {
      */
     func testBuildDeeplinkWithAllPickupParameters() {
         let location = CLLocation(latitude: pickupLat, longitude: pickupLong)
-        let rideParams = RideParametersBuilder().setPickupLocation(location, nickname: pickupNickname, address: pickupAddress).build()
+        let rideParams = RideParameters(pickupLocation: location, dropoffLocation: nil)
+        rideParams.pickupNickname = pickupNickname
+        rideParams.pickupAddress = pickupAddress
         let deeplink = RequestDeeplink(rideParameters: rideParams)
         
         let components = URLComponents(url: deeplink.deeplinkURL, resolvingAgainstBaseURL: false)
@@ -145,7 +147,7 @@ class UberRidesDeeplinkTests: XCTestCase {
      */
     func testBuildDeeplinkWithoutPickupParameters() {
         let location = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParams = RideParametersBuilder().setDropoffLocation(location).build()
+        let rideParams = RideParameters(pickupLocation: nil, dropoffLocation: location)
         let deeplink = RequestDeeplink(rideParameters: rideParams)
         
         let components = URLComponents(url: deeplink.deeplinkURL, resolvingAgainstBaseURL: false)
@@ -166,8 +168,12 @@ class UberRidesDeeplinkTests: XCTestCase {
     func testBuildDeeplinkWithAllParameters() {
         let pickupLocation = CLLocation(latitude: pickupLat, longitude: pickupLong)
         let dropoffLocation = CLLocation(latitude: dropoffLat, longitude: dropoffLong)
-        let rideParams = RideParametersBuilder().setProductID(productID).setPickupLocation(pickupLocation, nickname: pickupNickname, address: pickupAddress)
-            .setDropoffLocation(dropoffLocation, nickname: dropoffNickname, address: dropoffAddress).build()
+        let rideParams = RideParameters(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation)
+        rideParams.productID = productID
+        rideParams.pickupNickname = pickupNickname
+        rideParams.pickupAddress = pickupAddress
+        rideParams.dropoffNickname = dropoffNickname
+        rideParams.dropoffAddress = dropoffAddress
         let deeplink = RequestDeeplink(rideParameters: rideParams)
         
         let components = URLComponents(url: deeplink.deeplinkURL, resolvingAgainstBaseURL: false)
@@ -211,7 +217,7 @@ class UberRidesDeeplinkTests: XCTestCase {
             return false
         }
         
-        let deeplink = RequestDeeplinkMock(rideParameters: RideParametersBuilder().build(), testClosure: expectationClosure)
+        let deeplink = RequestDeeplinkMock(rideParameters: RideParameters(), testClosure: expectationClosure)
         
         deeplink.execute()
         

--- a/source/UberRidesTests/RequestURLUtilTests.swift
+++ b/source/UberRidesTests/RequestURLUtilTests.swift
@@ -45,7 +45,7 @@ class RequestURLUtilTests: XCTestCase {
     }
     
     func testCreateQueryParameters_withDefaultRideParameters() {
-        let parameters = RideParametersBuilder().build()
+        let parameters = RideParameters()
         let locationQueryItem = URLQueryItem(name: "pickup", value: "my_location")
         let actionQueryItem = URLQueryItem(name: "action", value: "setPickup")
         let clientIdQueryItem = URLQueryItem(name: "client_id", value: "testClientID")
@@ -90,11 +90,13 @@ class RequestURLUtilTests: XCTestCase {
                                        dropoffLatitudeQueryItem, dropoffLongitudeQueryItem, dropoffNicknameQueryItem, dropoffAddressQueryItem,
                                        productIdQueryItem, clientIdQueryItem, userAgentQueryItem, actionQueryItem]
         
-        var builder = RideParametersBuilder()
-        builder = builder.setPickupLocation(testPickupLocation, nickname: testPickupNickname, address: testPickupAddress)
-        builder = builder.setDropoffLocation(testDropoffLocation, nickname: testDropoffNickname, address: testDropoffAddress)
-        builder = builder.setProductID(testProductID).setSource(testSource)
-        let parameters = builder.build()
+        let parameters = RideParameters(pickupLocation: testPickupLocation, dropoffLocation: testDropoffLocation)
+        parameters.pickupNickname = testPickupNickname
+        parameters.pickupAddress = testPickupAddress
+        parameters.dropoffNickname = testDropoffNickname
+        parameters.dropoffAddress = testDropoffAddress
+        parameters.productID = testProductID
+        parameters.source = testSource
         
         let comparisonSet = NSSet(array: expectedQueryParameters)
         
@@ -131,11 +133,11 @@ class RequestURLUtilTests: XCTestCase {
                                        dropoffLatitudeQueryItem, dropoffLongitudeQueryItem, dropoffAddressQueryItem,
                                        productIdQueryItem, clientIdQueryItem, userAgentQueryItem, actionQueryItem]
         
-        var builder = RideParametersBuilder()
-        builder = builder.setPickupLocation(testPickupLocation, address: testPickupAddress)
-        builder = builder.setDropoffLocation(testDropoffLocation, address: testDropoffAddress)
-        builder = builder.setProductID(testProductID).setSource(testSource)
-        let parameters = builder.build()
+        let parameters = RideParameters(pickupLocation: testPickupLocation, dropoffLocation: testDropoffLocation)
+        parameters.pickupAddress = testPickupAddress
+        parameters.dropoffAddress = testDropoffAddress
+        parameters.productID = testProductID
+        parameters.source = testSource
         
         let comparisonSet = NSSet(array: expectedQueryParameters)
         
@@ -171,12 +173,12 @@ class RequestURLUtilTests: XCTestCase {
         let expectedQueryParameters = [pickupLatitudeQueryItem, pickupLongitudeQueryItem, pickupNicknameQueryItem,
                                        dropoffLatitudeQueryItem, dropoffLongitudeQueryItem, dropoffNicknameQueryItem,
                                        productIdQueryItem, clientIdQueryItem, userAgentQueryItem, actionQueryItem]
-        
-        var builder = RideParametersBuilder()
-        builder = builder.setPickupLocation(testPickupLocation, nickname: testPickupNickname)
-        builder = builder.setDropoffLocation(testDropoffLocation, nickname: testDropoffNickname)
-        builder = builder.setProductID(testProductID).setSource(testSource)
-        let parameters = builder.build()
+
+        let parameters = RideParameters(pickupLocation: testPickupLocation, dropoffLocation: testDropoffLocation)
+        parameters.pickupNickname = testPickupNickname
+        parameters.dropoffNickname = testDropoffNickname
+        parameters.productID = testProductID
+        parameters.source = testSource
         
         let comparisonSet = NSSet(array: expectedQueryParameters)
         
@@ -207,11 +209,12 @@ class RequestURLUtilTests: XCTestCase {
         
         let expectedQueryParameters = [pickupLatitudeQueryItem, pickupLongitudeQueryItem, pickupNicknameQueryItem, pickupAddressQueryItem,
                                        productIdQueryItem, clientIdQueryItem, userAgentQueryItem, actionQueryItem]
-        
-        var builder = RideParametersBuilder()
-        builder = builder.setPickupLocation(testPickupLocation, nickname: testPickupNickname, address: testPickupAddress)
-        builder = builder.setProductID(testProductID).setSource(testSource)
-        let parameters = builder.build()
+
+        let parameters = RideParameters(pickupLocation: testPickupLocation, dropoffLocation: nil)
+        parameters.pickupNickname = testPickupNickname
+        parameters.pickupAddress = testPickupAddress
+        parameters.productID = testProductID
+        parameters.source = testSource
         
         let comparisonSet = NSSet(array: expectedQueryParameters)
         

--- a/source/UberRidesTests/RideParametersTest.swift
+++ b/source/UberRidesTests/RideParametersTest.swift
@@ -28,19 +28,15 @@ class RideParametersTest: XCTestCase {
     private var versionNumber: String?
     private var baseUserAgent: String?
     
-    private var builder: RideParametersBuilder = RideParametersBuilder()
-    
     override func setUp() {
         super.setUp()
-        builder = RideParametersBuilder()
         versionNumber = Bundle(for: RideParameters.self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         baseUserAgent = "rides-ios-v\(versionNumber!)"
     }
     
     func testBuilder_withNoParams() {
-        let params = builder.build()
+        let params = RideParameters()
         XCTAssertNotNil(params)
-        XCTAssertTrue(params.useCurrentLocationForPickup)
         XCTAssertNil(params.pickupLocation)
         XCTAssertNil(params.pickupAddress)
         XCTAssertNil(params.pickupNickname)
@@ -53,9 +49,7 @@ class RideParametersTest: XCTestCase {
     
     func testBuilder_correctUseCurrentLocation() {
         let testPickup = CLLocation(latitude: 32.0, longitude: -32.0)
-        builder = builder.setPickupLocation(testPickup)
-        let params = builder.build()
-        XCTAssertFalse(params.useCurrentLocationForPickup)
+        let params = RideParameters(pickupLocation: testPickup, dropoffLocation: nil)
         XCTAssertEqual(testPickup, params.pickupLocation)
         XCTAssertNil(params.pickupAddress)
         XCTAssertNil(params.pickupNickname)
@@ -79,14 +73,16 @@ class RideParametersTest: XCTestCase {
         let testPaymentID = "test payment id"
         let testSurgeConfirm = "test surge confirm"
         let expectedUserAgent = "\(baseUserAgent!)-\(testSource)"
-        builder = builder.setPickupLocation(testPickupLocation, nickname: testPickupNickname, address: testPickupAddress)
-        builder = builder.setDropoffLocation(testDropoffLocation, nickname: testDropoffNickname, address: testDropoffAddress)
-        builder = builder.setPaymentMethod(testPaymentID)
-        builder = builder.setSurgeConfirmationID(testSurgeConfirm)
-        builder = builder.setProductID(testProductID).setSource(testSource)
-        let params = builder.build()
-        
-        XCTAssertFalse(params.useCurrentLocationForPickup)
+        let params = RideParameters(pickupLocation: testPickupLocation, dropoffLocation: testDropoffLocation)
+        params.pickupNickname = testPickupNickname
+        params.pickupAddress = testPickupAddress
+        params.dropoffNickname = testDropoffNickname
+        params.dropoffAddress = testDropoffAddress
+        params.paymentMethod = testPaymentID
+        params.surgeConfirmationID = testSurgeConfirm
+        params.productID = testProductID
+        params.source = testSource
+
         XCTAssertEqual(params.pickupLocation, testPickupLocation)
         XCTAssertEqual(params.pickupAddress, testPickupAddress)
         XCTAssertEqual(params.pickupNickname, testPickupNickname)
@@ -107,12 +103,11 @@ class RideParametersTest: XCTestCase {
         let testPaymentID = "test payment id"
         let testSurgeConfirm = "test surge confirm"
         let expectedUserAgent = "\(baseUserAgent!)-\(testSource)"
-        builder = builder.setPickupPlaceID(testPickupPlace)
-        builder = builder.setDropoffPlaceID(testDropoffPlace)
-        builder = builder.setPaymentMethod(testPaymentID)
-        builder = builder.setSurgeConfirmationID(testSurgeConfirm)
-        builder = builder.setProductID(testProductID).setSource(testSource)
-        let params = builder.build()
+        let params = RideParameters(pickupPlaceID: testPickupPlace, dropoffPlaceID: testDropoffPlace)
+        params.paymentMethod = testPaymentID
+        params.surgeConfirmationID = testSurgeConfirm
+        params.productID = testProductID
+        params.source = testSource
         
         XCTAssertEqual(params.pickupPlaceID, testPickupPlace)
         XCTAssertEqual(params.dropoffPlaceID, testDropoffPlace)
@@ -122,123 +117,9 @@ class RideParametersTest: XCTestCase {
         XCTAssertNil(params.pickupLocation)
         XCTAssertNil(params.pickupAddress)
         XCTAssertNil(params.pickupNickname)
-        XCTAssertFalse(params.useCurrentLocationForPickup)
         XCTAssertEqual(params.productID, testProductID)
         XCTAssertEqual(params.userAgent, expectedUserAgent)
         XCTAssertEqual(params.paymentMethod, testPaymentID)
         XCTAssertEqual(params.surgeConfirmationID, testSurgeConfirm)
-    }
-    
-    func testBuilder_updateParameter() {
-        let testPickupLocation1 = CLLocation(latitude: 32.0, longitude: -32.0)
-        let testPickupLocation2 = CLLocation(latitude: 62.0, longitude: -62.0)
-        builder = builder.setPickupLocation(testPickupLocation1)
-        builder = builder.setPickupLocation(testPickupLocation2)
-        let params = builder.build()
-        XCTAssertFalse(params.useCurrentLocationForPickup)
-        XCTAssertEqual(params.pickupLocation, testPickupLocation2)
-        XCTAssertNil(params.pickupAddress)
-        XCTAssertNil(params.pickupNickname)
-        XCTAssertNil(params.dropoffLocation)
-        XCTAssertNil(params.dropoffAddress)
-        XCTAssertNil(params.dropoffNickname)
-        XCTAssertNil(params.productID)
-        XCTAssertNil(params.paymentMethod)
-        XCTAssertNil(params.surgeConfirmationID)
-        XCTAssertNil(params.pickupPlaceID)
-        XCTAssertNil(params.dropoffPlaceID)
-        XCTAssertEqual(params.userAgent, baseUserAgent)
-    }
-    
-    func testBuilder_useCurrentLocation() {
-        let testPickupLocation = CLLocation(latitude: 32.0, longitude: -32.0)
-        let testPickupNickname = "testPickup nickname"
-        let testPickupAddress = "123 test pickup st"
-        builder = builder.setPickupLocation(testPickupLocation, nickname: testPickupNickname, address: testPickupAddress)
-        builder = builder.setPickupToCurrentLocation()
-        let params = builder.build()
-        XCTAssertTrue(params.useCurrentLocationForPickup)
-        XCTAssertNil(params.pickupLocation)
-        XCTAssertNil(params.pickupAddress)
-        XCTAssertNil(params.pickupNickname)
-        XCTAssertNil(params.dropoffLocation)
-        XCTAssertNil(params.dropoffAddress)
-        XCTAssertNil(params.dropoffNickname)
-        XCTAssertNil(params.productID)
-        XCTAssertNil(params.paymentMethod)
-        XCTAssertNil(params.surgeConfirmationID)
-        XCTAssertNil(params.pickupPlaceID)
-        XCTAssertNil(params.dropoffPlaceID)
-        XCTAssertEqual(params.userAgent, baseUserAgent)
-    }
-    
-    func testBuilder_withExistingParameters() {
-        var expectedBuilder = RideParametersBuilder()
-        let testPickupLocation = CLLocation(latitude: 32.0, longitude: -32.0)
-        let testDropoffLocation = CLLocation(latitude: 62.0, longitude: -62.0)
-        let testPickupNickname = "testPickup"
-        let testPickupAddress = "123 pickup address"
-        let testDropoffNickname = "testDropoff"
-        let testDropoffAddress = "123 dropoff address"
-        let testProductID = "test ID"
-        let testSource = "test source"
-        let testPaymentID = "test payment id"
-        let testSurgeConfirm = "test surge confirm"
-        
-        expectedBuilder = expectedBuilder.setPickupLocation(testPickupLocation, nickname: testPickupNickname, address: testPickupAddress)
-        expectedBuilder = expectedBuilder.setDropoffLocation(testDropoffLocation, nickname: testDropoffNickname, address: testDropoffAddress)
-        expectedBuilder = expectedBuilder.setPaymentMethod(testPaymentID)
-        expectedBuilder = expectedBuilder.setSurgeConfirmationID(testSurgeConfirm)
-        expectedBuilder = expectedBuilder.setProductID(testProductID).setSource(testSource)
-        let expectedParams = expectedBuilder.build()
-        let params = RideParametersBuilder(rideParameters: expectedParams).build()
-        
-        XCTAssertEqual(params.useCurrentLocationForPickup, expectedParams.useCurrentLocationForPickup)
-        XCTAssertEqual(params.pickupLocation, expectedParams.pickupLocation)
-        XCTAssertEqual(params.pickupAddress, expectedParams.pickupAddress)
-        XCTAssertEqual(params.pickupNickname, expectedParams.pickupNickname)
-        XCTAssertEqual(params.dropoffLocation, expectedParams.dropoffLocation)
-        XCTAssertEqual(params.dropoffAddress, expectedParams.dropoffAddress)
-        XCTAssertEqual(params.dropoffNickname, expectedParams.dropoffNickname)
-        XCTAssertEqual(params.productID, expectedParams.productID)
-        XCTAssertEqual(params.userAgent, expectedParams.userAgent)
-        XCTAssertEqual(params.surgeConfirmationID, expectedParams.surgeConfirmationID)
-        XCTAssertEqual(params.paymentMethod, expectedParams.paymentMethod)
-    }
-    
-    func testBuilder_withPickupPlaceID_hasNoPickupLocation() {
-        var expectedBuilder = RideParametersBuilder()
-        let testPickupLocation = CLLocation(latitude: 32.0, longitude: -32.0)
-        let testPickupNickname = "testPickup"
-        let testPickupAddress = "123 pickup address"
-
-        let testPlaceID = "home"
-        
-        expectedBuilder = expectedBuilder.setPickupLocation(testPickupLocation, nickname: testPickupNickname, address: testPickupAddress)
-        expectedBuilder = expectedBuilder.setPickupPlaceID(testPlaceID)
-        
-        let params = expectedBuilder.build()
-        XCTAssertNil(params.pickupLocation)
-        XCTAssertNil(params.pickupNickname)
-        XCTAssertNil(params.pickupAddress)
-        XCTAssertEqual(params.pickupPlaceID, testPlaceID)
-    }
-    
-    func testBuilder_withDropoffPlaceID_hasNoDropoffLocation() {
-        var expectedBuilder = RideParametersBuilder()
-        let testDropoffLocation = CLLocation(latitude: 32.0, longitude: -32.0)
-        let testDropoffNickname = "testDropoff"
-        let testDropoffAddress = "123 dropoff address"
-        
-        let testPlaceID = "home"
-        
-        expectedBuilder = expectedBuilder.setDropoffLocation(testDropoffLocation, nickname: testDropoffNickname, address: testDropoffAddress)
-        expectedBuilder = expectedBuilder.setDropoffPlaceID(testPlaceID)
-        
-        let params = expectedBuilder.build()
-        XCTAssertNil(params.dropoffLocation)
-        XCTAssertNil(params.dropoffNickname)
-        XCTAssertNil(params.dropoffAddress)
-        XCTAssertEqual(params.dropoffPlaceID, testPlaceID)
     }
 }

--- a/source/UberRidesTests/RideRequestViewControllerTests.swift
+++ b/source/UberRidesTests/RideRequestViewControllerTests.swift
@@ -50,7 +50,7 @@ class RideRequestViewControllerTests: XCTestCase {
             expectation = true
         }
         let loginManager = LoginManager(loginType: .implicit)
-        let rideRequestVC = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManager)
+        let rideRequestVC = RideRequestViewController(rideParameters: RideParameters(), loginManager: loginManager)
         let rideRequestVCDelegateMock = RideRequestViewControllerDelegateMock(testClosure: expectationClosure)
         rideRequestVC.delegate = rideRequestVCDelegateMock
         XCTAssertNotNil(rideRequestVC.view)
@@ -72,7 +72,7 @@ class RideRequestViewControllerTests: XCTestCase {
             _ = TokenManager.deleteToken(identifier: testIdentifier)
         }
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
-        let rideRequestVC = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
+        let rideRequestVC = RideRequestViewController(rideParameters: RideParameters(), loginManager: loginManger)
         rideRequestVC.rideRequestView = RideRequestViewMock(rideRequestView: rideRequestVC.rideRequestView, testClosure: expectationClosure)
         XCTAssertNotNil(rideRequestVC.view)
         rideRequestVC.load()
@@ -91,7 +91,7 @@ class RideRequestViewControllerTests: XCTestCase {
         let testIdentifier = "testAccessTokenIdentifier"
         _ = TokenManager.deleteToken(identifier: testIdentifier)
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
-        let rideRequestVC = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
+        let rideRequestVC = RideRequestViewController(rideParameters: RideParameters(), loginManager: loginManger)
 
         XCTAssertNotNil(rideRequestVC.view)
         XCTAssertNotNil(rideRequestVC.loginView)
@@ -110,7 +110,7 @@ class RideRequestViewControllerTests: XCTestCase {
         let testIdentifier = "testAccessTokenIdentifier"
         _ = TokenManager.deleteToken(identifier: testIdentifier)
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .native)
-        let rideRequestVC = RideRequestViewControllerMock(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
+        let rideRequestVC = RideRequestViewControllerMock(rideParameters: RideParameters(), loginManager: loginManger)
         
         let expectationClosure: () -> () = {
             expectation = true
@@ -134,7 +134,7 @@ class RideRequestViewControllerTests: XCTestCase {
         let testIdentifier = "testAccessTokenIdentifier"
         _ = TokenManager.deleteToken(identifier: testIdentifier)
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .native)
-        let rideRequestVC = RideRequestViewControllerMock(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
+        let rideRequestVC = RideRequestViewControllerMock(rideParameters: RideParameters(), loginManager: loginManger)
         
         let expectationClosure: () -> () = {
             XCTAssertEqual(loginManger.loginType, LoginType.implicit)
@@ -163,7 +163,7 @@ class RideRequestViewControllerTests: XCTestCase {
         
         _ = TokenManager.deleteToken(identifier: testIdentifier)
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .native)
-        let rideRequestVC = RideRequestViewControllerMock(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
+        let rideRequestVC = RideRequestViewControllerMock(rideParameters: RideParameters(), loginManager: loginManger)
         
         let expectationClosure: () -> () = {
             XCTAssertEqual(loginManger.loginType, LoginType.native)
@@ -196,7 +196,7 @@ class RideRequestViewControllerTests: XCTestCase {
         let testIdentifier = "testAccessTokenIdentifier"
         _ = TokenManager.deleteToken(identifier: testIdentifier)
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
-        let rideRequestVC = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
+        let rideRequestVC = RideRequestViewController(rideParameters: RideParameters(), loginManager: loginManger)
         
         XCTAssertNotNil(rideRequestVC.view)
         XCTAssertNotNil(rideRequestVC.loginView)
@@ -218,7 +218,7 @@ class RideRequestViewControllerTests: XCTestCase {
         let testIdentifier = "testAccessTokenIdentifier"
         _ = TokenManager.deleteToken(identifier: testIdentifier)
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
-        let rideRequestVC = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
+        let rideRequestVC = RideRequestViewController(rideParameters: RideParameters(), loginManager: loginManger)
         
         XCTAssertNotNil(rideRequestVC.view)
         XCTAssertNotNil(rideRequestVC.loginView)
@@ -253,7 +253,7 @@ class RideRequestViewControllerTests: XCTestCase {
         let testIdentifier = "testAccessTokenIdentifier"
         _ = TokenManager.deleteToken(identifier: testIdentifier)
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
-        let rideRequestVC = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
+        let rideRequestVC = RideRequestViewController(rideParameters: RideParameters(), loginManager: loginManger)
         
         XCTAssertNotNil(rideRequestVC.view)
         XCTAssertNotNil(rideRequestVC.loginView)
@@ -287,7 +287,7 @@ class RideRequestViewControllerTests: XCTestCase {
         let testIdentifier = "testAccessTokenIdentifier"
         _ = TokenManager.deleteToken(identifier: testIdentifier)
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
-        let rideRequestVC = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
+        let rideRequestVC = RideRequestViewController(rideParameters: RideParameters(), loginManager: loginManger)
         
         XCTAssertNotNil(rideRequestVC.view)
         XCTAssertNotNil(rideRequestVC.loginView)
@@ -325,7 +325,7 @@ class RideRequestViewControllerTests: XCTestCase {
             _ = TokenManager.deleteToken(identifier: testIdentifier)
         }
         let loginManager = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
-        let rideRequestVC = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManager)
+        let rideRequestVC = RideRequestViewController(rideParameters: RideParameters(), loginManager: loginManager)
         let requestViewMock = RideRequestViewMock(rideRequestView: rideRequestVC.rideRequestView, testClosure: loadExpectationClosure)
         rideRequestVC.rideRequestView = requestViewMock
         XCTAssertNotNil(rideRequestVC.view)
@@ -372,7 +372,7 @@ class RideRequestViewControllerTests: XCTestCase {
             _ = TokenManager.deleteToken(identifier: testIdentifier)
         }
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
-        let rideRequestVC = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
+        let rideRequestVC = RideRequestViewController(rideParameters: RideParameters(), loginManager: loginManger)
         XCTAssertNotNil(rideRequestVC.view)
         
         let webViewMock = WebViewMock(frame: CGRect.zero, configuration: WKWebViewConfiguration(), testClosure: expectationClosure)
@@ -399,7 +399,7 @@ class RideRequestViewControllerTests: XCTestCase {
         }
         let loginManager = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
         
-        let rideRequestViewControllerMock = RideRequestViewControllerMock(rideParameters: RideParametersBuilder().build(), loginManager: loginManager, loadClosure: nil, networkClosure: networkClosure, presentViewControllerClosure: nil)
+        let rideRequestViewControllerMock = RideRequestViewControllerMock(rideParameters: RideParameters(), loginManager: loginManager, loadClosure: nil, networkClosure: networkClosure, presentViewControllerClosure: nil)
         
         (rideRequestViewControllerMock as RideRequestViewDelegate).rideRequestView(rideRequestViewControllerMock.rideRequestView, didReceiveError: RideRequestViewErrorFactory.errorForType(.networkError))
         
@@ -417,7 +417,7 @@ class RideRequestViewControllerTests: XCTestCase {
         
         let loginManager = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
         
-        let rideRequestViewControllerMock = RideRequestViewControllerMock(rideParameters: RideParametersBuilder().build(), loginManager: loginManager, loadClosure: nil, networkClosure: networkClosure, presentViewControllerClosure: nil)
+        let rideRequestViewControllerMock = RideRequestViewControllerMock(rideParameters: RideParameters(), loginManager: loginManager, loadClosure: nil, networkClosure: networkClosure, presentViewControllerClosure: nil)
         
         (rideRequestViewControllerMock as RideRequestViewDelegate).rideRequestView(rideRequestViewControllerMock.rideRequestView, didReceiveError: RideRequestViewErrorFactory.errorForType(.networkError))
         
@@ -441,7 +441,7 @@ class RideRequestViewControllerTests: XCTestCase {
         }
         let loginManager = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
         
-        let rideRequestViewControllerMock = RideRequestViewControllerMock(rideParameters: RideParametersBuilder().build(), loginManager: loginManager, loadClosure: nil, networkClosure: nil, presentViewControllerClosure: presentViewControllerClosure)
+        let rideRequestViewControllerMock = RideRequestViewControllerMock(rideParameters: RideParameters(), loginManager: loginManager, loadClosure: nil, networkClosure: nil, presentViewControllerClosure: presentViewControllerClosure)
         
         let loginAuthenticator = LoginViewAuthenticator(presentingViewController: UIViewController(), scopes: [])
         let loginViewMock = LoginViewMock(loginBehavior: loginAuthenticator) { () -> () in
@@ -473,7 +473,7 @@ class RideRequestViewControllerTests: XCTestCase {
         
         let loginManager = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
         
-        let rideRequestViewControllerMock = RideRequestViewControllerMock(rideParameters: RideParametersBuilder().build(), loginManager: loginManager, notSupportedClosure: notSupportedClosure)
+        let rideRequestViewControllerMock = RideRequestViewControllerMock(rideParameters: RideParameters(), loginManager: loginManager, notSupportedClosure: notSupportedClosure)
         
         (rideRequestViewControllerMock as RideRequestViewDelegate).rideRequestView(rideRequestViewControllerMock.rideRequestView, didReceiveError: RideRequestViewErrorFactory.errorForType(.notSupported))
         
@@ -493,7 +493,7 @@ class RideRequestViewControllerTests: XCTestCase {
         
         let loginManager = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
         
-        let rideRequestViewControllerMock = RideRequestViewControllerMock(rideParameters: RideParametersBuilder().build(), loginManager: loginManager, presentViewControllerClosure: presentViewControllerClosure)
+        let rideRequestViewControllerMock = RideRequestViewControllerMock(rideParameters: RideParameters(), loginManager: loginManager, presentViewControllerClosure: presentViewControllerClosure)
         
         (rideRequestViewControllerMock as RideRequestViewDelegate).rideRequestView(rideRequestViewControllerMock.rideRequestView, didReceiveError: RideRequestViewErrorFactory.errorForType(.notSupported))
         
@@ -503,7 +503,7 @@ class RideRequestViewControllerTests: XCTestCase {
     func testNativeLogin_handlesError_whenAccessTokenAndErrorAreNotNil() {
         let testIdentifier = "testAccessTokenIdentifier"
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .native)
-        let rideRequestVC = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
+        let rideRequestVC = RideRequestViewController(rideParameters: RideParameters(), loginManager: loginManger)
         var delegateCalled = false
         let mock = RideRequestViewControllerDelegateMock { (_, _) in
             delegateCalled = true
@@ -523,7 +523,7 @@ class RideRequestViewControllerTests: XCTestCase {
     func testImplicitLogin_handlesError_whenAccessTokenAndErrorAreNotNil() {
         let testIdentifier = "testAccessTokenIdentifier"
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .implicit)
-        let rideRequestVC = RideRequestViewController(rideParameters: RideParametersBuilder().build(), loginManager: loginManger)
+        let rideRequestVC = RideRequestViewController(rideParameters: RideParameters(), loginManager: loginManger)
         var delegateCalled = false
         let mock = RideRequestViewControllerDelegateMock { (_, _) in
             delegateCalled = true

--- a/source/UberRidesTests/RideRequestViewRequestingBehaviorTests.swift
+++ b/source/UberRidesTests/RideRequestViewRequestingBehaviorTests.swift
@@ -65,7 +65,7 @@ class RideRequestViewRequestingBehaviorTests : XCTestCase {
         XCTAssertNotNil(behavior.modalRideRequestViewController)
         XCTAssertNotNil(behavior.modalRideRequestViewController.rideRequestViewController)
         let pickupLocation = CLLocation(latitude: -32.0, longitude: 42.2)
-        let newRideParams = RideParametersBuilder().setPickupLocation(pickupLocation).build()
+        let newRideParams = RideParameters(pickupLocation: pickupLocation, dropoffLocation: nil)
         behavior.requestRide(parameters: newRideParams)
         XCTAssertTrue(behavior.modalRideRequestViewController.rideRequestViewController.rideRequestView.rideParameters === newRideParams)
     }
@@ -97,7 +97,7 @@ class RideRequestViewRequestingBehaviorTests : XCTestCase {
         let baseVC = UIViewControllerMock(testClosure: expectationClosure)
         let initialLoginManger = LoginManager(loginType: .native)
         let behavior = RideRequestViewRequestingBehavior(presentingViewController: baseVC, loginManager: initialLoginManger)
-        behavior.requestRide(parameters: RideParametersBuilder().build())
+        behavior.requestRide(parameters: RideParameters())
         waitForExpectations(timeout: 2.0) {error in
             XCTAssertNil(error)
         }

--- a/source/UberRidesTests/RideRequestViewTests.swift
+++ b/source/UberRidesTests/RideRequestViewTests.swift
@@ -49,7 +49,7 @@ class RideRequestViewTests: XCTestCase {
      */
     func testAccessTokenExpired() {
         testExpectation = expectation(description: "access token expired delegate call")
-        let view = RideRequestView(rideParameters: RideParametersBuilder().build())
+        let view = RideRequestView(rideParameters: RideParameters())
         view.delegate = self
         let request = URLRequest(url: URL(string: "uberConnect://oauth#error=unauthorized")!)
         view.webView.load(request)
@@ -84,7 +84,7 @@ class RideRequestViewTests: XCTestCase {
         let tokenString = "accessToken1234"
         let tokenData = ["access_token" : tokenString]
         let token = AccessToken(JSON: tokenData)
-        let view = RideRequestView(rideParameters: RideParametersBuilder().build(), accessToken: token, frame: CGRect.zero)
+        let view = RideRequestView(rideParameters: RideParameters(), accessToken: token, frame: CGRect.zero)
         XCTAssertNotNil(view.accessToken)
         XCTAssertEqual(view.accessToken, token)
     }
@@ -169,7 +169,7 @@ class RideRequestViewTests: XCTestCase {
             _ = TokenManager.deleteToken(identifier: testIdentifier)
         }
         
-        let rideRequestView = RideRequestView(rideParameters: RideParametersBuilder().build(), accessToken: TokenManager.fetchToken(identifier: testIdentifier), frame: CGRect.zero)
+        let rideRequestView = RideRequestView(rideParameters: RideParameters(), accessToken: TokenManager.fetchToken(identifier: testIdentifier), frame: CGRect.zero)
         XCTAssertNotNil(rideRequestView)
         
         let webViewMock = WebViewMock(frame: CGRect.zero, configuration: WKWebViewConfiguration(), testClosure: expectationClosure)
@@ -188,7 +188,7 @@ class RideRequestViewTests: XCTestCase {
         testExpectation = expectation(description: "Delegate called")
         let cancelRequestExpectation = expectation(description: "Request was cancelled")
         
-        let rideRequestView = RideRequestView(rideParameters: RideParametersBuilder().build(), accessToken:nil, frame:CGRect.zero)
+        let rideRequestView = RideRequestView(rideParameters: RideParameters(), accessToken:nil, frame:CGRect.zero)
         rideRequestView.delegate = self
         let telURLString = "tel:5555555555"
         guard let telURL = URL(string: telURLString) else {

--- a/source/UberRidesTests/RidesClientTests.swift
+++ b/source/UberRidesTests/RidesClientTests.swift
@@ -256,7 +256,7 @@ class RidesClientTests: XCTestCase {
         
         let expectation = self.expectation(description: "make ride request")
         
-        let rideParameters = RideParametersBuilder().setPickupPlaceID("home").build()
+        let rideParameters = RideParameters(pickupPlaceID: "home", dropoffPlaceID: nil)
         client.requestRide(parameters: rideParameters, completion: { ride, response in
             XCTAssertNotNil(ride)
             XCTAssertEqual(ride!.status, RideStatus.processing)
@@ -332,7 +332,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "get request estimate")
-        let rideParams = RideParametersBuilder().setPickupPlaceID("home").build()
+        let rideParams = RideParameters(pickupPlaceID: "home", dropoffPlaceID: nil)
         
         client.fetchRideRequestEstimate(parameters: rideParams, completion:{ estimate, error in
             XCTAssertNotNil(estimate)
@@ -447,7 +447,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
         client.updateRideDetails(requestID: "requestID1234", rideParameters: params, completion: { response in
             XCTAssertNil(response.error)
             XCTAssertEqual(response.statusCode, 204)
@@ -465,7 +465,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
         client.updateRideDetails(requestID: "requestID1234", rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -489,7 +489,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
         client.updateRideDetails(requestID: "requestID1234", rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -513,7 +513,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
         client.updateRideDetails(requestID: "requestID1234", rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -537,7 +537,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
         client.updateCurrentRide(rideParameters: params, completion: { response in
             XCTAssertNil(response.error)
             XCTAssertEqual(response.statusCode, 204)
@@ -555,7 +555,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
         client.updateCurrentRide(rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -579,7 +579,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
         client.updateCurrentRide(rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -603,7 +603,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
         client.updateCurrentRide(rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -627,7 +627,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParametersBuilder().setDropoffPlaceID(Place.Work).build()
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
         client.updateCurrentRide(rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)

--- a/source/UberRidesTests/WidgetsEndpointTests.swift
+++ b/source/UberRidesTests/WidgetsEndpointTests.swift
@@ -65,7 +65,7 @@ class WidgetsEndpointTests: XCTestCase {
             ("pickup[latitude]", "\(expectedLat)" ),
             ("pickup[longitude]", "\(expectedLong)")
         )
-        let rideParameters = RideParametersBuilder().setPickupLocation(CLLocation(latitude: expectedLat, longitude: expectedLong)).build()
+        let rideParameters = RideParameters(pickupLocation: CLLocation(latitude: expectedLat, longitude: expectedLong), dropoffLocation: nil)
         let rideRequestWidget = Components.rideRequestWidget(rideParameters: rideParameters)
         
         XCTAssertEqual(rideRequestWidget.host, expectedHost)


### PR DESCRIPTION
Reduce complexity of the `RideParameters` model by removing the builder associated with it.

`RideParameters` represents the set of parameters sent via a deeplink, ride request widget, or the ride  estimate/request API endpoints. 

In the previous implementation, the primary thing the builder added was to ensure that the `RideParameters` were immutable. However, I don't think there is a huge issue around mutability with this model, and the builder pattern is not super common in Swift anyways. 