### PR TITLE
Migrate to Swift 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: objective-c
 xcode_project: source/UberRides.xcodeproj # path to your xcodeproj folder
 xcode_scheme: UberRides
-osx_image: xcode8.3
+osx_image: xcode9
 before_install:
  - brew install carthage
 install:
  - carthage bootstrap --platform ios
 script:
- - xcodebuild clean build -sdk iphonesimulator -project source/UberRides.xcodeproj -scheme UberRides -destination "OS=8.4,name=iPhone 4S" CODE_SIGNING_REQUIRED=NO test
+ - xcodebuild clean build -sdk iphonesimulator -project source/UberRides.xcodeproj -scheme UberRides -destination "OS=9.3,name=iPhone 4S" CODE_SIGNING_REQUIRED=NO test

--- a/source/UberRides.xcodeproj/project.pbxproj
+++ b/source/UberRides.xcodeproj/project.pbxproj
@@ -655,21 +655,21 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0800;
-				LastUpgradeCheck = 0830;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = Uber;
 				TargetAttributes = {
 					AC0404741BFACD1D00AC1501 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 0900;
 					};
 					AC04047E1BFACD1D00AC1501 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 0900;
 						TestTargetID = DCDD153A1D99A7F20053BC8F;
 					};
 					DCDD153A1D99A7F20053BC8F = {
 						CreatedOnToolsVersion = 8.0;
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Keychain = {
@@ -954,14 +954,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -1005,14 +1011,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -1059,7 +1071,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1080,7 +1092,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.uber.sdk.UberRides;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -1093,7 +1105,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.uber.sdk.UberRidesTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestAppShim.app/TestAppShim";
 			};
 			name = Debug;
@@ -1107,7 +1119,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.uber.sdk.UberRidesTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestAppShim.app/TestAppShim";
 			};
 			name = Release;
@@ -1127,7 +1139,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.uber.sdk.UberRides.TestAppShim;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1146,7 +1158,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.uber.sdk.UberRides.TestAppShim;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/source/UberRides.xcodeproj/xcshareddata/xcschemes/UberRides.xcscheme
+++ b/source/UberRides.xcodeproj/xcshareddata/xcschemes/UberRides.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -55,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/source/UberRides/AppStoreDeeplink.swift
+++ b/source/UberRides/AppStoreDeeplink.swift
@@ -34,7 +34,7 @@ import Foundation
      
      - returns: An initialized AppStoreDeeplink
      */
-    public init(userAgent: String?) {
+    @objc public init(userAgent: String?) {
         let scheme = "https"
         let domain = "m.uber.com"
         let path = "/sign-up"

--- a/source/UberRides/AuthenticationDeeplink.swift
+++ b/source/UberRides/AuthenticationDeeplink.swift
@@ -36,7 +36,7 @@ import Foundation
      
      - returns: An initialized AuthenticationDeeplink
      */
-    public init(scopes: [RidesScope]) {
+    @objc public init(scopes: [RidesScope]) {
         let queryItems = AuthenticationURLUtility.buildQueryParameters(scopes)
         let scheme = "uberauth"
         let domain = "connect"

--- a/source/UberRides/Configuration.swift
+++ b/source/UberRides/Configuration.swift
@@ -84,15 +84,15 @@ private let callbackURIStringKey = "URIString"
 */
 @objc(UBSDKConfiguration) open class Configuration : NSObject {
     // MARK : Variables
-    open static var shared: Configuration = Configuration()
+    @objc open static var shared: Configuration = Configuration()
     
     /// The .plist file to use, default is Info.plist
-    open static var plistName = "Info"
+    @objc open static var plistName = "Info"
     
     /// The bundle that contains the .plist file. Default is the mainBundle()
-    open static var bundle = Bundle.main
+    @objc open static var bundle = Bundle.main
     
-    open var processPool = WKProcessPool()
+    @objc open var processPool = WKProcessPool()
 
     /**
      Gets the client ID of this app. Defaults to the value stored in your Application's
@@ -100,7 +100,7 @@ private let callbackURIStringKey = "URIString"
 
      - returns: The string to use for the Client ID
      */
-    open var clientID: String
+    @objc open var clientID: String
 
     private var callbackURIs = [CallbackURIType: String]()
 
@@ -110,7 +110,7 @@ private let callbackURIStringKey = "URIString"
 
      - returns: The app's name
      */
-    open var appDisplayName: String
+    @objc open var appDisplayName: String
 
     /**
      Gets the Server Token of this app. Defaults to the value stored in your Appication's
@@ -120,7 +120,7 @@ private let callbackURIStringKey = "URIString"
 
      - returns: The string Representing your app's server token
      */
-    open var serverToken: String?
+    @objc open var serverToken: String?
 
     /**
      Gets the default keychain access group to save access tokens to. Advanced setting
@@ -128,7 +128,7 @@ private let callbackURIStringKey = "URIString"
 
      - returns: The default keychain access group to use
      */
-    open var defaultKeychainAccessGroup: String = ""
+    @objc open var defaultKeychainAccessGroup: String = ""
 
     /**
      Gets the default key to use when saving access tokens to the keychain. Defaults
@@ -136,14 +136,14 @@ private let callbackURIStringKey = "URIString"
 
      - returns: The default access token identifier to use
      */
-    open var defaultAccessTokenIdentifier: String = "RidesAccessTokenKey"
+    @objc open var defaultAccessTokenIdentifier: String = "RidesAccessTokenKey"
 
     /**
      Returns if sandbox is enabled or not
 
      - returns: true if Sandbox is enabled, false otherwise
      */
-    open var isSandbox: Bool = false
+    @objc open var isSandbox: Bool = false
 
     /**
      Returns if the fallback to use Authorization Code Grant is enabled. If true,
@@ -152,7 +152,7 @@ private let callbackURIStringKey = "URIString"
 
      - returns: true if fallback enabled, false otherwise
      */
-    open var useFallback: Bool = true
+    @objc open var useFallback: Bool = true
 
     public override init() {
         self.clientID = ""
@@ -174,7 +174,7 @@ private let callbackURIStringKey = "URIString"
     }
     
     /// The current version of the SDK as a string
-    open var sdkVersion: String {
+    @objc open var sdkVersion: String {
         guard let version = Bundle(for: Configuration.self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
             return "Unknown"
         }
@@ -184,7 +184,7 @@ private let callbackURIStringKey = "URIString"
     /**
      Resets all of the Configuration's values to default
      */
-    open static func restoreDefaults() {
+    @objc open static func restoreDefaults() {
         shared = Configuration()
     }
     
@@ -196,7 +196,7 @@ private let callbackURIStringKey = "URIString"
      
      - returns: The string to use for the Callback URI
     */
-    open func getCallbackURIString() -> String {
+    @objc open func getCallbackURIString() -> String {
         return getCallbackURIString(for: .general)
     }
     
@@ -211,7 +211,7 @@ private let callbackURIStringKey = "URIString"
      
      - returns: The callbackURIString for the the requested type
      */
-    open func getCallbackURIString(for type: CallbackURIType) -> String {
+    @objc open func getCallbackURIString(for type: CallbackURIType) -> String {
         if callbackURIs[type] == nil {
             let defaultCallbacks = parseCallbackURIs()
             var fallback = defaultCallbacks[type] ?? callbackURIs[.general]
@@ -235,7 +235,7 @@ private let callbackURIStringKey = "URIString"
      
      - parameter callbackURIString: The callback URI String to use
     */
-    open func setCallbackURIString(_ callbackURIString: String?) {
+    @objc open func setCallbackURIString(_ callbackURIString: String?) {
         setCallbackURIString(callbackURIString, type: .general)
     }
     
@@ -249,7 +249,7 @@ private let callbackURIStringKey = "URIString"
      - parameter callbackURIString: The callback URI String to use
      - parameter type:              The Callback URI Type to use
      */
-    open func setCallbackURIString(_ callbackURIString: String?, type: CallbackURIType) {
+    @objc open func setCallbackURIString(_ callbackURIString: String?, type: CallbackURIType) {
         var callbackURIs = self.callbackURIs
         callbackURIs[type] = callbackURIString
         self.callbackURIs = callbackURIs

--- a/source/UberRides/EndpointsManager.swift
+++ b/source/UberRides/EndpointsManager.swift
@@ -72,7 +72,7 @@ private enum Resources: String {
     case products = "products"
     case request = "requests"
     
-    fileprivate var version: String {
+    private var version: String {
         switch self {
         case .estimates: return "v1"
         case .history: return "v1.2"

--- a/source/UberRides/LoginButton.swift
+++ b/source/UberRides/LoginButton.swift
@@ -58,25 +58,25 @@ import UIKit
     let horizontalCenterPadding: CGFloat = 50
     let loginVerticalPadding: CGFloat = 15
     let loginHorizontalEdgePadding: CGFloat = 15
-    
+
     /// The LoginButtonDelegate for this button
-    open weak var delegate: LoginButtonDelegate?
+    @objc open weak var delegate: LoginButtonDelegate?
     
     /// The LoginManager to use for log in
-    open var loginManager: LoginManager {
+    @objc open var loginManager: LoginManager {
         didSet {
             refreshContent()
         }
     }
     
     /// The RidesScopes to request
-    open var scopes: [RidesScope]
+    @objc open var scopes: [RidesScope]
     
     /// The view controller to present login over. Used
-    open var presentingViewController: UIViewController?
+    @objc open var presentingViewController: UIViewController?
     
     /// The current LoginButtonState of this button (signed in / signed out)
-    open var buttonState: LoginButtonState {
+    @objc open var buttonState: LoginButtonState {
         if let _ = TokenManager.fetchToken(identifier: accessTokenIdentifier, accessGroup: keychainAccessGroup) {
             return .signedIn
         } else {
@@ -94,7 +94,7 @@ import UIKit
     
     private var loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?
     
-    public init(frame: CGRect, scopes: [RidesScope], loginManager: LoginManager) {
+    @objc public init(frame: CGRect, scopes: [RidesScope], loginManager: LoginManager) {
         self.loginManager = loginManager
         self.scopes = scopes
         super.init(frame: frame)
@@ -154,9 +154,9 @@ import UIKit
         uberTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         uberImageView.translatesAutoresizingMaskIntoConstraints = false
         
-        uberImageView.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .horizontal)
-        uberTitleLabel.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .horizontal)
-        uberTitleLabel.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .vertical)
+        uberImageView.setContentHuggingPriority(UILayoutPriority.defaultHigh, for: .horizontal)
+        uberTitleLabel.setContentHuggingPriority(UILayoutPriority.defaultHigh, for: .horizontal)
+        uberTitleLabel.setContentHuggingPriority(UILayoutPriority.defaultHigh, for: .vertical)
         
         let imageLeftConstraint = NSLayoutConstraint(item: uberImageView, attribute: .left, relatedBy: .equal, toItem: self, attribute: .left, multiplier: 1.0, constant: loginHorizontalEdgePadding)
         let imageTopConstraint = NSLayoutConstraint(item: uberImageView, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: loginVerticalPadding)
@@ -168,7 +168,7 @@ import UIKit
         let imagePaddingRightConstraint = NSLayoutConstraint(item: uberTitleLabel, attribute: .left, relatedBy: .greaterThanOrEqual , toItem: uberImageView, attribute: .right, multiplier: 1.0, constant: imageLabelPadding)
         
         let horizontalCenterPaddingConstraint = NSLayoutConstraint(item: uberTitleLabel, attribute: .left, relatedBy: .greaterThanOrEqual , toItem: uberImageView, attribute: .right, multiplier: 1.0, constant: horizontalCenterPadding)
-        horizontalCenterPaddingConstraint.priority = UILayoutPriorityDefaultLow
+        horizontalCenterPaddingConstraint.priority = UILayoutPriority.defaultLow
         
         addConstraints([imageLeftConstraint, imageTopConstraint, imageBottomConstraint])
         addConstraints([titleLabelRightConstraint, titleLabelCenterYConstraint])
@@ -198,7 +198,7 @@ import UIKit
     
     //Mark: Internal Interface
     
-    func uberButtonTapped(_ button: UIButton) {
+    @objc func uberButtonTapped(_ button: UIButton) {
         switch buttonState {
         case .signedIn:
             let success = TokenManager.deleteToken(identifier: accessTokenIdentifier, accessGroup: keychainAccessGroup)

--- a/source/UberRides/ModalRideRequestViewController.swift
+++ b/source/UberRides/ModalRideRequestViewController.swift
@@ -25,7 +25,7 @@
 /// Modal View Controller to use for presenting a RideRequestViewController. Handles errors & closing the modal for you
 @objc(UBSDKModalRideRequestViewController) open class ModalRideRequestViewController : ModalViewController {
     /// The RideRequestViewController this modal is wrapping
-    open internal(set) var rideRequestViewController : RideRequestViewController
+    @objc open internal(set) var rideRequestViewController : RideRequestViewController
     
     /**
      Initializer for the ModalRideRequestViewController. Wraps the provided RideRequestViewController

--- a/source/UberRides/ModalViewController.swift
+++ b/source/UberRides/ModalViewController.swift
@@ -67,9 +67,9 @@ Possible Styles for the ModalViewController
 /// Convenience to wrap a ViewController in a UINavigationController and add the appropriate buttons. Allows you to modally present a view controller w/ Uber branding.
 @objc(UBSDKModalViewController) open class ModalViewController : UIViewController {
     /// The ModalViewControllerDelegate
-    open var delegate: ModalViewControllerDelegate?
+    @objc open var delegate: ModalViewControllerDelegate?
     
-    open var colorStyle: ModalViewControllerColorStyle = .default {
+    @objc open var colorStyle: ModalViewControllerColorStyle = .default {
         didSet {
             setupStyle()
         }
@@ -143,7 +143,7 @@ Possible Styles for the ModalViewController
     /**
      Function to dimiss the modalViewController.
     */
-    open func dismiss() {
+    @objc open func dismiss() {
         self.delegate?.modalViewControllerWillDismiss(self)
         self.dismiss(animated: true, completion: nil)
     }
@@ -160,11 +160,11 @@ Possible Styles for the ModalViewController
     
     //MARK: Button Actions
     
-    func doneButtonPressed(_ button: UIButton) {
+    @objc func doneButtonPressed(_ button: UIButton) {
         dismiss()
     }
     
-    func backButtonPressed(_ button: UIButton) {
+    @objc func backButtonPressed(_ button: UIButton) {
         dismiss()
     }
     

--- a/source/UberRides/Model/DistanceEstimate.swift
+++ b/source/UberRides/Model/DistanceEstimate.swift
@@ -32,13 +32,13 @@ import ObjectMapper
 @objc(UBSDKDistanceEstimate) public class DistanceEstimate: NSObject {
     
     /// Expected activity distance.
-    public fileprivate(set) var distance: Double = 0.0
+    @objc public private(set) var distance: Double = 0.0
     
     /// The unit of distance (mile or km).
-    public fileprivate(set) var distanceUnit: String?
+    @objc public private(set) var distanceUnit: String?
     
     /// Expected activity duration (in seconds).
-    public fileprivate(set) var duration: Int = 0
+    @objc public private(set) var duration: Int = 0
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/Driver.swift
+++ b/source/UberRides/Model/Driver.swift
@@ -32,16 +32,16 @@ import ObjectMapper
 @objc(UBSDKDriver) public class Driver: NSObject {
     
     /// The first name of the driver.
-    public fileprivate(set) var name: String?
+    @objc public private(set) var name: String?
     
     /// The URL to the photo of the driver.
-    public fileprivate(set) var pictureURL: String?
+    @objc public private(set) var pictureURL: String?
     
     /// The formatted phone number for contacting the driver.
-    public fileprivate(set) var phoneNumber: String?
+    @objc public private(set) var phoneNumber: String?
     
     /// The driver's star rating out of 5 stars.
-    public fileprivate(set) var rating: Double = 0.0
+    @objc public private(set) var rating: Double = 0.0
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/PaymentMethod.swift
+++ b/source/UberRides/Model/PaymentMethod.swift
@@ -49,13 +49,13 @@ extension PaymentMethods: UberModel {
 @objc(UBSDKPaymentMethod) public class PaymentMethod: NSObject {
     
     /// The account identification or description associated with the payment method.
-    public fileprivate(set) var paymentDescription: String?
+    @objc public private(set) var paymentDescription: String?
     
     /// Unique identifier of the payment method.
-    public fileprivate(set) var methodID: String?
+    @objc public private(set) var methodID: String?
     
     /// The type of the payment method. See https://developer.uber.com/docs/v1-payment-methods.
-    public fileprivate(set) var type: String?
+    @objc public private(set) var type: String?
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/Place.swift
+++ b/source/UberRides/Model/Place.swift
@@ -30,13 +30,13 @@ import ObjectMapper
 @objc(UBSDKPlace) public class Place: NSObject {
     
     /// Convenience constant for "home" place ID
-    public static let Home = "home"
+    @objc public static let Home = "home"
     
     /// Convenience constant for "work" place ID
-    public static let Work = "work"
+    @objc public static let Work = "work"
     
     /// Fully qualified address of the location.
-    public fileprivate(set) var address: String?
+    @objc public private(set) var address: String?
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/PriceEstimate.swift
+++ b/source/UberRides/Model/PriceEstimate.swift
@@ -49,37 +49,37 @@ extension PriceEstimates: UberModel {
 @objc(UBSDKPriceEstimate) public class PriceEstimate: NSObject {
     
     /// ISO 4217 currency code.
-    public fileprivate(set) var currencyCode: String?
+    @objc public private(set) var currencyCode: String?
     
     /// Expected activity distance (in miles).
-    public fileprivate(set) var distance: Double = 0.0
+    @objc public private(set) var distance: Double = 0.0
     
     /// Expected activity duration (in seconds).
-    public fileprivate(set) var duration: Int = 0
+    @objc public private(set) var duration: Int = 0
     
     /// A formatted string representing the estimate in local currency. Could be range, single number, or "Metered" for TAXI.
-    public fileprivate(set) var estimate: String?
+    @objc public private(set) var estimate: String?
     
     /// Upper bound of the estimated price.
-    public fileprivate(set) var highEstimate: Int = 0
+    @objc public private(set) var highEstimate: Int = 0
     
     /// Lower bound of the estimated price.
-    public fileprivate(set) var lowEstimate: Int = 0
+    @objc public private(set) var lowEstimate: Int = 0
     
     /// Display name of product. Ex: "UberBLACK".
-    public fileprivate(set) var name: String?
+    @objc public private(set) var name: String?
     
     /// Unique identifier representing a specific product for a given latitude & longitude.
-    public fileprivate(set) var productID: String?
+    @objc public private(set) var productID: String?
     
     /// The unique identifier of the surge session for a user. Nil for no surge.
-    public fileprivate(set) var surgeConfirmationID: String?
+    @objc public private(set) var surgeConfirmationID: String?
     
     /// The URL a user must visit to accept surge pricing.
-    public fileprivate(set) var surgeConfirmationURL: String?
+    @objc public private(set) var surgeConfirmationURL: String?
     
     /// Expected surge multiplier (active if surge is greater than 1).
-    public fileprivate(set) var surgeMultiplier: Double = 1.0
+    @objc public private(set) var surgeMultiplier: Double = 1.0
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/Ride.swift
+++ b/source/UberRides/Model/Ride.swift
@@ -32,31 +32,31 @@ import ObjectMapper
 @objc(UBSDKRide) public class Ride: NSObject {
     
     /// Contains the information about the destination of the trip, if one has been set.
-    public fileprivate(set) var destination: RideRequestLocation?
+    @objc public private(set) var destination: RideRequestLocation?
     
     /// The object that contains driver details. Only non-null during an ongoing trip.
-    public fileprivate(set) var driver: Driver?
+    @objc public private(set) var driver: Driver?
     
     /// The object that contains the location information of the vehicle and driver.
-    public fileprivate(set) var driverLocation: RideRequestLocation?
+    @objc public private(set) var driverLocation: RideRequestLocation?
     
     /// The estimated time of vehicle arrival in minutes.
-    public fileprivate(set) var eta: Int = 0
+    @objc public private(set) var eta: Int = 0
     
     /// The object containing the information about the pickup for the trip.
-    public fileprivate(set) var pickup: RideRequestLocation?
+    @objc public private(set) var pickup: RideRequestLocation?
     
     /// The unique ID of the Request.
-    public fileprivate(set) var requestID: String?
+    @objc public private(set) var requestID: String?
     
     /// The status of the Request indicating state.
-    public fileprivate(set) var status: RideStatus = .unknown
+    @objc public private(set) var status: RideStatus = .unknown
     
     /// The surge pricing multiplier used to calculate the increased price of a Request.
-    public fileprivate(set) var surgeMultiplier: Double = 1.0
+    @objc public private(set) var surgeMultiplier: Double = 1.0
     
     /// The object that contains vehicle details. Only non-null during an ongoing trip.
-    public fileprivate(set) var vehicle: Vehicle?
+    @objc public private(set) var vehicle: Vehicle?
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/RideCharge.swift
+++ b/source/UberRides/Model/RideCharge.swift
@@ -32,13 +32,13 @@ import ObjectMapper
 @objc(UBSDKRideCharge) public class RideCharge: NSObject {
     
     /// The amount of the charge.
-    public fileprivate(set) var amount: Float = 0.0
+    @objc public private(set) var amount: Float = 0.0
     
     /// The name of the charge.
-    public fileprivate(set) var name: String?
+    @objc public private(set) var name: String?
     
     /// The type of the charge.
-    public fileprivate(set) var type: String?
+    @objc public private(set) var type: String?
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/RideEstimate.swift
+++ b/source/UberRides/Model/RideEstimate.swift
@@ -32,13 +32,13 @@ import ObjectMapper
 @objc(UBSDKRideEstimate) public class RideEstimate: NSObject {
     
     /// Details of the estimated fare. If end location omitted, only the minimum is returned.
-    public fileprivate(set) var priceEstimate: PriceEstimate?
+    @objc public private(set) var priceEstimate: PriceEstimate?
     
     /// Details of the estimated distance. Nil if end location is omitted.
-    public fileprivate(set) var distanceEstimate: DistanceEstimate?
+    @objc public private(set) var distanceEstimate: DistanceEstimate?
     
     /// The estimated time of vehicle arrival in minutes. -1 if there are no cars available.
-    public fileprivate(set) var pickupEstimate: Int = -1
+    @objc public private(set) var pickupEstimate: Int = -1
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/RideMap.swift
+++ b/source/UberRides/Model/RideMap.swift
@@ -32,10 +32,10 @@ import ObjectMapper
 @objc(UBSDKRideMap) public class RideMap: NSObject {
     
     /// URL to a map representing the requested trip.
-    public fileprivate(set) var path: String?
+    @objc public private(set) var path: String?
     
     /// Unique identifier representing a ride request.
-    public fileprivate(set) var requestID: String?
+    @objc public private(set) var requestID: String?
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/RideParameters.swift
+++ b/source/UberRides/Model/RideParameters.swift
@@ -28,50 +28,50 @@ import MapKit
 @objc(UBSDKRideParameters) public class RideParameters : NSObject {
     
     /// ProductID to use for the ride
-    public var productID: String?
+    @objc public var productID: String?
     
     /// The pickup location to use for the ride
-    public let pickupLocation: CLLocation?
+    @objc public let pickupLocation: CLLocation?
 
     /// The nickname of the pickup location of the ride
-    public var pickupNickname: String?
+    @objc public var pickupNickname: String?
     
     /// The address of the pickup location of the ride
-    public var pickupAddress: String?
+    @objc public var pickupAddress: String?
     
     /// This is the name of an Uber saved place. Only “home” or “work” is acceptable.
-    public let pickupPlaceID: String?
+    @objc public let pickupPlaceID: String?
     
     /// The dropoff location to use for the ride
-    public let dropoffLocation: CLLocation?
+    @objc public let dropoffLocation: CLLocation?
     
     /// The nickname of the dropoff location for the ride
-    public var dropoffNickname: String?
+    @objc public var dropoffNickname: String?
     
     /// The adress of the dropoff location of the ride
-    public var dropoffAddress: String?
+    @objc public var dropoffAddress: String?
     
     /// This is the name of an Uber saved place. Only “home” or “work” is acceptable.
-    public let dropoffPlaceID: String?
+    @objc public let dropoffPlaceID: String?
     
     /// The unique identifier of the payment method selected by a user.
-    public var paymentMethod: String?
+    @objc public var paymentMethod: String?
     
     /// The unique identifier of the surge session for a user.
-    public var surgeConfirmationID: String?
+    @objc public var surgeConfirmationID: String?
 
     /// The source to use for attributing the ride
-    public var source: String?
+    @objc public var source: String?
 
     convenience public override init() {
         self.init(pickupLocation: nil, dropoffLocation: nil, pickupPlaceID: nil, dropoffPlaceID: nil)
     }
 
-    convenience public init(pickupLocation: CLLocation?, dropoffLocation: CLLocation?) {
+    @objc convenience public init(pickupLocation: CLLocation?, dropoffLocation: CLLocation?) {
         self.init(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation, pickupPlaceID: nil, dropoffPlaceID: nil)
     }
 
-    convenience public init(pickupPlaceID: String?, dropoffPlaceID: String?) {
+    @objc convenience public init(pickupPlaceID: String?, dropoffPlaceID: String?) {
         self.init(pickupLocation: nil, dropoffLocation: nil, pickupPlaceID: pickupPlaceID, dropoffPlaceID: dropoffPlaceID)
     }
 

--- a/source/UberRides/Model/RideReceipt.swift
+++ b/source/UberRides/Model/RideReceipt.swift
@@ -32,40 +32,40 @@ import ObjectMapper
 @objc(UBSDKRideReceipt) public class RideReceipt: NSObject {
     
     /// Adjustments made to the charges such as promotions, and fees.
-    public fileprivate(set) var chargeAdjustments: [RideCharge]?
+    @objc public private(set) var chargeAdjustments: [RideCharge]?
     
     /// Describes the charges made against the rider.
-    public fileprivate(set) var charges: [RideCharge]?
+    @objc public private(set) var charges: [RideCharge]?
     
     /// ISO 4217
-    public fileprivate(set) var currencyCode: String?
+    @objc public private(set) var currencyCode: String?
     
     /// Distance of the trip charged.
-    public fileprivate(set) var distance: String?
+    @objc public private(set) var distance: String?
     
     /// The localized unit of distance.
-    public fileprivate(set) var distanceLabel: String?
+    @objc public private(set) var distanceLabel: String?
     
     /// Time duration of the trip in ISO 8601 HH:MM:SS format.
-    public fileprivate(set) var duration: String?
+    @objc public private(set) var duration: String?
     
     /// The summation of the charges array.
-    public fileprivate(set) var normalFare: String?
+    @objc public private(set) var normalFare: String?
     
     /// Unique identifier representing a Request.
-    public fileprivate(set) var requestID: String?
+    @objc public private(set) var requestID: String?
     
     /// The summation of the normal fare and surge charge amount.
-    public fileprivate(set) var subtotal: String?
+    @objc public private(set) var subtotal: String?
     
     /// Describes the surge charge. May be null if surge pricing was not in effect.
-    public fileprivate(set) var surgeCharge: RideCharge?
+    @objc public private(set) var surgeCharge: RideCharge?
     
     /// The total amount charged to the users payment method. This is the the subtotal (split if applicable) with taxes included.
-    public fileprivate(set) var totalCharged: String?
+    @objc public private(set) var totalCharged: String?
     
     /// The total amount still owed after attempting to charge the user. May be 0 if amount was paid in full.
-    public fileprivate(set) var totalOwed: Double = 0.0
+    @objc public private(set) var totalOwed: Double = 0.0
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/RideRequestLocation.swift
+++ b/source/UberRides/Model/RideRequestLocation.swift
@@ -32,16 +32,16 @@ import ObjectMapper
 @objc(UBSDKRideRequestLocation) public class RideRequestLocation: NSObject {
     
     /// The current bearing in degrees for a moving location.
-    public fileprivate(set) var bearing: Int = 0
+    @objc public private(set) var bearing: Int = 0
     
     /// ETA is only available when the trips is accepted or arriving.
-    public fileprivate(set) var eta: Int = 0
+    @objc public private(set) var eta: Int = 0
     
     /// The latitude of the location.
-    public fileprivate(set) var latitude: Double = 0
+    @objc public private(set) var latitude: Double = 0
     
     /// The longitude of the location.
-    public fileprivate(set) var longitude: Double = 0
+    @objc public private(set) var longitude: Double = 0
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/RidesError.swift
+++ b/source/UberRides/Model/RidesError.swift
@@ -29,19 +29,19 @@ import ObjectMapper
 /// Base class for errors that can be mapped from HTTP responses.
 @objc(UBSDKRidesError) public class RidesError : NSObject {
     /// HTTP status code for error.
-    public internal(set) var status: Int = -1
+    @objc public internal(set) var status: Int = -1
     
     /// Human readable message which corresponds to the client error.
-    public internal(set) var title: String?
+    @objc public internal(set) var title: String?
     
     /// Underscore delimited string.
-    public internal(set) var code: String?
+    @objc public internal(set) var code: String?
     
     /// Additional information about errors. Can be "fields" or "meta" as the key.
-    public internal(set) var meta: [String: AnyObject]?
+    @objc public internal(set) var meta: [String: AnyObject]?
     
     /// List of additional errors. This can be populated instead of status/code/title.
-    public internal(set) var errors: [RidesError]?
+    @objc public internal(set) var errors: [RidesError]?
 
     override init() {
     }
@@ -51,7 +51,7 @@ import ObjectMapper
     /// - parameter status: The Status code to use for this error
     /// - parameter code:   The underscore delimited code string to use for this error
     /// - parameter title:  Human readable message which corresponds to this error
-    public convenience init(status: Int, code: String?, title: String?) {
+    @objc public convenience init(status: Int, code: String?, title: String?) {
         self.init()
         self.status = status
         self.code = code

--- a/source/UberRides/Model/RidesScope.swift
+++ b/source/UberRides/Model/RidesScope.swift
@@ -99,13 +99,13 @@ import UIKit
  */
 @objc(UBSDKRidesScope) open class RidesScope : NSObject {
     /// The RidesScopeType of this RidesScope
-    open let ridesScopeType: RidesScopeType
+    @objc open let ridesScopeType: RidesScopeType
     /// The ScopeType of this RidesScope (General / Privileged)
-    open let scopeType : ScopeType
+    @objc open let scopeType : ScopeType
     /// The String raw value of the scope
-    open let rawValue : String
+    @objc open let rawValue : String
     
-    public init(ridesScopeType: RidesScopeType) {
+    @objc public init(ridesScopeType: RidesScopeType) {
         self.ridesScopeType = ridesScopeType
         scopeType = ridesScopeType.type
         rawValue = ridesScopeType.toString()
@@ -124,28 +124,28 @@ import UIKit
     }
     
     /// Convenience variable for the AllTrips scope
-    public static let AllTrips = RidesScope(ridesScopeType: .allTrips)
+    @objc public static let AllTrips = RidesScope(ridesScopeType: .allTrips)
     
     /// Convenience variable for the History scope
-    public static let History = RidesScope(ridesScopeType: .history)
+    @objc public static let History = RidesScope(ridesScopeType: .history)
     
     /// Convenience variable for the HistoryLite scope
-    public static let HistoryLite = RidesScope(ridesScopeType: .historyLite)
+    @objc public static let HistoryLite = RidesScope(ridesScopeType: .historyLite)
     
     /// Convenience variable for the Places scope
-    public static let Places = RidesScope(ridesScopeType: .places)
+    @objc public static let Places = RidesScope(ridesScopeType: .places)
     
     /// Convenience variable for the Profile scope
-    public static let Profile = RidesScope(ridesScopeType: .profile)
+    @objc public static let Profile = RidesScope(ridesScopeType: .profile)
     
     /// Convenience variable for the Request scope
-    public static let Request = RidesScope(ridesScopeType: .request)
+    @objc public static let Request = RidesScope(ridesScopeType: .request)
     
     /// Convenience variable for the RequestReceipt scope
-    public static let RequestReceipt = RidesScope(ridesScopeType: .requestReceipt)
+    @objc public static let RequestReceipt = RidesScope(ridesScopeType: .requestReceipt)
     
     /// Convenience variable for the RideWidgets scope
-    public static let RideWidgets = RidesScope(ridesScopeType: .rideWidgets)
+    @objc public static let RideWidgets = RidesScope(ridesScopeType: .rideWidgets)
     
 }
 

--- a/source/UberRides/Model/TimeEstimate.swift
+++ b/source/UberRides/Model/TimeEstimate.swift
@@ -48,13 +48,13 @@ extension TimeEstimates: UberModel {
 */
 @objc(UBSDKTimeEstimate) public class TimeEstimate: NSObject {
     /// Unique identifier representing a specific product for a given latitude & longitude.
-    public fileprivate(set) var productID: String?
+    @objc public private(set) var productID: String?
     
     /// Display name of product. Ex: "UberBLACK".
-    public fileprivate(set) var name: String?
+    @objc public private(set) var name: String?
     
     /// ETA for the product (in seconds).
-    public fileprivate(set) var estimate: Int = 0
+    @objc public private(set) var estimate: Int = 0
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/UberProduct.swift
+++ b/source/UberRides/Model/UberProduct.swift
@@ -49,22 +49,22 @@ extension UberProducts: UberModel {
 */
 @objc(UBSDKUberProduct) public class UberProduct: NSObject {
     /// Unique identifier representing a specific product for a given latitude & longitude.
-    public fileprivate(set) var productID: String?
+    @objc public private(set) var productID: String?
     
     /// Display name of product. Ex: "UberBLACK".
-    public fileprivate(set) var name: String?
+    @objc public private(set) var name: String?
     
     /// Description of product. Ex: "The original Uber".
-    public fileprivate(set) var details: String?
+    @objc public private(set) var details: String?
     
     /// Capacity of product. Ex: 4, for a product that fits 4.
-    public fileprivate(set) var capacity: Int = 0
+    @objc public private(set) var capacity: Int = 0
     
     /// Path of image URL representing the product.
-    public fileprivate(set) var imagePath: String?
+    @objc public private(set) var imagePath: String?
     
     /// The basic price details. See `PriceDetails` for structure.
-    public fileprivate(set) var priceDetails: PriceDetails?
+    @objc public private(set) var priceDetails: PriceDetails?
     
     /// Specifies whether this product allows for the pickup and dropoff of other riders during the trip.
     public fileprivate(set) var shared: Bool = false
@@ -92,28 +92,28 @@ extension UberProduct : UberModel {
 */
 @objc(UBSDKPriceDetails) public class PriceDetails : NSObject {
     /// Unit of distance used to calculate fare (mile or km).
-    public fileprivate(set) var distanceUnit: String?
+    @objc public private(set) var distanceUnit: String?
     
     /// ISO 4217 currency code.
-    public fileprivate(set) var currencyCode: String?
+    @objc public private(set) var currencyCode: String?
     
     /// The charge per minute (if applicable).
-    public fileprivate(set) var costPerMinute: Double = -1
+    @objc public private(set) var costPerMinute: Double = -1
     
     /// The charge per distance unit (if applicable).
-    public fileprivate(set) var costPerDistance: Double = -1
+    @objc public private(set) var costPerDistance: Double = -1
     
     /// The base price.
-    public fileprivate(set) var baseFee: Double = 0
+    @objc public private(set) var baseFee: Double = 0
     
     /// The minimum price of a trip.
-    public fileprivate(set) var minimumFee: Double = 0
+    @objc public private(set) var minimumFee: Double = 0
     
     /// The fee if a rider cancels the trip after a grace period.
-    public fileprivate(set) var cancellationFee: Double = 0
+    @objc public private(set) var cancellationFee: Double = 0
     
     /// Array containing additional fees added to the price. See `ServiceFee`.
-    public fileprivate(set) var serviceFees: [ServiceFee]?
+    @objc public private(set) var serviceFees: [ServiceFee]?
     
     public required init?(map: Map) {
     }
@@ -139,10 +139,10 @@ extension PriceDetails : Mappable {
 */
 public class ServiceFee : NSObject {
     /// The name of the service fee.
-    public fileprivate(set) var name: String?
+    @objc public private(set) var name: String?
     
     /// The amount of the service fee.
-    public fileprivate(set) var fee: Double = 0.0
+    @objc public private(set) var fee: Double = 0.0
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/UserActivity.swift
+++ b/source/UberRides/Model/UserActivity.swift
@@ -31,16 +31,16 @@ import ObjectMapper
 */
 @objc(UBSDKTripHistory) public class TripHistory: NSObject {
     /// Position in pagination.
-    public fileprivate(set) var offset: Int = 0
+    @objc public private(set) var offset: Int = 0
     
     /// Number of items retrieved.
-    public fileprivate(set) var limit: Int = 0
+    @objc public private(set) var limit: Int = 0
     
     /// Total number of items available.
-    public fileprivate(set) var count: Int = 0
+    @objc public private(set) var count: Int = 0
     
     /// Array of trip information.
-    public fileprivate(set) var history: [UserActivity]?
+    @objc public private(set) var history: [UserActivity]?
     
     public required init?(map: Map) {
     }
@@ -62,28 +62,28 @@ extension TripHistory: UberModel {
 */
 @objc(UBSDKUserActivity) public class UserActivity: NSObject {
     /// Status of the activity. Only returns completed for now.
-    public fileprivate(set) var status: RideStatus?
+    public private(set) var status: RideStatus?
     
     /// Length of activity in miles.
-    public fileprivate(set) var distance: Float = 0.0
+    @objc public private(set) var distance: Float = 0.0
     
     /// Represents timestamp of activity request time in current locale.
-    public fileprivate(set) var requestTime: Date?
+    @objc public private(set) var requestTime: Date?
     
     /// Represents timestamp of activity start time in current locale.
-    public fileprivate(set) var startTime: Date?
+    @objc public private(set) var startTime: Date?
     
     /// Represents timestamp of activity end time in current locale.
-    public fileprivate(set) var endTime: Date?
+    @objc public private(set) var endTime: Date?
     
     /// City that activity started in.
-    public fileprivate(set) var startCity: TripCity?
+    @objc public private(set) var startCity: TripCity?
     
     /// Unique activity identifier.
-    public fileprivate(set) var requestID: String?
+    @objc public private(set) var requestID: String?
     
     /// Unique identifier representing a specific product for a given latitude & longitude.
-    public fileprivate(set) var productID: String?
+    @objc public private(set) var productID: String?
     
     public required init?(map: Map) {
     }
@@ -113,13 +113,13 @@ extension UserActivity: UberModel {
 */
 @objc(UBSDKTripCity) public class TripCity : NSObject {
     /// Latitude of city location.
-    public fileprivate(set) var latitude: Float = 0.0
+    @objc public private(set) var latitude: Float = 0.0
     
     /// Longitude of city location.
-    public fileprivate(set) var longitude: Float = 0.0
+    @objc public private(set) var longitude: Float = 0.0
     
     /// Display name of city.
-    public fileprivate(set) var name: String?
+    @objc public private(set) var name: String?
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/UserProfile.swift
+++ b/source/UberRides/Model/UserProfile.swift
@@ -31,22 +31,22 @@ import ObjectMapper
 */
 @objc(UBSDKUserProfile) public class UserProfile: NSObject {
     /// First name of the Uber user.
-    public fileprivate(set) var firstName: String?
+    @objc public private(set) var firstName: String?
     
     /// Last name of the Uber user.
-    public fileprivate(set) var lastName: String?
+    @objc public private(set) var lastName: String?
     
     /// Email address of the Uber user.
-    public fileprivate(set) var email: String?
+    @objc public private(set) var email: String?
     
     /// Image URL of the Uber user.
-    public fileprivate(set) var picturePath: String?
+    @objc public private(set) var picturePath: String?
     
     /// Promo code of the Uber user.
-    public fileprivate(set) var promoCode: String?
+    @objc public private(set) var promoCode: String?
     
     /// Unique identifier of the Uber user.
-    public fileprivate(set) var UUID: String?
+    @objc public private(set) var UUID: String?
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/Model/Vehicle.swift
+++ b/source/UberRides/Model/Vehicle.swift
@@ -32,16 +32,16 @@ import ObjectMapper
 @objc(UBSDKVehicle) public class Vehicle: NSObject {
     
     /// The license plate number of the vehicle.
-    public fileprivate(set) var licensePlate: String?
+    @objc public private(set) var licensePlate: String?
     
     /// The vehicle make or brand.
-    public fileprivate(set) var make: String?
+    @objc public private(set) var make: String?
     
     /// The vehicle model or type.
-    public fileprivate(set) var model: String?
+    @objc public private(set) var model: String?
     
     /// The URL to a stock photo of the vehicle (may be null).
-    public fileprivate(set) var pictureURL: String?
+    @objc public private(set) var pictureURL: String?
     
     public required init?(map: Map) {
     }

--- a/source/UberRides/OAuth/AccessToken.swift
+++ b/source/UberRides/OAuth/AccessToken.swift
@@ -28,16 +28,16 @@ import ObjectMapper
 @objc(UBSDKAccessToken) public class AccessToken: NSObject, NSCoding, UberModel {
     
     /// String containing the bearer token.
-    public private(set) var tokenString: String?
+    @objc public private(set) var tokenString: String?
     
     /// String containing the refresh token.
-    public private(set) var refreshToken: String?
+    @objc public private(set) var refreshToken: String?
     
     /// The expiration date for this access token
-    public private(set) var expirationDate: Date?
+    @objc public private(set) var expirationDate: Date?
     
     /// The scopes this token is valid for
-    public private(set) var grantedScopes: [RidesScope]?
+    @objc public private(set) var grantedScopes: [RidesScope]?
     
     /**
      Initializes an AccessToken with the provided tokenString

--- a/source/UberRides/OAuth/AuthorizationCodeGrantAuthenticator.swift
+++ b/source/UberRides/OAuth/AuthorizationCodeGrantAuthenticator.swift
@@ -25,7 +25,7 @@
 import UIKit
 
 @objc(UBSDKAuthorizationCodeGrantAuthenticator) open class AuthorizationCodeGrantAuthenticator: LoginViewAuthenticator {
-    open var state: String?
+    @objc open var state: String?
     
     @objc public init(presentingViewController: UIViewController, scopes: [RidesScope], state: String?) {
         self.state = state

--- a/source/UberRides/OAuth/BaseAuthenticator.swift
+++ b/source/UberRides/OAuth/BaseAuthenticator.swift
@@ -28,21 +28,21 @@ import UIKit
 @objc(UBSDKBaseAuthenticator) open class BaseAuthenticator: NSObject, UberAuthenticating {
     
     /// Optional identifier for saving the access token in keychain
-    open var accessTokenIdentifier: String?
+    @objc open var accessTokenIdentifier: String?
     
     /// Optional access group for saving the access token in keychain
-    open var keychainAccessGroup: String?
+    @objc open var keychainAccessGroup: String?
     
     /// Completion block for when login has completed
-    open var loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?
+    @objc open var loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?
     
     /// Scopes to request during login
-    open var scopes: [RidesScope]
+    @objc open var scopes: [RidesScope]
     
     /// The Callback URL Type to use for this authentication method
-    open var callbackURIType: CallbackURIType = .general
+    @objc open var callbackURIType: CallbackURIType = .general
     
-    init(scopes: [RidesScope]) {
+    @objc init(scopes: [RidesScope]) {
         self.scopes = scopes
         super.init()
     }

--- a/source/UberRides/OAuth/LoginManager.swift
+++ b/source/UberRides/OAuth/LoginManager.swift
@@ -28,7 +28,7 @@
 @objc(UBSDKLoginManager) open class LoginManager: NSObject, LoginManaging {
     
     /// Optional state to use for explcit grant authorization
-    open var state: String?
+    @objc open var state: String?
     
     var accessTokenIdentifier: String
     var keychainAccessGroup: String
@@ -36,7 +36,7 @@
     var oauthViewController: OAuthViewController?
     var authenticator: UberAuthenticating?
     var loggingIn: Bool = false
-    
+
     /**
     Create instance of login manager to authenticate user and retreive access token.
     

--- a/source/UberRides/OAuth/LoginView.swift
+++ b/source/UberRides/OAuth/LoginView.swift
@@ -28,7 +28,7 @@ import WebKit
 /// Login Web View class. Wrapper around a WKWebView to handle Login flow for Implicit Grant
 @objc(UBSDKLoginView) open class LoginView: UIView {
     
-    open var loginAuthenticator: LoginViewAuthenticator
+    @objc open var loginAuthenticator: LoginViewAuthenticator
     
     var clientID = Configuration.shared.clientID
     let webView: WKWebView
@@ -90,7 +90,7 @@ import WebKit
     /**
     Loads the login page
     */
-    open func load() {
+    @objc open func load() {
         // Create URL for request
         guard let request = Request(session: nil, endpoint: loginAuthenticator.endpoint) else {
             loginAuthenticator.loginCompletion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType:.invalidRequest))
@@ -106,7 +106,7 @@ import WebKit
      Stops loading the login page and clears the view.
      If the login page has already loaded, calling this still clears the view.
      */
-    open func cancelLoad() {
+    @objc open func cancelLoad() {
         webView.stopLoading()
         if let url = URL(string: "about:blank") {
             webView.load(URLRequest(url: url))

--- a/source/UberRides/OAuth/LoginViewAuthenticator.swift
+++ b/source/UberRides/OAuth/LoginViewAuthenticator.swift
@@ -28,7 +28,7 @@ import UIKit
 @objc open class LoginViewAuthenticator: BaseAuthenticator {
     
     /// View controller that will present the login
-    open var presentingViewController: UIViewController
+    @objc open var presentingViewController: UIViewController
     
     /// Endpoint to hit for authorization request.
     var endpoint: UberAPI {

--- a/source/UberRides/OAuth/NativeAuthenticator.swift
+++ b/source/UberRides/OAuth/NativeAuthenticator.swift
@@ -30,7 +30,7 @@ import Foundation
 @objc(UBSSONativeAuthenticator) open class NativeAuthenticator: BaseAuthenticator {
     
     /// The completion block to call when the deeplink is completed. Bool indicates if the deeplink was successful
-    open var deeplinkCompletion: ((NSError?) -> ())?
+    @objc open var deeplinkCompletion: ((NSError?) -> ())?
 
     
     var deeplink: Deeplinking

--- a/source/UberRides/OAuth/OAuthViewController.swift
+++ b/source/UberRides/OAuth/OAuthViewController.swift
@@ -32,7 +32,7 @@ class OAuthViewController: UIViewController {
     
     var hasLoaded = false
     var loginView: LoginView
-    
+
     /**
      Initializes the web view controller with the necessary information.
      
@@ -68,7 +68,7 @@ class OAuthViewController: UIViewController {
         }
     }
     
-    func cancel() {
+    @objc func cancel() {
         self.loginView.loginAuthenticator.loginCompletion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .userCancelled))
         dismiss(animated: true, completion: nil)
     }

--- a/source/UberRides/Request.swift
+++ b/source/UberRides/Request.swift
@@ -27,16 +27,16 @@
 */
 @objc(UBSDKResponse) public class Response: NSObject {
     /// String representing JSON response data.
-    public var data: Data?
+    @objc public var data: Data?
     
     /// HTTP status code of response.
-    public var statusCode: Int
+    @objc public var statusCode: Int
     
     /// Response metadata.
-    public var response: HTTPURLResponse?
+    @objc public var response: HTTPURLResponse?
     
     /// NSError representing an optional error.
-    public var error: RidesError?
+    @objc public var error: RidesError?
     
     /**
      Initialize a Response object.
@@ -45,7 +45,7 @@
      - parameter response: Provides response metadata, such as HTTP headers and status code.
      - parameter error:    Indicates why the request failed, or nil if the request was successful.
      */
-    init(data: Data?, statusCode: Int, response: HTTPURLResponse?, error: RidesError?) {
+    @objc init(data: Data?, statusCode: Int, response: HTTPURLResponse?, error: RidesError?) {
         self.data = data
         self.response = response
         self.statusCode = statusCode

--- a/source/UberRides/RideRequestButton.swift
+++ b/source/UberRides/RideRequestButton.swift
@@ -48,22 +48,22 @@ import CoreLocation
 /// RequestButton implements a button on the touch screen to request a ride.
 @objc(UBSDKRideRequestButton) open class RideRequestButton: UberButton {
     /// Delegate is informed of events that occur with request button.
-    open var delegate: RideRequestButtonDelegate?
+    @objc open var delegate: RideRequestButtonDelegate?
     
     /// The RideParameters object this button will use to make a request
-    open var rideParameters: RideParameters
+    @objc open var rideParameters: RideParameters
     
     /// The RideRequesting object the button will use to make a request
-    open var requestBehavior: RideRequesting
+    @objc open var requestBehavior: RideRequesting
     
     /// The RidesClient used for retrieving metadata for the button.
-    open var client: RidesClient?
+    @objc open var client: RidesClient?
     
     static let sourceString = "button"
     
     var metadata: ButtonMetadata = ButtonMetadata()
     var uberMetadataLabel: UILabel = UILabel()
-    
+
     private let opticalCorrection: CGFloat = 1.0
     
     /**
@@ -208,10 +208,10 @@ import CoreLocation
         let views = ["image": uberImageView, "titleLabel": uberTitleLabel, "metadataLabel": uberMetadataLabel]
         let metrics = ["edgePadding": horizontalEdgePadding, "verticalPadding": verticalPadding, "imageLabelPadding": imageLabelPadding, "middlePadding": horizontalEdgePadding*2]
         
-        uberImageView.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .horizontal)
-        uberTitleLabel.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .horizontal)
-        uberTitleLabel.setContentHuggingPriority(UILayoutPriorityDefaultHigh, for: .vertical)
-        uberMetadataLabel.setContentHuggingPriority(UILayoutPriorityDefaultLow, for: .horizontal)
+        uberImageView.setContentHuggingPriority(UILayoutPriority.defaultHigh, for: .horizontal)
+        uberTitleLabel.setContentHuggingPriority(UILayoutPriority.defaultHigh, for: .horizontal)
+        uberTitleLabel.setContentHuggingPriority(UILayoutPriority.defaultHigh, for: .vertical)
+        uberMetadataLabel.setContentHuggingPriority(UILayoutPriority.defaultLow, for: .horizontal)
         
         let horizontalConstraints: [NSLayoutConstraint] = NSLayoutConstraint.constraints(withVisualFormat: "H:|-edgePadding-[image]-imageLabelPadding-[titleLabel]-middlePadding-[metadataLabel]-edgePadding-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views)
         let verticalConstraints: [NSLayoutConstraint] = NSLayoutConstraint.constraints(withVisualFormat: "V:|-verticalPadding-[image]-verticalPadding-|", options: .alignAllLeading, metrics: metrics, views: views)
@@ -276,7 +276,7 @@ import CoreLocation
     /**
      Manual refresh for the ride information on the button. The product ID must be set in order to show any metadata.
      */
-    open func loadRideInformation() {
+    @objc open func loadRideInformation() {
         guard client != nil else {
             delegate?.rideRequestButton(self, didReceiveError: createValidationFailedError())
             return
@@ -294,7 +294,7 @@ import CoreLocation
     //Mark: Internal Interface
     
     // Initiate deeplink when button is tapped
-    func uberButtonTapped(_ sender: UIButton) {
+    @objc func uberButtonTapped(_ sender: UIButton) {
         rideParameters.source = RideRequestButton.sourceString
         requestBehavior.requestRide(parameters: rideParameters)
     }
@@ -332,14 +332,14 @@ import CoreLocation
                 let paragraphStyle = NSMutableParagraphStyle()
                 paragraphStyle.alignment = .right
                 paragraphStyle.maximumLineHeight = 16
-                attrString.addAttribute(NSParagraphStyleAttributeName, value:paragraphStyle, range:NSMakeRange(0, attrString.length))
+                attrString.addAttribute(NSAttributedStringKey.paragraphStyle, value:paragraphStyle, range:NSMakeRange(0, attrString.length))
             }
             
             attrString.append(NSAttributedString(string: "\(subtitle)"))
         }
         
-        attrString.addAttribute(NSFontAttributeName, value: metadataFont, range: (attrString.string as NSString).range(of: title))
-        attrString.addAttribute(NSFontAttributeName, value: metadataFont, range: (attrString.string as NSString).range(of: subtitle))
+        attrString.addAttribute(NSAttributedStringKey.font, value: metadataFont, range: (attrString.string as NSString).range(of: title))
+        attrString.addAttribute(NSAttributedStringKey.font, value: metadataFont, range: (attrString.string as NSString).range(of: subtitle))
 
         if attrString.string.isEmpty {
             uberTitleLabel.text = LocalizationUtil.localizedString(forKey: "Ride there with Uber", comment: "Request button description")

--- a/source/UberRides/RideRequestView.swift
+++ b/source/UberRides/RideRequestView.swift
@@ -41,13 +41,13 @@ import CoreLocation
 /// A view that shows the embedded Uber experience. 
 @objc(UBSDKRideRequestView) open class RideRequestView: UIView {
     /// The RideRequestViewDelegate of this view.
-    open var delegate: RideRequestViewDelegate?
+    @objc open var delegate: RideRequestViewDelegate?
     
     /// The access token used to authorize the web view
-    open var accessToken: AccessToken?
+    @objc open var accessToken: AccessToken?
     
     /// Ther RideParameters to use for prefilling the RideRequestView
-    open var rideParameters: RideParameters
+    @objc open var rideParameters: RideParameters
     
     var webView: WKWebView
     let redirectURL = "uberconnect://oauth"
@@ -144,7 +144,7 @@ import CoreLocation
      Load the Uber Ride Request Widget view.
      Requires that the access token has been retrieved.
      */
-    open func load() {
+    @objc open func load() {
         guard let accessToken = accessToken else {
             self.delegate?.rideRequestView(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.accessTokenMissing))
             return
@@ -171,7 +171,7 @@ import CoreLocation
      Stop loading the Ride Request Widget View and clears the view.
      If the view has already loaded, calling this still clears the view.
     */
-    open func cancelLoad() {
+    @objc open func cancelLoad() {
         webView.stopLoading()
         if let url = URL(string: "about:blank") {
             webView.load(URLRequest(url: url))
@@ -205,11 +205,11 @@ import CoreLocation
     
     // MARK: Keyboard Notifications
     
-    func keyboardWillAppear(_ notification: Notification) {
+    @objc func keyboardWillAppear(_ notification: Notification) {
         webView.scrollView.isScrollEnabled = false
     }
     
-    func keyboardDidAppear(_ notification: Notification) {
+    @objc func keyboardDidAppear(_ notification: Notification) {
         webView.scrollView.isScrollEnabled = true
     }
 }

--- a/source/UberRides/RideRequestViewController.swift
+++ b/source/UberRides/RideRequestViewController.swift
@@ -43,10 +43,10 @@ import MapKit
 // View controller to wrap the RideRequestView
 @objc (UBSDKRideRequestViewController) open class RideRequestViewController: UIViewController {
     /// The RideRequestViewControllerDelegate to handle the errors
-    open var delegate: RideRequestViewControllerDelegate?
+    @objc open var delegate: RideRequestViewControllerDelegate?
     
     /// The LoginManager to use for managing the login process
-    open var loginManager: LoginManager {
+    @objc open var loginManager: LoginManager {
         didSet {
             accessTokenIdentifier = loginManager.accessTokenIdentifier
             keychainAccessGroup = loginManager.keychainAccessGroup
@@ -56,12 +56,12 @@ import MapKit
     lazy var rideRequestView: RideRequestView = RideRequestView()
     lazy var loginView: LoginView = LoginView(loginAuthenticator: ImplicitGrantAuthenticator(presentingViewController: self, scopes: [.RideWidgets]))
     lazy var nativeAuthenticator = NativeAuthenticator(scopes: [.RideWidgets])
-    
+
     static let sourceString = "ride_request_widget"
-    
-    fileprivate var accessTokenWasUnauthorizedOnPreviousAttempt = false
-    fileprivate var accessTokenIdentifier: String
-    fileprivate var keychainAccessGroup: String
+
+    private var accessTokenWasUnauthorizedOnPreviousAttempt = false
+    private var accessTokenIdentifier: String
+    private var keychainAccessGroup: String
     private var loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?
     
     /**

--- a/source/UberRides/RideRequestViewRequestingBehavior.swift
+++ b/source/UberRides/RideRequestViewRequestingBehavior.swift
@@ -27,14 +27,14 @@
 @objc(UBSDKRideRequestViewRequestingBehavior) open class RideRequestViewRequestingBehavior : NSObject {
     
     /// The UIViewController to present the RideRequestViewController over
-    unowned open var presentingViewController: UIViewController
+    @objc unowned open var presentingViewController: UIViewController
     
     /**
      The LoginManager to use with the RideRequestViewController. Uses the
      accessTokenIdentifier & keychainAccessGroup to get an AccessToken. Will be used
      to log a user in, if necessary
      */
-    open var loginManager: LoginManager {
+    @objc open var loginManager: LoginManager {
         get {
             return self.modalRideRequestViewController.rideRequestViewController.loginManager
         }
@@ -44,7 +44,7 @@
     }
     
     /// The ModalRideRequestViewController that is created by this behavior, only exists after requestRide() is called
-    open internal(set) var modalRideRequestViewController: ModalRideRequestViewController
+    @objc open internal(set) var modalRideRequestViewController: ModalRideRequestViewController
     
     /**
      Creates the RideRequestViewRequestingBehavior with the given presenting view controller.

--- a/source/UberRides/RidesAppDelegate.swift
+++ b/source/UberRides/RidesAppDelegate.swift
@@ -31,11 +31,11 @@
     
     //MARK: Class variables
     
-    open static let shared = RidesAppDelegate()
+    @objc open static let shared = RidesAppDelegate()
     
     //MARK: Public variables
     
-    open var loginManager : LoginManaging?
+    @objc open var loginManager : LoginManaging?
     
     //Mark: NSObject
     
@@ -67,7 +67,7 @@
      communicate information to the receiving app As passed to the corresponding AppDelegate method
      - returns: true if the URL was intended for the Rides SDK, false otherwise
      */
-    open func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
+    @objc open func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
         guard let manager = loginManager else {
             return false
         }
@@ -79,7 +79,7 @@
         return urlHandled
     }
     
-    open func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    @objc open func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
         guard let options = launchOptions, let launchURL = options[UIApplicationLaunchOptionsKey.url] as? URL else {
             return false
         }
@@ -94,7 +94,7 @@
     
     //MARK: Private Methods
     
-    @objc fileprivate func didBecomeActive(_ notification: Notification) {
+    @objc private func didBecomeActive(_ notification: Notification) {
         if let manager = loginManager {
             manager.applicationDidBecomeActive()
             loginManager = nil

--- a/source/UberRides/RidesClient.swift
+++ b/source/UberRides/RidesClient.swift
@@ -30,16 +30,16 @@ import CoreLocation
     
     /// Application client ID. Required for every instance of RidesClient.
     var clientID: String = Configuration.shared.clientID
-    
+
     /// The Access Token Identifier. The identifier to use for looking up this client's accessToken
     let accessTokenIdentifier: String
-    
+
     /// The Keychain Access Group. The access group to use when looking up this client's accessToken
     let keychainAccessGroup: String
-    
+
     /// NSURLSession used to make requests to Uber API. Default session configuration unless otherwise initialized.
     var session: URLSession
-    
+
     /// Developer server token.
     private var serverToken: String? = Configuration.shared.serverToken
     
@@ -509,7 +509,7 @@ import CoreLocation
      - parameter requestID:  unique identifier representing a ride request
      - parameter completion: completion handler for receipt
      */
-    open func fetchRideReceipt(requestID: String, completion:@escaping (_ rideReceipt: RideReceipt?, _ response: Response) -> Void) {
+    @objc open func fetchRideReceipt(requestID: String, completion:@escaping (_ rideReceipt: RideReceipt?, _ response: Response) -> Void) {
         let endpoint = Requests.rideReceipt(requestID: requestID)
         apiCall(endpoint, completion: { response in
             var receipt: RideReceipt?
@@ -526,7 +526,7 @@ import CoreLocation
      - parameter requestID:  unique identifier representing a request
      - parameter completion: completion handler for map
      */
-    open func fetchRideMap(requestID: String, completion:@escaping (_ map: RideMap?, _ response: Response) -> Void) {
+    @objc open func fetchRideMap(requestID: String, completion:@escaping (_ map: RideMap?, _ response: Response) -> Void) {
         let endpoint = Requests.rideMap(requestID: requestID)
         apiCall(endpoint, completion: { response in
             var map: RideMap?
@@ -544,7 +544,7 @@ import CoreLocation
      - parameter refreshToken: The Refresh Token String from an SSO access token
      - parameter completion:   completion handler for the new access token
      */
-    open func refreshAccessToken(usingRefreshToken refreshToken: String, completion:@escaping (_ accessToken: AccessToken?, _ response: Response) -> Void) {
+    @objc open func refreshAccessToken(usingRefreshToken refreshToken: String, completion:@escaping (_ accessToken: AccessToken?, _ response: Response) -> Void) {
         let endpoint = OAuth.refresh(clientID: clientID, refreshToken: refreshToken)
         apiCall(endpoint) { response in
             var accessToken: AccessToken?

--- a/source/UberRides/TokenManager.swift
+++ b/source/UberRides/TokenManager.swift
@@ -27,8 +27,8 @@ import Foundation
 /// Manager class for saving and deleting AccessTokens. Allows you to manage tokens based on token identifier & keychain access group
 @objc(UBSDKTokenManager) public class TokenManager: NSObject {
 
-    public static let tokenManagerDidSaveTokenNotification = "TokenManagerDidSaveTokenNotification"
-    public static let tokenManagerDidDeleteTokenNotification = "TokenManagerDidDeleteTokenNotification"
+    @objc public static let tokenManagerDidSaveTokenNotification = "TokenManagerDidSaveTokenNotification"
+    @objc public static let tokenManagerDidDeleteTokenNotification = "TokenManagerDidDeleteTokenNotification"
     
     private static let keychainWrapper = KeychainWrapper()
 

--- a/source/UberRides/UberButton.swift
+++ b/source/UberRides/UberButton.swift
@@ -62,7 +62,7 @@ import UIKit
      Function responsible for the initial setup of the button. 
      Calls addSubviews(), setContent(), and setConstraints()
      */
-    open func setup() {
+    @objc open func setup() {
         addSubviews()
         setContent()
         setConstraints()
@@ -72,7 +72,7 @@ import UIKit
      Function responsible for adding all the subviews to the button. Subclasses
      should override this method and add any necessary subviews.
      */
-    open func addSubviews() {
+    @objc open func addSubviews() {
         addSubview(uberImageView)
         addSubview(uberTitleLabel)
     }
@@ -81,7 +81,7 @@ import UIKit
      Function responsible for updating content on the button. Subclasses should
      override and do any necessary view setup
      */
-    open func setContent() {
+    @objc open func setContent() {
         clipsToBounds = true
         layer.cornerRadius = cornerRadius
     }
@@ -90,7 +90,7 @@ import UIKit
      Function responsible for adding autolayout constriants on the button. Subclasses
      should override and add any additional autolayout constraints
      */
-    open func setConstraints() {
+    @objc open func setConstraints() {
         
         uberTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         uberImageView.translatesAutoresizingMaskIntoConstraints = false

--- a/source/UberRides/Utilities/RidesUtil.swift
+++ b/source/UberRides/Utilities/RidesUtil.swift
@@ -70,8 +70,8 @@ class FontUtil {
                 var error: Unmanaged<CFError>?
                 let cfdata = CFDataCreate(nil, (inData as NSData).bytes.bindMemory(to: UInt8.self, capacity: inData.count), inData.count)
                 if let provider = CGDataProvider(data: cfdata!) {
-                    let font = CGFont(provider)
-                    if (CTFontManagerRegisterGraphicsFont(font, &error)) {
+                    if let font = CGFont(provider),
+                    (CTFontManagerRegisterGraphicsFont(font, &error)) {
                         return true
                     } else {
                         print("Failed to load font with error: \(error.debugDescription)")


### PR DESCRIPTION
Migrate to Swift 4 using the auto migrator + manual audits of the migration.

The primary impact of Swift 4 on our codebase is that Swift 4 no longer automatically generates Objective-C entry points for subclasses of Objective C objects. Since our codebase is meant to be consumed from Objective-C clients as well as Swift only clients, we need to add `@objc` annotations to tell the compiler to still generate these entry points. 

See:

* https://github.com/apple/swift-evolution/blob/master/proposals/0160-objc-inference.md
* https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160509/017308.html

Also, the `private` access control modifier gained a bit of scope, making `fileprivate` unnecessary for the most part. 

See: 

* https://swifting.io/blog/2017/05/30/43-bye-bye-fileprivate/
* https://github.com/apple/swift-evolution/blob/master/proposals/0169-improve-interaction-between-private-declarations-and-extensions.md