### PR TITLE
Remove ObjectMapper dependency

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "https://github.com/Hearst-DD/ObjectMapper.git" ~> 2.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,1 @@
 github "AliSoftware/OHHTTPStubs" "57feceaabf333e72b2c637dfba6c13a7a5c49619"
-github "Hearst-DD/ObjectMapper" "2.2.2"

--- a/source/UberRides.xcodeproj/project.pbxproj
+++ b/source/UberRides.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3A66B4721D1F38D600B4F181 /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCA459AF1D000813003CBA3D /* ObjectMapper.framework */; };
 		AC0404791BFACD1D00AC1501 /* UberRides.h in Headers */ = {isa = PBXBuildFile; fileRef = AC0404781BFACD1D00AC1501 /* UberRides.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AC0404801BFACD1D00AC1501 /* UberRides.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC0404751BFACD1D00AC1501 /* UberRides.framework */; };
 		AC0404851BFACD1D00AC1501 /* UberRidesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0404841BFACD1D00AC1501 /* UberRidesTests.swift */; };
@@ -69,7 +68,6 @@
 		D8D18E871CBF42AD00055B76 /* postRequests.json in Resources */ = {isa = PBXBuildFile; fileRef = D8D18E861CBF42AD00055B76 /* postRequests.json */; };
 		D8D2DC091C90E54700A65FF0 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D2DC081C90E54700A65FF0 /* UserProfile.swift */; };
 		D8D2DC0B1C90E55900A65FF0 /* getMe.json in Resources */ = {isa = PBXBuildFile; fileRef = D8D2DC0A1C90E55900A65FF0 /* getMe.json */; };
-		D8DAB6371C60240B007DE82C /* ModelMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DAB6361C60240B007DE82C /* ModelMapper.swift */; };
 		D8E2C96C1C62B3B2006091BA /* PriceEstimate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E2C96B1C62B3B2006091BA /* PriceEstimate.swift */; };
 		D8E2C96E1C62B3C7006091BA /* getPriceEstimates.json in Resources */ = {isa = PBXBuildFile; fileRef = D8E2C96D1C62B3C7006091BA /* getPriceEstimates.json */; };
 		DC1039731C96B1CE004854E3 /* RidesScopeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1039721C96B1CE004854E3 /* RidesScopeExtensionsTests.swift */; };
@@ -119,8 +117,6 @@
 		DC92DC041CA38DBE001A0DCC /* WidgetsEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC92DC031CA38DBE001A0DCC /* WidgetsEndpointTests.swift */; };
 		DC92DC061CA3AC59001A0DCC /* OauthEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC92DC051CA3AC59001A0DCC /* OauthEndpointTests.swift */; };
 		DC9C2BCB1CF3FF34007C0FE9 /* LoginManagingProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9C2BCA1CF3FF34007C0FE9 /* LoginManagingProtocol.swift */; };
-		DCA459B21D000861003CBA3D /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCA459AF1D000813003CBA3D /* ObjectMapper.framework */; };
-		DCA459D41D003EFC003CBA3D /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCA459D31D003EFC003CBA3D /* OHHTTPStubs.framework */; };
 		DCAEA98F1CEE4C9C00E6F239 /* RequestURLUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCAEA98E1CEE4C9C00E6F239 /* RequestURLUtilTests.swift */; };
 		DCAEA9911CEE61C400E6F239 /* AuthenticationDeeplink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCAEA9901CEE61C400E6F239 /* AuthenticationDeeplink.swift */; };
 		DCAEA9941CEE91D000E6F239 /* AuthenticationURLUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCAEA9931CEE91D000E6F239 /* AuthenticationURLUtility.swift */; };
@@ -140,6 +136,7 @@
 		DCF87E7B1CF3995C0081894C /* BaseAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF87E7A1CF3995C0081894C /* BaseAuthenticator.swift */; };
 		DCF87E7D1CF3A9D40081894C /* BaseAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF87E7C1CF3A9D40081894C /* BaseAuthenticatorTests.swift */; };
 		DCF87E7F1CF3DD010081894C /* NativeAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF87E7E1CF3DD010081894C /* NativeAuthenticatorTests.swift */; };
+		DFCA38F51F4F575300131FF0 /* Codable+Uber.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFCA38F41F4F575300131FF0 /* Codable+Uber.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -230,7 +227,6 @@
 		D8D18E861CBF42AD00055B76 /* postRequests.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = postRequests.json; sourceTree = "<group>"; };
 		D8D2DC081C90E54700A65FF0 /* UserProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserProfile.swift; path = Model/UserProfile.swift; sourceTree = "<group>"; };
 		D8D2DC0A1C90E55900A65FF0 /* getMe.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = getMe.json; sourceTree = "<group>"; };
-		D8DAB6361C60240B007DE82C /* ModelMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelMapper.swift; sourceTree = "<group>"; };
 		D8E2C96B1C62B3B2006091BA /* PriceEstimate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PriceEstimate.swift; path = Model/PriceEstimate.swift; sourceTree = "<group>"; };
 		D8E2C96D1C62B3C7006091BA /* getPriceEstimates.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = getPriceEstimates.json; sourceTree = "<group>"; };
 		DC1039721C96B1CE004854E3 /* RidesScopeExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RidesScopeExtensionsTests.swift; sourceTree = "<group>"; };
@@ -283,7 +279,6 @@
 		DC92DC031CA38DBE001A0DCC /* WidgetsEndpointTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WidgetsEndpointTests.swift; sourceTree = "<group>"; };
 		DC92DC051CA3AC59001A0DCC /* OauthEndpointTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OauthEndpointTests.swift; sourceTree = "<group>"; };
 		DC9C2BCA1CF3FF34007C0FE9 /* LoginManagingProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LoginManagingProtocol.swift; path = OAuth/LoginManagingProtocol.swift; sourceTree = "<group>"; };
-		DCA459AF1D000813003CBA3D /* ObjectMapper.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ObjectMapper.framework; path = ../Carthage/Build/iOS/ObjectMapper.framework; sourceTree = "<group>"; };
 		DCA459D31D003EFC003CBA3D /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = ../Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		DCAEA98E1CEE4C9C00E6F239 /* RequestURLUtilTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestURLUtilTests.swift; sourceTree = "<group>"; };
 		DCAEA9901CEE61C400E6F239 /* AuthenticationDeeplink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationDeeplink.swift; sourceTree = "<group>"; };
@@ -307,6 +302,7 @@
 		DCF87E7A1CF3995C0081894C /* BaseAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BaseAuthenticator.swift; path = OAuth/BaseAuthenticator.swift; sourceTree = "<group>"; };
 		DCF87E7C1CF3A9D40081894C /* BaseAuthenticatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseAuthenticatorTests.swift; sourceTree = "<group>"; };
 		DCF87E7E1CF3DD010081894C /* NativeAuthenticatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeAuthenticatorTests.swift; sourceTree = "<group>"; };
+		DFCA38F41F4F575300131FF0 /* Codable+Uber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Codable+Uber.swift"; path = "Utilities/Codable+Uber.swift"; sourceTree = "<group>"; };
 		DFD7096F1F159865007550C8 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "Resources/pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		EA01FB909C9A04DC5D83A4D9 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -316,7 +312,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DCA459B21D000861003CBA3D /* ObjectMapper.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -324,9 +319,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3A66B4721D1F38D600B4F181 /* ObjectMapper.framework in Frameworks */,
 				AC0404801BFACD1D00AC1501 /* UberRides.framework in Frameworks */,
-				DCA459D41D003EFC003CBA3D /* OHHTTPStubs.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -459,7 +452,6 @@
 				D8E2C96B1C62B3B2006091BA /* PriceEstimate.swift */,
 				D81C85311CC819C500DC82EE /* Place.swift */,
 				D81A8B151C658A2800339C13 /* TimeEstimate.swift */,
-				D8DAB6361C60240B007DE82C /* ModelMapper.swift */,
 				DC75DFEB1CA5EC1200071417 /* RideParameters.swift */,
 				D81C852B1CC801B500DC82EE /* RideRequestDataBuilder.swift */,
 				D8D18E7E1CBF417600055B76 /* Ride.swift */,
@@ -539,6 +531,7 @@
 			children = (
 				D8A93F0C1C6E62D800AA5E58 /* RidesUtil.swift */,
 				DCAEA9931CEE91D000E6F239 /* AuthenticationURLUtility.swift */,
+				DFCA38F41F4F575300131FF0 /* Codable+Uber.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -572,7 +565,6 @@
 			isa = PBXGroup;
 			children = (
 				DCA459D31D003EFC003CBA3D /* OHHTTPStubs.framework */,
-				DCA459AF1D000813003CBA3D /* ObjectMapper.framework */,
 				01CD6B39D5C3EB668427CE75 /* Pods.framework */,
 				3B095F1A046D6ABD97CBBFE1 /* Pods_UberRidesTests.framework */,
 			);
@@ -763,7 +755,6 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/../Carthage/Build/iOS/OHHTTPStubs.framework",
-				"$(SRCROOT)/../Carthage/Build/iOS/ObjectMapper.framework",
 			);
 			name = "Copy Carthage Frameworks";
 			outputPaths = (
@@ -815,7 +806,7 @@
 				D81C85361CC8315200DC82EE /* RideEstimate.swift in Sources */,
 				DCB0D38E1CAD9D5800194DD5 /* RideRequestViewRequestingBehavior.swift in Sources */,
 				DC78ED0F1CB502BF00850814 /* RideRequestViewErrorFactory.swift in Sources */,
-				D8DAB6371C60240B007DE82C /* ModelMapper.swift in Sources */,
+				DFCA38F51F4F575300131FF0 /* Codable+Uber.swift in Sources */,
 				DC9C2BCB1CF3FF34007C0FE9 /* LoginManagingProtocol.swift in Sources */,
 				DC8D42A91CF4C95000C16D16 /* RidesAppDelegate.swift in Sources */,
 				D81C852E1CC801E900DC82EE /* Vehicle.swift in Sources */,

--- a/source/UberRides/Model/DistanceEstimate.swift
+++ b/source/UberRides/Model/DistanceEstimate.swift
@@ -33,7 +33,7 @@
     @objc public private(set) var distance: Double
     
     /// The unit of distance (mile or km).
-    @objc public private(set) var distanceUnit: String?
+    @objc public private(set) var distanceUnit: String
     
     /// Expected activity duration (in seconds).
     @objc public private(set) var duration: Int
@@ -47,7 +47,7 @@
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         distance = try container.decodeIfPresent(Double.self, forKey: .distance) ?? 0.0
-        distanceUnit = try container.decodeIfPresent(String.self, forKey: .distanceUnit)
+        distanceUnit = try container.decodeIfPresent(String.self, forKey: .distanceUnit) ?? ""
         duration = try container.decodeIfPresent(Int.self, forKey: .duration) ?? 0
     }
 }

--- a/source/UberRides/Model/DistanceEstimate.swift
+++ b/source/UberRides/Model/DistanceEstimate.swift
@@ -22,32 +22,32 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: DistanceEstimate
 
 /**
  *  Estimate information on an Uber trip.
  */
-@objc(UBSDKDistanceEstimate) public class DistanceEstimate: NSObject {
+@objc(UBSDKDistanceEstimate) public class DistanceEstimate: NSObject, Codable {
     
     /// Expected activity distance.
-    @objc public private(set) var distance: Double = 0.0
+    @objc public private(set) var distance: Double
     
     /// The unit of distance (mile or km).
     @objc public private(set) var distanceUnit: String?
     
     /// Expected activity duration (in seconds).
-    @objc public private(set) var duration: Int = 0
-    
-    public required init?(map: Map) {
-    }
-}
+    @objc public private(set) var duration: Int
 
-extension DistanceEstimate: UberModel {
-    public func mapping(map: Map) {
-        distance     <- map["distance_estimate"]
-        distanceUnit <- map["distance_unit"]
-        duration     <- map["duration_estimate"]
+    enum CodingKeys: String, CodingKey {
+        case distance        = "distance_estimate"
+        case distanceUnit    = "distance_unit"
+        case duration        = "duration_estimate"
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        distance = try container.decodeIfPresent(Double.self, forKey: .distance) ?? 0.0
+        distanceUnit = try container.decodeIfPresent(String.self, forKey: .distanceUnit)
+        duration = try container.decodeIfPresent(Int.self, forKey: .duration) ?? 0
     }
 }

--- a/source/UberRides/Model/Driver.swift
+++ b/source/UberRides/Model/Driver.swift
@@ -22,14 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: Driver
 
 /**
  *  Contains information for an Uber driver dispatched for a ride request.
  */
-@objc(UBSDKDriver) public class Driver: NSObject {
+@objc(UBSDKDriver) public class Driver: NSObject, Codable {
     
     /// The first name of the driver.
     @objc public private(set) var name: String?
@@ -41,17 +39,20 @@ import ObjectMapper
     @objc public private(set) var phoneNumber: String?
     
     /// The driver's star rating out of 5 stars.
-    @objc public private(set) var rating: Double = 0.0
-    
-    public required init?(map: Map) {
-    }
-}
+    @objc public private(set) var rating: Double
 
-extension Driver: UberModel {
-    public func mapping(map: Map) {
-        name        <- map["name"]
-        pictureURL  <- map["picture_url"]
-        phoneNumber <- map["phone_number"]
-        rating      <- map["rating"]
+    enum CodingKeys: String, CodingKey {
+        case name        = "name"
+        case pictureURL  = "picture_url"
+        case phoneNumber = "phone_number"
+        case rating      = "rating"
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decodeIfPresent(String.self, forKey: .name)
+        pictureURL = try container.decodeIfPresent(String.self, forKey: .pictureURL)
+        phoneNumber = try container.decodeIfPresent(String.self, forKey: .phoneNumber)
+        rating = try container.decodeIfPresent(Double.self, forKey: .rating) ?? 0.0
     }
 }

--- a/source/UberRides/Model/Driver.swift
+++ b/source/UberRides/Model/Driver.swift
@@ -30,13 +30,13 @@
 @objc(UBSDKDriver) public class Driver: NSObject, Codable {
     
     /// The first name of the driver.
-    @objc public private(set) var name: String?
+    @objc public private(set) var name: String
     
     /// The URL to the photo of the driver.
-    @objc public private(set) var pictureURL: String?
+    @objc public private(set) var pictureURL: URL
     
     /// The formatted phone number for contacting the driver.
-    @objc public private(set) var phoneNumber: String?
+    @objc public private(set) var phoneNumber: String
     
     /// The driver's star rating out of 5 stars.
     @objc public private(set) var rating: Double
@@ -50,9 +50,9 @@
 
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        name = try container.decodeIfPresent(String.self, forKey: .name)
-        pictureURL = try container.decodeIfPresent(String.self, forKey: .pictureURL)
-        phoneNumber = try container.decodeIfPresent(String.self, forKey: .phoneNumber)
-        rating = try container.decodeIfPresent(Double.self, forKey: .rating) ?? 0.0
+        name = try container.decode(String.self, forKey: .name)
+        pictureURL = try container.decode(URL.self, forKey: .pictureURL)
+        phoneNumber = try container.decode(String.self, forKey: .phoneNumber)
+        rating = try container.decode(Double.self, forKey: .rating)
     }
 }

--- a/source/UberRides/Model/PaymentMethod.swift
+++ b/source/UberRides/Model/PaymentMethod.swift
@@ -41,13 +41,13 @@ struct PaymentMethods: Codable {
 @objc(UBSDKPaymentMethod) public class PaymentMethod: NSObject, Codable {
     
     /// The account identification or description associated with the payment method.
-    @objc public private(set) var paymentDescription: String?
+    @objc public private(set) var paymentDescription: String = ""
     
     /// Unique identifier of the payment method.
-    @objc public private(set) var methodID: String?
+    @objc public private(set) var methodID: String = ""
     
     /// The type of the payment method. See https://developer.uber.com/docs/v1-payment-methods.
-    @objc public private(set) var type: String?
+    @objc public private(set) var type: String = ""
 
     enum CodingKeys: String, CodingKey {
         case paymentDescription = "description"

--- a/source/UberRides/Model/PaymentMethod.swift
+++ b/source/UberRides/Model/PaymentMethod.swift
@@ -22,31 +22,23 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: PaymentMethods
 
 /**
  *  Internal struct for handling a list of payment methods
  */
-struct PaymentMethods {
+struct PaymentMethods: Codable {
     var lastUsed: String?
     var list: [PaymentMethod]?
-    
-    init?(map: Map) {
+
+    enum CodingKeys: String, CodingKey {
+        case lastUsed = "last_used"
+        case list     = "payment_methods"
     }
 }
-
-extension PaymentMethods: UberModel {
-    mutating func mapping(map: Map) {
-        lastUsed <- map["last_used"]
-        list     <- map["payment_methods"]
-    }
-}
-
 // MARK: PaymentMethod
 
-@objc(UBSDKPaymentMethod) public class PaymentMethod: NSObject {
+@objc(UBSDKPaymentMethod) public class PaymentMethod: NSObject, Codable {
     
     /// The account identification or description associated with the payment method.
     @objc public private(set) var paymentDescription: String?
@@ -56,15 +48,10 @@ extension PaymentMethods: UberModel {
     
     /// The type of the payment method. See https://developer.uber.com/docs/v1-payment-methods.
     @objc public private(set) var type: String?
-    
-    public required init?(map: Map) {
-    }
-}
 
-extension PaymentMethod: UberModel {
-    public func mapping(map: Map) {
-        paymentDescription <- map["description"]
-        methodID           <- map["payment_method_id"]
-        type               <- map["type"]
+    enum CodingKeys: String, CodingKey {
+        case paymentDescription = "description"
+        case methodID           = "payment_method_id"
+        case type               = "type"
     }
 }

--- a/source/UberRides/Model/Place.swift
+++ b/source/UberRides/Model/Place.swift
@@ -22,28 +22,17 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 /**
  *  Describes a pre-set place for an Uber account (home or work).
  */
-@objc(UBSDKPlace) public class Place: NSObject {
+@objc(UBSDKPlace) public class Place: NSObject, Codable {
     
     /// Convenience constant for "home" place ID
-    @objc public static let Home = "home"
+    @objc public static let home = "home"
     
     /// Convenience constant for "work" place ID
-    @objc public static let Work = "work"
+    @objc public static let work = "work"
     
     /// Fully qualified address of the location.
     @objc public private(set) var address: String?
-    
-    public required init?(map: Map) {
-    }
-}
-
-extension Place: UberModel {
-    public func mapping(map: Map) {
-        address <- map["address"]
-    }
 }

--- a/source/UberRides/Model/Place.swift
+++ b/source/UberRides/Model/Place.swift
@@ -34,5 +34,5 @@
     @objc public static let work = "work"
     
     /// Fully qualified address of the location.
-    @objc public private(set) var address: String?
+    @objc public private(set) var address: String = ""
 }

--- a/source/UberRides/Model/PriceEstimate.swift
+++ b/source/UberRides/Model/PriceEstimate.swift
@@ -22,22 +22,16 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: PriceEstimates
 
 /**
 *  Internal object that contains a list of price estimates for Uber products.
 */
-struct PriceEstimates {
+struct PriceEstimates: Codable {
     var list: [PriceEstimate]?
-    init?(map: Map) {
-    }
-}
 
-extension PriceEstimates: UberModel {
-    mutating func mapping(map: Map) {
-        list <- map["prices"]
+    enum CodingKeys: String, CodingKey {
+        case list = "prices"
     }
 }
 
@@ -46,25 +40,25 @@ extension PriceEstimates: UberModel {
 /**
 *  Contains information about estimated price range for each Uber product offered at a location.
 */
-@objc(UBSDKPriceEstimate) public class PriceEstimate: NSObject {
+@objc(UBSDKPriceEstimate) public class PriceEstimate: NSObject, Codable {
     
     /// ISO 4217 currency code.
     @objc public private(set) var currencyCode: String?
     
     /// Expected activity distance (in miles).
-    @objc public private(set) var distance: Double = 0.0
+    @objc public private(set) var distance: Double
     
     /// Expected activity duration (in seconds).
-    @objc public private(set) var duration: Int = 0
+    @objc public private(set) var duration: Int
     
     /// A formatted string representing the estimate in local currency. Could be range, single number, or "Metered" for TAXI.
     @objc public private(set) var estimate: String?
     
     /// Upper bound of the estimated price.
-    @objc public private(set) var highEstimate: Int = 0
+    @objc public private(set) var highEstimate: Int
     
     /// Lower bound of the estimated price.
-    @objc public private(set) var lowEstimate: Int = 0
+    @objc public private(set) var lowEstimate: Int
     
     /// Display name of product. Ex: "UberBLACK".
     @objc public private(set) var name: String?
@@ -79,24 +73,34 @@ extension PriceEstimates: UberModel {
     @objc public private(set) var surgeConfirmationURL: String?
     
     /// Expected surge multiplier (active if surge is greater than 1).
-    @objc public private(set) var surgeMultiplier: Double = 1.0
-    
-    public required init?(map: Map) {
-    }
-}
+    @objc public private(set) var surgeMultiplier: Double
 
-extension PriceEstimate: UberModel {
-    public func mapping(map: Map) {
-        currencyCode         <- map["currency_code"]
-        distance             <- map["distance"]
-        duration             <- map["duration"]
-        estimate             <- map["estimate"]
-        highEstimate         <- map["high_estimate"]
-        lowEstimate          <- map["low_estimate"]
-        name                 <- map["display_name"]
-        productID            <- map["product_id"]
-        surgeConfirmationID  <- map["surge_confirmation_id"]
-        surgeConfirmationURL <- map["surge_confirmation_href"]
-        surgeMultiplier      <- map["surge_multiplier"]
+    enum CodingKeys: String, CodingKey {
+        case currencyCode         = "currency_code"
+        case distance             = "distance"
+        case duration             = "duration"
+        case estimate             = "estimate"
+        case highEstimate         = "high_estimate"
+        case lowEstimate          = "low_estimate"
+        case name                 = "display_name"
+        case productID            = "product_id"
+        case surgeConfirmationID  = "surge_confirmation_id"
+        case surgeConfirmationURL = "surge_confirmation_href"
+        case surgeMultiplier      = "surge_multiplier"
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        currencyCode = try container.decodeIfPresent(String.self, forKey: .currencyCode)
+        distance = try container.decodeIfPresent(Double.self, forKey: .distance) ?? 0.0
+        duration = try container.decodeIfPresent(Int.self, forKey: .duration) ?? 0
+        estimate = try container.decodeIfPresent(String.self, forKey: .estimate)
+        highEstimate = try container.decodeIfPresent(Int.self, forKey: .highEstimate) ?? 0
+        lowEstimate = try container.decodeIfPresent(Int.self, forKey: .lowEstimate) ?? 0
+        name = try container.decodeIfPresent(String.self, forKey: .name)
+        productID = try container.decodeIfPresent(String.self, forKey: .productID)
+        surgeConfirmationID = try container.decodeIfPresent(String.self, forKey: .surgeConfirmationID)
+        surgeConfirmationURL = try container.decodeIfPresent(String.self, forKey: .surgeConfirmationURL)
+        surgeMultiplier = try container.decodeIfPresent(Double.self, forKey: .surgeMultiplier) ?? 1.0
     }
 }

--- a/source/UberRides/Model/Ride.swift
+++ b/source/UberRides/Model/Ride.swift
@@ -22,14 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: Ride
 
 /**
  *  Contains the status of an ongoing/completed trip created using the Ride Request endpoint
  */
-@objc(UBSDKRide) public class Ride: NSObject {
+@objc(UBSDKRide) public class Ride: NSObject, Codable {
     
     /// Contains the information about the destination of the trip, if one has been set.
     @objc public private(set) var destination: RideRequestLocation?
@@ -41,7 +39,7 @@ import ObjectMapper
     @objc public private(set) var driverLocation: RideRequestLocation?
     
     /// The estimated time of vehicle arrival in minutes.
-    @objc public private(set) var eta: Int = 0
+    @objc public private(set) var eta: Int
     
     /// The object containing the information about the pickup for the trip.
     @objc public private(set) var pickup: RideRequestLocation?
@@ -50,32 +48,36 @@ import ObjectMapper
     @objc public private(set) var requestID: String?
     
     /// The status of the Request indicating state.
-    @objc public private(set) var status: RideStatus = .unknown
+    @objc public private(set) var status: RideStatus
     
     /// The surge pricing multiplier used to calculate the increased price of a Request.
-    @objc public private(set) var surgeMultiplier: Double = 1.0
+    @objc public private(set) var surgeMultiplier: Double
     
     /// The object that contains vehicle details. Only non-null during an ongoing trip.
     @objc public private(set) var vehicle: Vehicle?
-    
-    public required init?(map: Map) {
-    }
-}
 
-extension Ride: UberModel {
-    public func mapping(map: Map) {
-        destination     <- map["destination"]
-        driver          <- map["driver"]
-        driverLocation  <- map["location"]
-        eta             <- map["eta"]
-        pickup          <- map["pickup"]
-        requestID       <- map["request_id"]
-        surgeMultiplier <- map["surge_multiplier"]
-        vehicle         <- map["vehicle"]
-        
-        status = .unknown
-        if let value = map["status"].currentValue as? String {
-            status = RideStatusFactory.convertRideStatus(value)
-        }
+    enum CodingKeys: String, CodingKey {
+        case destination     = "destination"
+        case driver          = "driver"
+        case driverLocation  = "location"
+        case eta             = "eta"
+        case pickup          = "pickup"
+        case requestID       = "request_id"
+        case surgeMultiplier = "surge_multiplier"
+        case vehicle         = "vehicle"
+        case status          = "status"
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        destination = try container.decodeIfPresent(RideRequestLocation.self, forKey: .destination)
+        driver = try container.decodeIfPresent(Driver.self, forKey: .driver)
+        driverLocation = try container.decodeIfPresent(RideRequestLocation.self, forKey: .driverLocation)
+        eta = try container.decodeIfPresent(Int.self, forKey: .eta) ?? 0
+        pickup = try container.decodeIfPresent(RideRequestLocation.self, forKey: .pickup)
+        requestID = try container.decodeIfPresent(String.self, forKey: .requestID)
+        surgeMultiplier = try container.decodeIfPresent(Double.self, forKey: .surgeMultiplier) ?? 1.0
+        vehicle = try container.decodeIfPresent(Vehicle.self, forKey: .vehicle)
+        status = try container.decodeIfPresent(RideStatus.self, forKey: .status) ?? .unknown
     }
 }

--- a/source/UberRides/Model/Ride.swift
+++ b/source/UberRides/Model/Ride.swift
@@ -45,7 +45,7 @@
     @objc public private(set) var pickup: RideRequestLocation?
     
     /// The unique ID of the Request.
-    @objc public private(set) var requestID: String?
+    @objc public private(set) var requestID: String
     
     /// The status of the Request indicating state.
     @objc public private(set) var status: RideStatus
@@ -75,7 +75,7 @@
         driverLocation = try container.decodeIfPresent(RideRequestLocation.self, forKey: .driverLocation)
         eta = try container.decodeIfPresent(Int.self, forKey: .eta) ?? 0
         pickup = try container.decodeIfPresent(RideRequestLocation.self, forKey: .pickup)
-        requestID = try container.decodeIfPresent(String.self, forKey: .requestID)
+        requestID = try container.decode(String.self, forKey: .requestID)
         surgeMultiplier = try container.decodeIfPresent(Double.self, forKey: .surgeMultiplier) ?? 1.0
         vehicle = try container.decodeIfPresent(Vehicle.self, forKey: .vehicle)
         status = try container.decodeIfPresent(RideStatus.self, forKey: .status) ?? .unknown

--- a/source/UberRides/Model/RideCharge.swift
+++ b/source/UberRides/Model/RideCharge.swift
@@ -33,15 +33,15 @@
     @objc public private(set) var amount: Double
     
     /// The name of the charge.
-    @objc public private(set) var name: String?
+    @objc public private(set) var name: String
     
     /// The type of the charge.
-    @objc public private(set) var type: String?
+    @objc public private(set) var type: String
 
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        amount = try container.decodeIfPresent(Double.self, forKey: .amount) ?? 0.0
-        name = try container.decodeIfPresent(String.self, forKey: .name)
-        type = try container.decodeIfPresent(String.self, forKey: .type)
+        amount = try container.decode(Double.self, forKey: .amount)
+        name = try container.decode(String.self, forKey: .name)
+        type = try container.decode(String.self, forKey: .type)
     }
 }

--- a/source/UberRides/Model/RideCharge.swift
+++ b/source/UberRides/Model/RideCharge.swift
@@ -22,32 +22,26 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: RideCharge
 
 /**
  *  Describes the charges made against the rider in a ride receipt.
  */
-@objc(UBSDKRideCharge) public class RideCharge: NSObject {
+@objc(UBSDKRideCharge) public class RideCharge: NSObject, Codable {
     
     /// The amount of the charge.
-    @objc public private(set) var amount: Float = 0.0
+    @objc public private(set) var amount: Double
     
     /// The name of the charge.
     @objc public private(set) var name: String?
     
     /// The type of the charge.
     @objc public private(set) var type: String?
-    
-    public required init?(map: Map) {
-    }
-}
 
-extension RideCharge: UberModel {
-    public func mapping(map: Map) {
-        amount <- map["amount"]
-        name   <- map["name"]
-        type   <- map["type"]
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        amount = try container.decodeIfPresent(Double.self, forKey: .amount) ?? 0.0
+        name = try container.decodeIfPresent(String.self, forKey: .name)
+        type = try container.decodeIfPresent(String.self, forKey: .type)
     }
 }

--- a/source/UberRides/Model/RideEstimate.swift
+++ b/source/UberRides/Model/RideEstimate.swift
@@ -22,14 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: RideEstimate
 
 /**
  *  Contains estimates for a desired ride request.
  */
-@objc(UBSDKRideEstimate) public class RideEstimate: NSObject {
+@objc(UBSDKRideEstimate) public class RideEstimate: NSObject, Codable {
     
     /// Details of the estimated fare. If end location omitted, only the minimum is returned.
     @objc public private(set) var priceEstimate: PriceEstimate?
@@ -38,16 +36,18 @@ import ObjectMapper
     @objc public private(set) var distanceEstimate: DistanceEstimate?
     
     /// The estimated time of vehicle arrival in minutes. -1 if there are no cars available.
-    @objc public private(set) var pickupEstimate: Int = -1
-    
-    public required init?(map: Map) {
-    }
-}
+    @objc public private(set) var pickupEstimate: Int
 
-extension RideEstimate: UberModel {
-    public func mapping(map: Map) {
-        priceEstimate    <- map["price"]
-        distanceEstimate <- map["trip"]
-        pickupEstimate   <- map["pickup_estimate", ignoreNil: true]
+    enum CodingKeys: String, CodingKey {
+        case priceEstimate    = "price"
+        case distanceEstimate = "trip"
+        case pickupEstimate   = "pickup_estimate"
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        priceEstimate = try container.decodeIfPresent(PriceEstimate.self, forKey: .priceEstimate)
+        distanceEstimate = try container.decodeIfPresent(DistanceEstimate.self, forKey: .distanceEstimate)
+        pickupEstimate = try container.decodeIfPresent(Int.self, forKey: .pickupEstimate) ?? -1
     }
 }

--- a/source/UberRides/Model/RideEstimate.swift
+++ b/source/UberRides/Model/RideEstimate.swift
@@ -30,7 +30,7 @@
 @objc(UBSDKRideEstimate) public class RideEstimate: NSObject, Codable {
     
     /// Details of the estimated fare. If end location omitted, only the minimum is returned.
-    @objc public private(set) var priceEstimate: PriceEstimate?
+    @objc public private(set) var priceEstimate: PriceEstimate
     
     /// Details of the estimated distance. Nil if end location is omitted.
     @objc public private(set) var distanceEstimate: DistanceEstimate?
@@ -46,7 +46,7 @@
 
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        priceEstimate = try container.decodeIfPresent(PriceEstimate.self, forKey: .priceEstimate)
+        priceEstimate = try container.decode(PriceEstimate.self, forKey: .priceEstimate)
         distanceEstimate = try container.decodeIfPresent(DistanceEstimate.self, forKey: .distanceEstimate)
         pickupEstimate = try container.decodeIfPresent(Int.self, forKey: .pickupEstimate) ?? -1
     }

--- a/source/UberRides/Model/RideMap.swift
+++ b/source/UberRides/Model/RideMap.swift
@@ -22,28 +22,21 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: RideMap
 
 /**
  *  Visual representation of a ride request, only available after a request is accepted.
  */
-@objc(UBSDKRideMap) public class RideMap: NSObject {
+@objc(UBSDKRideMap) public class RideMap: NSObject, Codable {
     
     /// URL to a map representing the requested trip.
     @objc public private(set) var path: String?
     
     /// Unique identifier representing a ride request.
     @objc public private(set) var requestID: String?
-    
-    public required init?(map: Map) {
-    }
-}
 
-extension RideMap: UberModel {
-    public func mapping(map: Map) {
-        path      <- map["href"]
-        requestID <- map["request_id"]
+    enum CodingKeys: String, CodingKey {
+        case path      = "href"
+        case requestID = "request_id"
     }
 }

--- a/source/UberRides/Model/RideMap.swift
+++ b/source/UberRides/Model/RideMap.swift
@@ -30,13 +30,19 @@
 @objc(UBSDKRideMap) public class RideMap: NSObject, Codable {
     
     /// URL to a map representing the requested trip.
-    @objc public private(set) var path: String?
+    @objc public private(set) var path: URL
     
     /// Unique identifier representing a ride request.
-    @objc public private(set) var requestID: String?
+    @objc public private(set) var requestID: String = ""
 
     enum CodingKeys: String, CodingKey {
         case path      = "href"
         case requestID = "request_id"
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        path = try container.decode(URL.self, forKey: .path)
+        requestID = try container.decode(String.self, forKey: .requestID)
     }
 }

--- a/source/UberRides/Model/RideReceipt.swift
+++ b/source/UberRides/Model/RideReceipt.swift
@@ -22,14 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: RideReceipt
 
 /**
  *  Get the receipt information of a completed request that was made with the request endpoint.
  */
-@objc(UBSDKRideReceipt) public class RideReceipt: NSObject {
+@objc(UBSDKRideReceipt) public class RideReceipt: NSObject, Codable {
     
     /// Adjustments made to the charges such as promotions, and fees.
     @objc public private(set) var chargeAdjustments: [RideCharge]?
@@ -65,25 +63,36 @@ import ObjectMapper
     @objc public private(set) var totalCharged: String?
     
     /// The total amount still owed after attempting to charge the user. May be 0 if amount was paid in full.
-    @objc public private(set) var totalOwed: Double = 0.0
-    
-    public required init?(map: Map) {
-    }
-}
+    @objc public private(set) var totalOwed: Double
 
-extension RideReceipt: UberModel {
-    public func mapping(map: Map) {
-        chargeAdjustments <- map["charge_adjustments"]
-        charges           <- map["charges"]
-        currencyCode      <- map["currency_code"]
-        distance          <- map["distance"]
-        distanceLabel     <- map["distance_label"]
-        duration          <- map["duration"]
-        normalFare        <- map["normal_fare"]
-        requestID         <- map["request_id"]
-        subtotal          <- map["subtotal"]
-        surgeCharge       <- map["surge_charge"]
-        totalCharged      <- map["total_charged"]
-        totalOwed         <- map["total_owed"]
+    enum CodingKeys: String, CodingKey {
+        case chargeAdjustments = "charge_adjustments"
+        case charges           = "charges"
+        case currencyCode      = "currency_code"
+        case distance          = "distance"
+        case distanceLabel     = "distance_label"
+        case duration          = "duration"
+        case normalFare        = "normal_fare"
+        case requestID         = "request_id"
+        case subtotal          = "subtotal"
+        case surgeCharge       = "surge_charge"
+        case totalCharged      = "total_charged"
+        case totalOwed         = "total_owed"
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        chargeAdjustments = try container.decodeIfPresent([RideCharge].self, forKey: .chargeAdjustments)
+        charges = try container.decodeIfPresent([RideCharge].self, forKey: .charges)
+        currencyCode = try container.decodeIfPresent(String.self, forKey: .currencyCode)
+        distance = try container.decodeIfPresent(String.self, forKey: .distance)
+        distanceLabel = try container.decodeIfPresent(String.self, forKey: .distanceLabel)
+        duration = try container.decodeIfPresent(String.self, forKey: .duration)
+        normalFare = try container.decodeIfPresent(String.self, forKey: .normalFare)
+        requestID = try container.decodeIfPresent(String.self, forKey: .requestID)
+        subtotal = try container.decodeIfPresent(String.self, forKey: .subtotal)
+        surgeCharge = try container.decodeIfPresent(RideCharge.self, forKey: .surgeCharge)
+        totalCharged = try container.decodeIfPresent(String.self, forKey: .totalCharged)
+        totalOwed = try container.decodeIfPresent(Double.self, forKey: .totalOwed) ?? 0.0
     }
 }

--- a/source/UberRides/Model/RideReceipt.swift
+++ b/source/UberRides/Model/RideReceipt.swift
@@ -30,37 +30,37 @@
 @objc(UBSDKRideReceipt) public class RideReceipt: NSObject, Codable {
     
     /// Adjustments made to the charges such as promotions, and fees.
-    @objc public private(set) var chargeAdjustments: [RideCharge]?
+    @objc public private(set) var chargeAdjustments: [RideCharge]
     
     /// Describes the charges made against the rider.
-    @objc public private(set) var charges: [RideCharge]?
+    @objc public private(set) var charges: [RideCharge]
     
     /// ISO 4217
-    @objc public private(set) var currencyCode: String?
+    @objc public private(set) var currencyCode: String
     
     /// Distance of the trip charged.
-    @objc public private(set) var distance: String?
+    @objc public private(set) var distance: String
     
     /// The localized unit of distance.
-    @objc public private(set) var distanceLabel: String?
+    @objc public private(set) var distanceLabel: String
     
     /// Time duration of the trip in ISO 8601 HH:MM:SS format.
-    @objc public private(set) var duration: String?
+    @objc public private(set) var duration: String // TODO
     
     /// The summation of the charges array.
-    @objc public private(set) var normalFare: String?
+    @objc public private(set) var normalFare: String
     
     /// Unique identifier representing a Request.
-    @objc public private(set) var requestID: String?
+    @objc public private(set) var requestID: String
     
     /// The summation of the normal fare and surge charge amount.
-    @objc public private(set) var subtotal: String?
+    @objc public private(set) var subtotal: String
     
     /// Describes the surge charge. May be null if surge pricing was not in effect.
     @objc public private(set) var surgeCharge: RideCharge?
     
     /// The total amount charged to the users payment method. This is the the subtotal (split if applicable) with taxes included.
-    @objc public private(set) var totalCharged: String?
+    @objc public private(set) var totalCharged: String
     
     /// The total amount still owed after attempting to charge the user. May be 0 if amount was paid in full.
     @objc public private(set) var totalOwed: Double
@@ -82,17 +82,17 @@
 
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        chargeAdjustments = try container.decodeIfPresent([RideCharge].self, forKey: .chargeAdjustments)
-        charges = try container.decodeIfPresent([RideCharge].self, forKey: .charges)
-        currencyCode = try container.decodeIfPresent(String.self, forKey: .currencyCode)
-        distance = try container.decodeIfPresent(String.self, forKey: .distance)
-        distanceLabel = try container.decodeIfPresent(String.self, forKey: .distanceLabel)
-        duration = try container.decodeIfPresent(String.self, forKey: .duration)
-        normalFare = try container.decodeIfPresent(String.self, forKey: .normalFare)
-        requestID = try container.decodeIfPresent(String.self, forKey: .requestID)
-        subtotal = try container.decodeIfPresent(String.self, forKey: .subtotal)
+        chargeAdjustments = try container.decode([RideCharge].self, forKey: .chargeAdjustments)
+        charges = try container.decode([RideCharge].self, forKey: .charges)
+        currencyCode = try container.decode(String.self, forKey: .currencyCode)
+        distance = try container.decode(String.self, forKey: .distance)
+        distanceLabel = try container.decode(String.self, forKey: .distanceLabel)
+        duration = try container.decode(String.self, forKey: .duration)
+        normalFare = try container.decode(String.self, forKey: .normalFare)
+        requestID = try container.decode(String.self, forKey: .requestID)
+        subtotal = try container.decode(String.self, forKey: .subtotal)
         surgeCharge = try container.decodeIfPresent(RideCharge.self, forKey: .surgeCharge)
-        totalCharged = try container.decodeIfPresent(String.self, forKey: .totalCharged)
+        totalCharged = try container.decode(String.self, forKey: .totalCharged)
         totalOwed = try container.decodeIfPresent(Double.self, forKey: .totalOwed) ?? 0.0
     }
 }

--- a/source/UberRides/Model/RideRequestDataBuilder.swift
+++ b/source/UberRides/Model/RideRequestDataBuilder.swift
@@ -23,7 +23,6 @@
 //  THE SOFTWARE.
 
 import CoreLocation
-import ObjectMapper
 
 // MARK: RideRequestDataBuilder
 

--- a/source/UberRides/Model/RideRequestLocation.swift
+++ b/source/UberRides/Model/RideRequestLocation.swift
@@ -22,36 +22,30 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: RideRequestLocation
 
 /**
  *  Location of a pickup or destination in a ride request.
  */
-@objc(UBSDKRideRequestLocation) public class RideRequestLocation: NSObject {
+@objc(UBSDKRideRequestLocation) public class RideRequestLocation: NSObject, Codable {
     
     /// The current bearing in degrees for a moving location.
-    @objc public private(set) var bearing: Int = 0
+    @objc public private(set) var bearing: Int
     
     /// ETA is only available when the trips is accepted or arriving.
-    @objc public private(set) var eta: Int = 0
+    @objc public private(set) var eta: Int
     
     /// The latitude of the location.
-    @objc public private(set) var latitude: Double = 0
+    @objc public private(set) var latitude: Double
     
     /// The longitude of the location.
-    @objc public private(set) var longitude: Double = 0
-    
-    public required init?(map: Map) {
-    }
-}
+    @objc public private(set) var longitude: Double
 
-extension RideRequestLocation: UberModel {
-    public func mapping(map: Map) {
-        bearing   <- map["bearing"]
-        eta       <- map["eta"]
-        latitude  <- map["latitude"]
-        longitude <- map["longitude"]
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        bearing = try container.decodeIfPresent(Int.self, forKey: .bearing) ?? 0
+        eta = try container.decodeIfPresent(Int.self, forKey: .eta) ?? 0
+        latitude = try container.decodeIfPresent(Double.self, forKey: .latitude) ?? 0
+        longitude = try container.decodeIfPresent(Double.self, forKey: .longitude) ?? 0
     }
 }

--- a/source/UberRides/Model/RideStatus.swift
+++ b/source/UberRides/Model/RideStatus.swift
@@ -37,7 +37,7 @@
  - RiderCanceled:      The ride request was canceled by rider.
  - Unknown:            An unexpected status.
  */
-@objc(UBSDKRideStatus) public enum RideStatus: Int {
+@objc(UBSDKRideStatus) public enum RideStatus: Int, Codable {
     case accepted
     case arriving
     case completed
@@ -47,44 +47,39 @@
     case processing
     case riderCanceled
     case unknown
-}
 
-// MARK: Objective-C Compatibility
+    enum CodingKeys: String, CodingKey {
+        case accepted = "accepted"
+        case arriving = "arriving"
+        case completed = "completed"
+        case driverCanceled = "driver_canceled"
+        case inProgress = "in_progress"
+        case noDriversAvailable = "no_drivers_available"
+        case processing = "processing"
+        case riderCanceled = "rider_canceled"
+    }
 
-private enum RideStatusString: String {
-    case accepted = "accepted"
-    case arriving = "arriving"
-    case completed = "completed"
-    case driverCanceled = "driver_canceled"
-    case inProgress = "in_progress"
-    case noDriversAvailable = "no_drivers_available"
-    case processing = "processing"
-    case riderCanceled = "rider_canceled"
-}
-
-class RideStatusFactory: NSObject {
-    static func convertRideStatus(_ stringValue: String) -> RideStatus {
-        guard let status = RideStatusString(rawValue: stringValue) else {
-            return .unknown
-        }
-        
-        switch status {
-        case .accepted:
-            return .accepted
-        case .arriving:
-            return .arriving
-        case .completed:
-            return .completed
-        case .driverCanceled:
-            return .driverCanceled
-        case .inProgress:
-            return .inProgress
-        case .noDriversAvailable:
-            return .noDriversAvailable
-        case .processing:
-            return .processing
-        case .riderCanceled:
-            return .riderCanceled
+    public init(from decoder: Decoder) throws {
+        let string = try decoder.singleValueContainer().decode(String.self)
+        switch string {
+        case "accepted":
+            self = .accepted
+        case "arriving":
+            self = .arriving
+        case "completed":
+            self = .completed
+        case "driver_canceled":
+            self = .driverCanceled
+        case "in_progress":
+            self = .inProgress
+        case "no_drivers_available":
+            self = .noDriversAvailable
+        case "processing":
+            self = .processing
+        case "rider_canceled":
+            self = .riderCanceled
+        default:
+            self = .unknown
         }
     }
 }

--- a/source/UberRides/Model/TimeEstimate.swift
+++ b/source/UberRides/Model/TimeEstimate.swift
@@ -22,22 +22,16 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: TimeEstimates
 
 /**
 *  Internal object that contains a list of ETAs for Uber products.
 */
-struct TimeEstimates {
+struct TimeEstimates: Codable {
     var list: [TimeEstimate]?
-    init?(map: Map) {
-    }
-}
 
-extension TimeEstimates: UberModel {
-    mutating func mapping(map: Map) {
-        list <- map["times"]
+    enum CodingKeys: String, CodingKey {
+        case list = "times"
     }
 }
 
@@ -46,7 +40,7 @@ extension TimeEstimates: UberModel {
 /**
 *  Contains information regarding the ETA of an Uber product.
 */
-@objc(UBSDKTimeEstimate) public class TimeEstimate: NSObject {
+@objc(UBSDKTimeEstimate) public class TimeEstimate: NSObject, Codable {
     /// Unique identifier representing a specific product for a given latitude & longitude.
     @objc public private(set) var productID: String?
     
@@ -54,16 +48,18 @@ extension TimeEstimates: UberModel {
     @objc public private(set) var name: String?
     
     /// ETA for the product (in seconds).
-    @objc public private(set) var estimate: Int = 0
-    
-    public required init?(map: Map) {
-    }
-}
+    @objc public private(set) var estimate: Int
 
-extension TimeEstimate: UberModel {
-    public func mapping(map: Map) {
-        productID <- map["product_id"]
-        name      <- map["display_name"]
-        estimate  <- map["estimate"]
+    enum CodingKeys: String, CodingKey {
+        case productID = "product_id"
+        case name      = "display_name"
+        case estimate  = "estimate"
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        productID = try container.decodeIfPresent(String.self, forKey: .productID)
+        name = try container.decodeIfPresent(String.self, forKey: .name)
+        estimate = try container.decodeIfPresent(Int.self, forKey: .estimate) ?? 0
     }
 }

--- a/source/UberRides/Model/TimeEstimate.swift
+++ b/source/UberRides/Model/TimeEstimate.swift
@@ -42,10 +42,10 @@ struct TimeEstimates: Codable {
 */
 @objc(UBSDKTimeEstimate) public class TimeEstimate: NSObject, Codable {
     /// Unique identifier representing a specific product for a given latitude & longitude.
-    @objc public private(set) var productID: String?
+    @objc public private(set) var productID: String
     
     /// Display name of product. Ex: "UberBLACK".
-    @objc public private(set) var name: String?
+    @objc public private(set) var name: String
     
     /// ETA for the product (in seconds).
     @objc public private(set) var estimate: Int
@@ -58,8 +58,8 @@ struct TimeEstimates: Codable {
 
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        productID = try container.decodeIfPresent(String.self, forKey: .productID)
-        name = try container.decodeIfPresent(String.self, forKey: .name)
-        estimate = try container.decodeIfPresent(Int.self, forKey: .estimate) ?? 0
+        productID = try container.decode(String.self, forKey: .productID)
+        name = try container.decode(String.self, forKey: .name)
+        estimate = try container.decode(Int.self, forKey: .estimate)
     }
 }

--- a/source/UberRides/Model/UberProduct.swift
+++ b/source/UberRides/Model/UberProduct.swift
@@ -44,19 +44,19 @@ struct UberProducts: Codable {
 */
 @objc(UBSDKUberProduct) public class UberProduct: NSObject, Codable {
     /// Unique identifier representing a specific product for a given latitude & longitude.
-    @objc public private(set) var productID: String?
+    @objc public private(set) var productID: String
     
     /// Display name of product. Ex: "UberBLACK".
-    @objc public private(set) var name: String?
+    @objc public private(set) var name: String
     
     /// Description of product. Ex: "The original Uber".
-    @objc public private(set) var details: String?
+    @objc public private(set) var details: String
     
     /// Capacity of product. Ex: 4, for a product that fits 4.
-    @objc public private(set) var capacity: Int = 0
+    @objc public private(set) var capacity: Int
     
     /// Path of image URL representing the product.
-    @objc public private(set) var imagePath: String?
+    @objc public private(set) var imagePath: URL
     
     /// The basic price details. See `PriceDetails` for structure.
     @objc public private(set) var priceDetails: PriceDetails?
@@ -68,6 +68,16 @@ struct UberProducts: Codable {
         case capacity     = "capacity"
         case imagePath    = "image"
         case priceDetails = "price_details"
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        productID = try container.decode(String.self, forKey: .productID)
+        name = try container.decode(String.self, forKey: .name)
+        details = try container.decode(String.self, forKey: .details)
+        capacity = try container.decode(Int.self, forKey: .capacity)
+        imagePath = try container.decode(URL.self, forKey: .imagePath)
+        priceDetails = try container.decodeIfPresent(PriceDetails.self, forKey: .priceDetails)
     }
 }
 

--- a/source/UberRides/Model/UberProduct.swift
+++ b/source/UberRides/Model/UberProduct.swift
@@ -23,22 +23,17 @@
 //  THE SOFTWARE.
 
 import UIKit
-import ObjectMapper
 
 // MARK: UberProducts
 
 /**
 *  Internal object that contains a list of Uber products.
 */
-struct UberProducts {
+struct UberProducts: Codable {
     var list: [UberProduct]?
-    init?(map: Map){
-    }
-}
 
-extension UberProducts: UberModel {
-    mutating func mapping(map: Map) {
-        list <- map["products"]
+    enum CodingKeys: String, CodingKey {
+        case list = "products"
     }
 }
 
@@ -47,7 +42,7 @@ extension UberProducts: UberModel {
 /**
 *  Contains information for a single Uber product.
 */
-@objc(UBSDKUberProduct) public class UberProduct: NSObject {
+@objc(UBSDKUberProduct) public class UberProduct: NSObject, Codable {
     /// Unique identifier representing a specific product for a given latitude & longitude.
     @objc public private(set) var productID: String?
     
@@ -65,23 +60,14 @@ extension UberProducts: UberModel {
     
     /// The basic price details. See `PriceDetails` for structure.
     @objc public private(set) var priceDetails: PriceDetails?
-    
-    /// Specifies whether this product allows for the pickup and dropoff of other riders during the trip.
-    public fileprivate(set) var shared: Bool = false
-    
-    public required init?(map: Map) {
-    }
-}
 
-extension UberProduct : UberModel {
-    public func mapping(map: Map) {
-        productID    <- map["product_id"]
-        name         <- map["display_name"]
-        details      <- map["description"]
-        capacity     <- map["capacity"]
-        imagePath    <- map["image"]
-        priceDetails <- map["price_details"]
-        shared       <- map["shared"]
+    enum CodingKeys: String, CodingKey {
+        case productID    = "product_id"
+        case name         = "display_name"
+        case details      = "description"
+        case capacity     = "capacity"
+        case imagePath    = "image"
+        case priceDetails = "price_details"
     }
 }
 
@@ -90,7 +76,7 @@ extension UberProduct : UberModel {
 /**
 *  Contains basic price details for an Uber product.
 */
-@objc(UBSDKPriceDetails) public class PriceDetails : NSObject {
+@objc(UBSDKPriceDetails) public class PriceDetails: NSObject, Codable {
     /// Unit of distance used to calculate fare (mile or km).
     @objc public private(set) var distanceUnit: String?
     
@@ -114,21 +100,16 @@ extension UberProduct : UberModel {
     
     /// Array containing additional fees added to the price. See `ServiceFee`.
     @objc public private(set) var serviceFees: [ServiceFee]?
-    
-    public required init?(map: Map) {
-    }
-}
 
-extension PriceDetails : Mappable {
-    public func mapping(map: Map) {
-        distanceUnit    <- map["distance_unit"]
-        currencyCode    <- map["currency_code"]
-        costPerMinute   <- map["cost_per_minute"]
-        costPerDistance <- map["cost_per_distance"]
-        baseFee         <- map["base"]
-        minimumFee      <- map["minimum"]
-        cancellationFee <- map["cancellation_fee"]
-        serviceFees     <- map["service_fees"]
+    enum CodingKeys: String, CodingKey {
+        case distanceUnit    = "distance_unit"
+        case currencyCode    = "currency_code"
+        case costPerMinute   = "cost_per_minute"
+        case costPerDistance = "cost_per_distance"
+        case baseFee         = "base"
+        case minimumFee      = "minimum"
+        case cancellationFee = "cancellation_fee"
+        case serviceFees     = "service_fees"
     }
 }
 
@@ -137,20 +118,15 @@ extension PriceDetails : Mappable {
 /**
 *  Contains information for additional fees that can be added to the price of an Uber product.
 */
-public class ServiceFee : NSObject {
+public class ServiceFee: NSObject, Codable {
     /// The name of the service fee.
     @objc public private(set) var name: String?
     
     /// The amount of the service fee.
     @objc public private(set) var fee: Double = 0.0
-    
-    public required init?(map: Map) {
-    }
-}
 
-extension ServiceFee: Mappable {
-    public func mapping(map: Map) {
-        name <- map["name"]
-        fee  <- map["fee"]
+    enum CodingKeys: String, CodingKey {
+        case name = "name"
+        case fee  = "fee"
     }
 }

--- a/source/UberRides/Model/UserActivity.swift
+++ b/source/UberRides/Model/UserActivity.swift
@@ -61,22 +61,22 @@
     @objc public private(set) var distance: Double
     
     /// Represents timestamp of activity request time in current locale.
-    @objc public private(set) var requestTime: Date?
+    @objc public private(set) var requestTime: Date
     
     /// Represents timestamp of activity start time in current locale.
-    @objc public private(set) var startTime: Date?
+    @objc public private(set) var startTime: Date
     
     /// Represents timestamp of activity end time in current locale.
-    @objc public private(set) var endTime: Date?
+    @objc public private(set) var endTime: Date
     
     /// City that activity started in.
-    @objc public private(set) var startCity: TripCity?
+    @objc public private(set) var startCity: TripCity
     
     /// Unique activity identifier.
-    @objc public private(set) var requestID: String?
+    @objc public private(set) var requestID: String
     
     /// Unique identifier representing a specific product for a given latitude & longitude.
-    @objc public private(set) var productID: String?
+    @objc public private(set) var productID: String
 
     enum CodingKeys: String, CodingKey {
         case distance    = "distance"
@@ -91,12 +91,12 @@
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         distance = try container.decodeIfPresent(Double.self, forKey: .distance) ?? 0.0
-        requestTime = try container.decodeIfPresent(Date.self, forKey: .requestTime)
-        startTime = try container.decodeIfPresent(Date.self, forKey: .startTime)
-        endTime = try container.decodeIfPresent(Date.self, forKey: .endTime)
-        startCity = try container.decodeIfPresent(TripCity.self, forKey: .startCity)
-        requestID = try container.decodeIfPresent(String.self, forKey: .requestID)
-        productID = try container.decodeIfPresent(String.self, forKey: .productID)
+        requestTime = try container.decode(Date.self, forKey: .requestTime)
+        startTime = try container.decode(Date.self, forKey: .startTime)
+        endTime = try container.decode(Date.self, forKey: .endTime)
+        startCity = try container.decode(TripCity.self, forKey: .startCity)
+        requestID = try container.decode(String.self, forKey: .requestID)
+        productID = try container.decode(String.self, forKey: .productID)
         status = try container.decodeIfPresent(RideStatus.self, forKey: .status) ?? .unknown
     }
 }
@@ -114,7 +114,7 @@
     @objc public private(set) var longitude: Float = 0.0
     
     /// Display name of city.
-    @objc public private(set) var name: String?
+    @objc public private(set) var name: String = ""
 
     enum CodingKeys: String, CodingKey {
         case latitude  = "latitude"

--- a/source/UberRides/Model/UserActivity.swift
+++ b/source/UberRides/Model/UserActivity.swift
@@ -22,14 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: TripHistory
 
 /**
 *  User's lifetime trip activity with Uber.
 */
-@objc(UBSDKTripHistory) public class TripHistory: NSObject {
+@objc(UBSDKTripHistory) public class TripHistory: NSObject, Codable {
     /// Position in pagination.
     @objc public private(set) var offset: Int = 0
     
@@ -41,17 +39,12 @@ import ObjectMapper
     
     /// Array of trip information.
     @objc public private(set) var history: [UserActivity]?
-    
-    public required init?(map: Map) {
-    }
-}
 
-extension TripHistory: UberModel {
-    public func mapping(map: Map) {
-        offset  <- map["offset"]
-        limit   <- map["limit"]
-        count   <- map["count"]
-        history <- map["history"]
+    enum CodingKeys: String, CodingKey {
+        case offset  = "offset"
+        case limit   = "limit"
+        case count   = "count"
+        case history = "history"
     }
 }
 
@@ -60,12 +53,12 @@ extension TripHistory: UberModel {
 /**
 *  Information regarding an Uber trip in a user's activity history.
 */
-@objc(UBSDKUserActivity) public class UserActivity: NSObject {
+@objc(UBSDKUserActivity) public class UserActivity: NSObject, Codable {
     /// Status of the activity. Only returns completed for now.
-    public private(set) var status: RideStatus?
+    public private(set) var status: RideStatus
     
     /// Length of activity in miles.
-    @objc public private(set) var distance: Float = 0.0
+    @objc public private(set) var distance: Double
     
     /// Represents timestamp of activity request time in current locale.
     @objc public private(set) var requestTime: Date?
@@ -84,25 +77,27 @@ extension TripHistory: UberModel {
     
     /// Unique identifier representing a specific product for a given latitude & longitude.
     @objc public private(set) var productID: String?
-    
-    public required init?(map: Map) {
-    }
-}
 
-extension UserActivity: UberModel {
-    public func mapping(map: Map) {
-        distance    <- map["distance"]
-        requestTime <- (map["request_time"], DateTransform())
-        startTime   <- (map["start_time"], DateTransform())
-        endTime     <- (map["end_time"], DateTransform())
-        startCity   <- map["start_city"]
-        requestID   <- map["request_id"]
-        productID   <- map["product_id"]
-        
-        status = .unknown
-        if let value = map["status"].currentValue as? String {
-            status = RideStatusFactory.convertRideStatus(value)
-        }
+    enum CodingKeys: String, CodingKey {
+        case distance    = "distance"
+        case requestTime = "request_time"
+        case startTime   = "start_time"
+        case endTime     = "end_time"
+        case startCity   = "start_city"
+        case requestID   = "request_id"
+        case productID   = "product_id"
+        case status      = "status"
+    }
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        distance = try container.decodeIfPresent(Double.self, forKey: .distance) ?? 0.0
+        requestTime = try container.decodeIfPresent(Date.self, forKey: .requestTime)
+        startTime = try container.decodeIfPresent(Date.self, forKey: .startTime)
+        endTime = try container.decodeIfPresent(Date.self, forKey: .endTime)
+        startCity = try container.decodeIfPresent(TripCity.self, forKey: .startCity)
+        requestID = try container.decodeIfPresent(String.self, forKey: .requestID)
+        productID = try container.decodeIfPresent(String.self, forKey: .productID)
+        status = try container.decodeIfPresent(RideStatus.self, forKey: .status) ?? .unknown
     }
 }
 
@@ -111,7 +106,7 @@ extension UserActivity: UberModel {
 /**
 *  Information relating to a city in a trip activity.
 */
-@objc(UBSDKTripCity) public class TripCity : NSObject {
+@objc(UBSDKTripCity) public class TripCity: NSObject, Codable {
     /// Latitude of city location.
     @objc public private(set) var latitude: Float = 0.0
     
@@ -120,15 +115,10 @@ extension UserActivity: UberModel {
     
     /// Display name of city.
     @objc public private(set) var name: String?
-    
-    public required init?(map: Map) {
-    }
-}
 
-extension TripCity: Mappable {
-    public func mapping(map: Map) {
-        latitude  <- map["latitude"]
-        longitude <- map["longitude"]
-        name      <- map["display_name"]
+    enum CodingKeys: String, CodingKey {
+        case latitude  = "latitude"
+        case longitude = "longitude"
+        case name      = "display_name"
     }
 }

--- a/source/UberRides/Model/UserProfile.swift
+++ b/source/UberRides/Model/UserProfile.swift
@@ -22,14 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: UserProfile
 
 /**
 *  Information regarding an Uber user.
 */
-@objc(UBSDKUserProfile) public class UserProfile: NSObject {
+@objc(UBSDKUserProfile) public class UserProfile: NSObject, Codable {
     /// First name of the Uber user.
     @objc public private(set) var firstName: String?
     
@@ -47,18 +45,13 @@ import ObjectMapper
     
     /// Unique identifier of the Uber user.
     @objc public private(set) var UUID: String?
-    
-    public required init?(map: Map) {
-    }
-}
 
-extension UserProfile: UberModel {
-    public func mapping(map: Map) {
-        firstName   <- map["first_name"]
-        lastName    <- map["last_name"]
-        email       <- map["email"]
-        picturePath <- map["picture"]
-        promoCode   <- map["promo_code"]
-        UUID        <- map["uuid"]
+    enum CodingKeys: String, CodingKey {
+        case firstName   = "first_name"
+        case lastName    = "last_name"
+        case email       = "email"
+        case picturePath = "picture"
+        case promoCode   = "promo_code"
+        case UUID        = "uuid"
     }
 }

--- a/source/UberRides/Model/UserProfile.swift
+++ b/source/UberRides/Model/UserProfile.swift
@@ -44,7 +44,7 @@
     @objc public private(set) var promoCode: String?
     
     /// Unique identifier of the Uber user.
-    @objc public private(set) var UUID: String?
+    @objc public private(set) var UUID: String
 
     enum CodingKeys: String, CodingKey {
         case firstName   = "first_name"
@@ -53,5 +53,15 @@
         case picturePath = "picture"
         case promoCode   = "promo_code"
         case UUID        = "uuid"
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        firstName = try container.decodeIfPresent(String.self, forKey: .firstName)
+        lastName = try container.decodeIfPresent(String.self, forKey: .lastName)
+        email = try container.decodeIfPresent(String.self, forKey: .email)
+        picturePath = try container.decodeIfPresent(String.self, forKey: .picturePath)
+        promoCode = try container.decodeIfPresent(String.self, forKey: .promoCode)
+        UUID = try container.decode(String.self, forKey: .UUID)
     }
 }

--- a/source/UberRides/Model/Vehicle.swift
+++ b/source/UberRides/Model/Vehicle.swift
@@ -30,16 +30,16 @@
 @objc(UBSDKVehicle) public class Vehicle: NSObject, Codable {
     
     /// The license plate number of the vehicle.
-    @objc public private(set) var licensePlate: String?
+    @objc public private(set) var licensePlate: String = ""
     
     /// The vehicle make or brand.
-    @objc public private(set) var make: String?
+    @objc public private(set) var make: String = ""
     
     /// The vehicle model or type.
-    @objc public private(set) var model: String?
+    @objc public private(set) var model: String = ""
     
     /// The URL to a stock photo of the vehicle (may be null).
-    @objc public private(set) var pictureURL: String?
+    @objc public private(set) var pictureURL: URL?
 
     enum CodingKeys: String, CodingKey {
         case make         = "make"

--- a/source/UberRides/Model/Vehicle.swift
+++ b/source/UberRides/Model/Vehicle.swift
@@ -22,14 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
 // MARK: Vehicle
 
 /**
  *  Contains information for an Uber driver's car.
  */
-@objc(UBSDKVehicle) public class Vehicle: NSObject {
+@objc(UBSDKVehicle) public class Vehicle: NSObject, Codable {
     
     /// The license plate number of the vehicle.
     @objc public private(set) var licensePlate: String?
@@ -42,16 +40,11 @@ import ObjectMapper
     
     /// The URL to a stock photo of the vehicle (may be null).
     @objc public private(set) var pictureURL: String?
-    
-    public required init?(map: Map) {
-    }
-}
 
-extension Vehicle: UberModel {
-    public func mapping(map: Map) {
-        make         <- map["make"]
-        model        <- map["model"]
-        licensePlate <- map["license_plate"]
-        pictureURL   <- map["picture_url"]
+    enum CodingKeys: String, CodingKey {
+        case make         = "make"
+        case model        = "model"
+        case licensePlate = "license_plate"
+        case pictureURL   = "picture_url"
     }
 }

--- a/source/UberRides/OAuth/AccessTokenFactory.swift
+++ b/source/UberRides/OAuth/AccessTokenFactory.swift
@@ -29,11 +29,6 @@ import Foundation
 Factory class to build access tokens
 */
 @objc(UBSDKAccessTokenFactory) public class AccessTokenFactory: NSObject {
-    
-    @objc public static func createAccessToken(fromJSONString jsonString: String) -> AccessToken? {
-        return ModelMapper<AccessToken>().mapFromJSON(jsonString)
-    }
-    
     /**
      Builds an AccessToken from the provided redirect URL
      
@@ -59,26 +54,28 @@ Factory class to build access tokens
         guard let queryItems = components.queryItems else {
             throw RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidRequest)
         }
-        var queryDictionary = [String : String]()
+        var queryDictionary = [String: Any]()
         for queryItem in queryItems {
             guard let value = queryItem.value else {
                 continue
             }
             queryDictionary[queryItem.name] = value
         }
-        if let error = queryDictionary["error"] {
+        if let error = queryDictionary["error"] as? String {
             guard let error = RidesAuthenticationErrorFactory.createRidesAuthenticationError(rawValue: error) else {
                 throw RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidRequest)
             }
             throw error
         } else {
-            if let expiresInString = queryDictionary["expires_in"] as String? {
+            if let expiresInString = queryDictionary["expires_in"] as? String {
                 let expiresInSeconds =  TimeInterval(atof(expiresInString))
                 let expirationDateSeconds = Date().timeIntervalSince1970 + expiresInSeconds
-                queryDictionary["expiration_date"] = "\(expirationDateSeconds)"
+                queryDictionary["expiration_date"] = expirationDateSeconds
                 queryDictionary.removeValue(forKey: "expires_in")
             }
-            if let token = AccessToken(JSON: queryDictionary) {
+            
+            if let json = try? JSONSerialization.data(withJSONObject: queryDictionary, options: []),
+                let token = try? JSONDecoder.uberDecoder.decode(AccessToken.self, from: json) {
                 return token
             }
         }

--- a/source/UberRides/Request.swift
+++ b/source/UberRides/Request.swift
@@ -148,13 +148,12 @@ class Request: NSObject {
                     break errorCheck
                 }
                 
-                let jsonString = String(data: data!, encoding: String.Encoding.utf8)!
                 if statusCode >= 400 && statusCode <= 499 {
-                    ridesError = ModelMapper<RidesClientError>().mapFromJSON(jsonString)
+                    ridesError = try? JSONDecoder.uberDecoder.decode(RidesClientError.self, from: data!)
                 } else if (statusCode >= 500 && statusCode <= 599) {
-                    ridesError = ModelMapper<RidesServerError>().mapFromJSON(jsonString)
+                    ridesError = try? JSONDecoder.uberDecoder.decode(RidesServerError.self, from: data!)
                 } else {
-                    ridesError = ModelMapper<RidesUnknownError>().mapFromJSON(jsonString)
+                    ridesError = try? JSONDecoder.uberDecoder.decode(RidesUnknownError.self, from: data!)
                 }
                 
                 ridesError?.status = statusCode

--- a/source/UberRides/RidesClient.swift
+++ b/source/UberRides/RidesClient.swift
@@ -187,8 +187,9 @@ import CoreLocation
     private func apiCallForRideResponse(_ endpoint: UberAPI, completion:@escaping (_ ride: Ride?, _ response: Response) -> Void) {
         apiCall(endpoint, completion: { response in
             var ride: Ride? = nil
-            if response.error == nil {
-                ride = ModelMapper<Ride>().mapFromJSON(response.toJSONString())
+            if let data = response.data,
+                response.error == nil {
+                ride = try? JSONDecoder.uberDecoder.decode(Ride.self, from: data)
             }
             completion(ride, response)
         })
@@ -229,8 +230,9 @@ import CoreLocation
         let endpoint = Products.getAll(location: location)
         apiCall(endpoint, completion: { response in
             var products: UberProducts?
-            if response.error == nil {
-                products = ModelMapper<UberProducts>().mapFromJSON(response.toJSONString())
+            if let data = response.data,
+                response.error == nil {
+                products = try? JSONDecoder.uberDecoder.decode(UberProducts.self, from: data)
                 if let productList = products?.list {
                     completion(productList, response)
                     return
@@ -250,8 +252,9 @@ import CoreLocation
         let endpoint = Products.getProduct(productID: productID)
         apiCall(endpoint, completion: { response in
             var product: UberProduct?
-            if response.error == nil {
-                product = ModelMapper<UberProduct>().mapFromJSON(response.toJSONString())
+            if let data = response.data,
+                response.error == nil {
+                product = try? JSONDecoder.uberDecoder.decode(UberProduct.self, from: data)
             }
             completion(product, response)
         })
@@ -268,8 +271,9 @@ import CoreLocation
         let endpoint = Estimates.time(location: location, productID: productID)
         apiCall(endpoint, completion: { response in
             var timeEstimates: TimeEstimates?
-            if response.error == nil {
-                timeEstimates = ModelMapper<TimeEstimates>().mapFromJSON(response.toJSONString())
+            if let data = response.data,
+                response.error == nil {
+                timeEstimates = try? JSONDecoder.uberDecoder.decode(TimeEstimates.self, from: data)
                 if let estimateList = timeEstimates?.list {
                     completion(estimateList, response)
                     return
@@ -291,8 +295,9 @@ import CoreLocation
                                        endLocation: dropoffLocation)
         apiCall(endpoint, completion: { response in
             var priceEstimates: PriceEstimates?
-            if response.error == nil {
-                priceEstimates = ModelMapper<PriceEstimates>().mapFromJSON(response.toJSONString())
+            if let data = response.data,
+                response.error == nil {
+                priceEstimates = try? JSONDecoder.uberDecoder.decode(PriceEstimates.self, from: data)
                 if let estimateList = priceEstimates?.list {
                     completion(estimateList, response)
                     return
@@ -313,8 +318,9 @@ import CoreLocation
         let endpoint = History.get(offset: offset, limit: limit)
         apiCall(endpoint, completion: { response in
             var history: TripHistory?
-            if response.error == nil {
-                history = ModelMapper<TripHistory>().mapFromJSON(response.toJSONString())
+            if let data = response.data,
+                response.error == nil {
+                history = try? JSONDecoder.uberDecoder.decode(TripHistory.self, from: data)
             }
             completion(history, response)
         })
@@ -329,8 +335,9 @@ import CoreLocation
         let endpoint = Me.userProfile
         apiCall(endpoint, completion: { response in
             var userProfile: UserProfile?
-            if response.error == nil {
-                userProfile = ModelMapper<UserProfile>().mapFromJSON(response.toJSONString())
+            if let data = response.data,
+                response.error == nil {
+                userProfile = try? JSONDecoder.uberDecoder.decode(UserProfile.self, from: data)
             }
             completion(userProfile, response)
         })
@@ -378,8 +385,9 @@ import CoreLocation
         let endpoint = Requests.estimate(rideParameters: parameters)
         apiCall(endpoint, completion: { response in
             var estimate: RideEstimate? = nil
-            if response.error == nil {
-                estimate = ModelMapper<RideEstimate>().mapFromJSON(response.toJSONString())
+            if let data = response.data,
+                response.error == nil {
+                estimate = try? JSONDecoder.uberDecoder.decode(RideEstimate.self, from: data)
             }
             completion(estimate, response)
         })
@@ -396,7 +404,8 @@ import CoreLocation
             var paymentMethods = [PaymentMethod]()
             var lastUsed: PaymentMethod?
             if response.error == nil,
-                let allPayments = ModelMapper<PaymentMethods>().mapFromJSON(response.toJSONString()),
+                let data = response.data,
+                let allPayments = try? JSONDecoder.uberDecoder.decode(PaymentMethods.self, from: data),
                 let payments = allPayments.list {
                 paymentMethods = payments
                 lastUsed = paymentMethods.filter({$0.methodID == allPayments.lastUsed}).first
@@ -416,8 +425,9 @@ import CoreLocation
         let endpoint = Places.getPlace(placeID: placeID)
         apiCall(endpoint, completion: { response in
             var place: Place? = nil
-            if response.error == nil {
-                place = ModelMapper<Place>().mapFromJSON(response.toJSONString())
+            if let data = response.data,
+                response.error == nil {
+                place = try? JSONDecoder.uberDecoder.decode(Place.self, from: data)
             }
             completion(place, response)
         })
@@ -434,8 +444,9 @@ import CoreLocation
         let endpoint = Places.putPlace(placeID: placeID, address: address)
         apiCall(endpoint, completion: { response in
             var place: Place?
-            if response.error == nil {
-                place = ModelMapper<Place>().mapFromJSON(response.toJSONString())
+            if let data = response.data,
+                response.error == nil {
+                place = try? JSONDecoder.uberDecoder.decode(Place.self, from: data)
             }
             completion(place, response)
         })
@@ -513,8 +524,9 @@ import CoreLocation
         let endpoint = Requests.rideReceipt(requestID: requestID)
         apiCall(endpoint, completion: { response in
             var receipt: RideReceipt?
-            if response.error == nil {
-                receipt = ModelMapper<RideReceipt>().mapFromJSON(response.toJSONString())
+            if let data = response.data,
+                response.error == nil {
+                receipt = try? JSONDecoder.uberDecoder.decode(RideReceipt.self, from: data)
             }
             completion(receipt, response)
         })
@@ -530,8 +542,9 @@ import CoreLocation
         let endpoint = Requests.rideMap(requestID: requestID)
         apiCall(endpoint, completion: { response in
             var map: RideMap?
-            if response.error == nil {
-                map = ModelMapper<RideMap>().mapFromJSON(response.toJSONString())
+            if let data = response.data,
+                response.error == nil {
+                map = try? JSONDecoder.uberDecoder.decode(RideMap.self, from: data)
             }
             completion(map, response)
         })
@@ -548,8 +561,9 @@ import CoreLocation
         let endpoint = OAuth.refresh(clientID: clientID, refreshToken: refreshToken)
         apiCall(endpoint) { response in
             var accessToken: AccessToken?
-            if response.error == nil {
-                accessToken = ModelMapper<AccessToken>().mapFromJSON(response.toJSONString())
+            if let data = response.data,
+                response.error == nil {
+                accessToken = try? JSONDecoder.uberDecoder.decode(AccessToken.self, from: data)
             }
             completion(accessToken, response)
         }

--- a/source/UberRides/Utilities/Codable+Uber.swift
+++ b/source/UberRides/Utilities/Codable+Uber.swift
@@ -1,8 +1,8 @@
 //
-//  ModelMapper.swift
+//  Codable+Uber.swift
 //  UberRides
 //
-//  Copyright © 2016 Uber Technologies, Inc. All rights reserved.
+//  Copyright © 2015 Uber Technologies, Inc. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -22,24 +22,11 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import ObjectMapper
-
-protocol UberModel: Mappable {
-    init?(map: Map)
-    mutating func mapping(map: Map)
-}
-
-/**
- *  Layer between models and external callers mapping JSON to and from models.
- */
-struct ModelMapper<U> where U:UberModel {
-    /**
-     Map a JSON string representation to a model that conforms to the Mappable protocol.
-     
-     - parameter json: string representing the JSON information.
-     - returns: an object that conforms to the Mappable protocol.
-     */
-    func mapFromJSON(_ json: String) -> U? {
-        return Mapper<U>().map(JSONString: json)
+extension JSONDecoder {
+    /// JSON Decoder tailored to the Uber API JSON
+    static var uberDecoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        return decoder
     }
 }

--- a/source/UberRidesTests/APIManagerTests.swift
+++ b/source/UberRidesTests/APIManagerTests.swift
@@ -29,7 +29,7 @@ import CoreLocation
 let offset = 1
 let limit = 25
 let requestID = "request1234"
-let placeID = Place.Home
+let placeID = Place.home
 
 struct ExpectedEndpoint {
     static let GetProducts = "https://sandbox-api.uber.com/v1/products?latitude=\(pickupLat)&longitude=\(pickupLong)"
@@ -331,7 +331,7 @@ class APIManagerTests: XCTestCase {
      Tests the GET /v1/places/{place_id} endpoint.
      */
     func testGetPlace() {
-        let placeID = Place.Home
+        let placeID = Place.home
         let request = buildRequestForEndpoint(Places.getPlace(placeID: placeID))
         XCTAssertEqual(request.httpMethod, Method.get.rawValue)
         if let url = request.url {
@@ -347,7 +347,7 @@ class APIManagerTests: XCTestCase {
      */
     func testPutPlace() {
         let testAddress = "testAddress"
-        let placeID = Place.Home
+        let placeID = Place.home
         let request = buildRequestForEndpoint(Places.putPlace(placeID: placeID, address: testAddress))
         XCTAssertEqual(request.httpMethod, Method.put.rawValue)
         if let url = request.url {
@@ -381,7 +381,7 @@ class APIManagerTests: XCTestCase {
      Tests the PATCH /v1/requests/curent endpoint.
      */
     func testPatchCurrentRequest() {
-        let rideParams = RideParameters(pickupPlaceID: Place.Home, dropoffPlaceID: nil)
+        let rideParams = RideParameters(pickupPlaceID: Place.home, dropoffPlaceID: nil)
         let request = buildRequestForEndpoint(Requests.patchCurrent(rideParameters: rideParams))
         XCTAssertEqual(request.httpMethod, "PATCH")
         if let url = request.url {
@@ -413,14 +413,14 @@ class APIManagerTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(dictionary["start_place_id"] as? String, Place.Home)
+        XCTAssertEqual(dictionary["start_place_id"] as? String, Place.home)
     }
     
     /**
      Tests the PATCH /v1/requests/{request_id} endpoint.
      */
     func testPatchRequestByID() {
-        let rideParams = RideParameters(pickupPlaceID: Place.Home, dropoffPlaceID: nil)
+        let rideParams = RideParameters(pickupPlaceID: Place.home, dropoffPlaceID: nil)
         let request = buildRequestForEndpoint(Requests.patchRequest(requestID: requestID, rideParameters: rideParams))
         XCTAssertEqual(request.httpMethod, "PATCH")
         if let url = request.url {
@@ -452,7 +452,7 @@ class APIManagerTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(dictionary["start_place_id"] as? String, Place.Home)
+        XCTAssertEqual(dictionary["start_place_id"] as? String, Place.home)
     }
     
     /**

--- a/source/UberRidesTests/AccessTokenFactoryTests.swift
+++ b/source/UberRidesTests/AccessTokenFactoryTests.swift
@@ -60,7 +60,7 @@ class AccessTokenFactoryTests: XCTestCase {
             XCTAssertNotNil(token)
             XCTAssertEqual(token.tokenString, tokenString)
             XCTAssertEqual(token.refreshToken, refreshTokenString)
-            XCTAssertEqual(token.grantedScopes?.toRidesScopeString(), allowedScopesString)
+            XCTAssertEqual(token.grantedScopes.toRidesScopeString(), allowedScopesString)
             
             guard let expiration = token.expirationDate?.timeIntervalSince1970 else {
                 XCTAssert(false)
@@ -129,7 +129,7 @@ class AccessTokenFactoryTests: XCTestCase {
             XCTAssertEqual(token.tokenString, tokenString)
             XCTAssertNil(token.refreshToken)
             XCTAssertNil(token.expirationDate)
-            XCTAssertEqual(token.grantedScopes!, [RidesScope]())
+            XCTAssertEqual(token.grantedScopes, [RidesScope]())
         } catch _ as NSError {
             XCTAssert(false)
         } catch {
@@ -158,10 +158,9 @@ class AccessTokenFactoryTests: XCTestCase {
     }
     
     func testParseTokenFromURL_withFragmentAndQuery_withSuccess() {
-        var components = URLComponents()
+        var components = URLComponents(string: redirectURI)!
         components.fragment = "access_token=\(tokenString)&refresh_token=\(refreshTokenString)"
         components.query = "expires_in=\(expirationTime)&scope=\(allowedScopesString)"
-        components.host = redirectURI
         guard let url = components.url else {
             XCTAssert(false)
             return
@@ -173,7 +172,7 @@ class AccessTokenFactoryTests: XCTestCase {
             XCTAssertNotNil(token)
             XCTAssertEqual(token.tokenString, tokenString)
             XCTAssertEqual(token.refreshToken, refreshTokenString)
-            XCTAssertEqual(token.grantedScopes?.toRidesScopeString(), allowedScopesString)
+            XCTAssertEqual(token.grantedScopes.toRidesScopeString(), allowedScopesString)
             
             guard let expiration = token.expirationDate?.timeIntervalSince1970 else {
                 XCTAssert(false)
@@ -183,8 +182,6 @@ class AccessTokenFactoryTests: XCTestCase {
             let timeDiff = abs(expiration - expectedExpirationInterval)
             XCTAssertLessThanOrEqual(timeDiff, maxExpirationDifference)
             
-        } catch _ as NSError {
-            XCTAssert(false)
         } catch {
             XCTAssert(false)
         }
@@ -204,7 +201,7 @@ class AccessTokenFactoryTests: XCTestCase {
             XCTAssertEqual(token.tokenString, tokenString)
             XCTAssertNil(token.refreshToken)
             XCTAssertNil(token.expirationDate)
-            XCTAssertEqual(token.grantedScopes!, [RidesScope]())
+            XCTAssertEqual(token.grantedScopes, [RidesScope]())
         } catch _ as NSError {
             XCTAssert(false)
         } catch {
@@ -215,7 +212,7 @@ class AccessTokenFactoryTests: XCTestCase {
     func testParseValidJsonStringToAccessToken() {
         let tokenString = "tokenString1234"
         let jsonString = "{\"access_token\": \"\(tokenString)\"}"
-        let accessToken = AccessTokenFactory.createAccessToken(fromJSONString: jsonString)
+        let accessToken = try? JSONDecoder.uberDecoder.decode(AccessToken.self, from: jsonString.data(using: .utf8)!)
         
         XCTAssertNotNil(accessToken)
         XCTAssertEqual(accessToken?.tokenString, tokenString)
@@ -224,7 +221,7 @@ class AccessTokenFactoryTests: XCTestCase {
     func testParseInvalidJsonStringToAccessToken() {
         let tokenString = "tokenString1234"
         let jsonString = "{\"access_token\": \"\(tokenString)\""
-        let accessToken = AccessTokenFactory.createAccessToken(fromJSONString: jsonString)
+        let accessToken = try? JSONDecoder.uberDecoder.decode(AccessToken.self, from: jsonString.data(using: .utf8)!)
         
         XCTAssertNil(accessToken)
     }

--- a/source/UberRidesTests/LoginButtonTests.swift
+++ b/source/UberRidesTests/LoginButtonTests.swift
@@ -36,8 +36,7 @@ class LoginButtonTests : XCTestCase {
         Configuration.restoreDefaults()
         Configuration.shared.isSandbox = true
         keychain = KeychainWrapper()
-        let tokenData = ["access_token" : "testTokenString"]
-        testToken = AccessToken(JSON: tokenData)
+        testToken = AccessToken(tokenString: "testTokenString")
     }
     
     override func tearDown() {

--- a/source/UberRidesTests/OAuthTests.swift
+++ b/source/UberRidesTests/OAuthTests.swift
@@ -267,7 +267,7 @@ class OAuthTests: XCTestCase {
         let result = keychain.getObjectForKey(key) as! AccessToken
         XCTAssertEqual(result.tokenString, token.tokenString)
         XCTAssertEqual(result.refreshToken, token.refreshToken)
-        XCTAssertEqual(result.grantedScopes!, token.grantedScopes!)
+        XCTAssertEqual(result.grantedScopes, token.grantedScopes)
         
         XCTAssertTrue(keychain.deleteObjectForKey(key))
         
@@ -293,7 +293,7 @@ class OAuthTests: XCTestCase {
         let result = keychain.getObjectForKey(key) as! AccessToken
         XCTAssertEqual(result.tokenString, newToken.tokenString)
         XCTAssertEqual(result.refreshToken, newToken.refreshToken)
-        XCTAssertEqual(result.grantedScopes!, newToken.grantedScopes!)
+        XCTAssertEqual(result.grantedScopes, newToken.grantedScopes)
         
         XCTAssertTrue(keychain.deleteObjectForKey(key))
         
@@ -512,10 +512,11 @@ private class UIViewControllerMock : UIViewController {
 
 func tokenFixture(_ accessToken: String = "token") -> AccessToken?
 {
-    var jsonDictionary = [String : AnyObject]()
-    jsonDictionary["access_token"] = accessToken as AnyObject?
-    jsonDictionary["refresh_token"] = "refresh" as AnyObject?
-    jsonDictionary["expires_in"] = "10030.23" as AnyObject?
-    jsonDictionary["scope"] = "profile history" as AnyObject?
-    return AccessToken(JSON: jsonDictionary)
+    var jsonDictionary = [String: String]()
+    jsonDictionary["access_token"] = accessToken
+    jsonDictionary["refresh_token"] = "refresh"
+    jsonDictionary["expires_in"] = "10030.23"
+    jsonDictionary["scope"] = "profile history"
+    let jsonData = try! JSONEncoder().encode(jsonDictionary)
+    return try? JSONDecoder.uberDecoder.decode(AccessToken.self, from: jsonData)
 }

--- a/source/UberRidesTests/ObjectMappingTests.swift
+++ b/source/UberRidesTests/ObjectMappingTests.swift
@@ -51,7 +51,7 @@ class ObjectMappingTests: XCTestCase {
                 XCTAssertEqual(product!.name, "UberBLACK")
                 XCTAssertEqual(product!.details, "The original Uber")
                 XCTAssertEqual(product!.capacity, 4)
-                XCTAssertEqual(product!.imagePath, "http://d1a3f4spazzrp4.cloudfront.net/car.jpg")
+                XCTAssertEqual(product!.imagePath, URL(string: "http://d1a3f4spazzrp4.cloudfront.net/car.jpg")!)
                 
                 let priceDetails = product!.priceDetails
                 XCTAssertNotNil(priceDetails)
@@ -244,7 +244,7 @@ class ObjectMappingTests: XCTestCase {
                 
                 XCTAssertNotNil(history[0].startCity)
                 
-                let city = history[0].startCity!
+                let city = history[0].startCity
                 XCTAssertEqual(city.name, "San Francisco")
                 XCTAssertEqual(city.latitude, 37.7749295)
                 XCTAssertEqual(city.longitude, -122.4194155)
@@ -355,11 +355,11 @@ class ObjectMappingTests: XCTestCase {
                 XCTAssertEqual(trip.vehicle!.make, "Bugatti")
                 XCTAssertEqual(trip.vehicle!.model, "Veyron")
                 XCTAssertEqual(trip.vehicle!.licensePlate, "I<3Uber")
-                XCTAssertEqual(trip.vehicle!.pictureURL, "https://d1w2poirtb3as9.cloudfront.net/car.jpeg")
+                XCTAssertEqual(trip.vehicle!.pictureURL, URL(string: "https://d1w2poirtb3as9.cloudfront.net/car.jpeg")!)
                 
                 XCTAssertNotNil(trip.driver)
                 XCTAssertEqual(trip.driver!.name, "Bob")
-                XCTAssertEqual(trip.driver!.pictureURL, "https://d1w2poirtb3as9.cloudfront.net/img.jpeg")
+                XCTAssertEqual(trip.driver!.pictureURL, URL(string: "https://d1w2poirtb3as9.cloudfront.net/img.jpeg")!)
                 XCTAssertEqual(trip.driver!.phoneNumber, "(555)555-5555")
                 XCTAssertEqual(trip.driver!.rating, 5)
                 
@@ -388,8 +388,8 @@ class ObjectMappingTests: XCTestCase {
                 XCTAssertEqual(estimate!.pickupEstimate, 2)
                 
                 XCTAssertNotNil(estimate!.priceEstimate)
-                XCTAssertEqual(estimate!.priceEstimate!.surgeConfirmationURL, "https://api.uber.com/v1/surge-confirmations/7d604f5e")
-                XCTAssertEqual(estimate!.priceEstimate!.surgeConfirmationID, "7d604f5e")
+                XCTAssertEqual(estimate!.priceEstimate.surgeConfirmationURL, "https://api.uber.com/v1/surge-confirmations/7d604f5e")
+                XCTAssertEqual(estimate!.priceEstimate.surgeConfirmationID, "7d604f5e")
                 
                 XCTAssertNotNil(estimate!.distanceEstimate)
                 XCTAssertEqual(estimate!.distanceEstimate!.distance, 2.1)
@@ -408,8 +408,8 @@ class ObjectMappingTests: XCTestCase {
                 XCTAssertEqual(estimate!.pickupEstimate, -1)
                 
                 XCTAssertNotNil(estimate!.priceEstimate)
-                XCTAssertEqual(estimate!.priceEstimate!.surgeConfirmationURL, "https://api.uber.com/v1/surge-confirmations/7d604f5e")
-                XCTAssertEqual(estimate!.priceEstimate!.surgeConfirmationID, "7d604f5e")
+                XCTAssertEqual(estimate!.priceEstimate.surgeConfirmationURL, "https://api.uber.com/v1/surge-confirmations/7d604f5e")
+                XCTAssertEqual(estimate!.priceEstimate.surgeConfirmationID, "7d604f5e")
                 
                 XCTAssertNotNil(estimate!.distanceEstimate)
                 XCTAssertEqual(estimate!.distanceEstimate!.distance, 2.1)
@@ -495,11 +495,7 @@ class ObjectMappingTests: XCTestCase {
                 
                 XCTAssertEqual(receipt.requestID, "b5512127-a134-4bf4-b1ba-fe9f48f56d9d")
                 
-                guard let charges = receipt.charges else {
-                    XCTAssert(false)
-                    return
-                }
-                
+                let charges = receipt.charges
                 XCTAssertEqual(charges.count, 3)
                 XCTAssertEqual(charges[0].name, "Base Fare")
                 XCTAssertEqual(charges[0].amount, 2.20)
@@ -520,10 +516,7 @@ class ObjectMappingTests: XCTestCase {
                 XCTAssertEqual(surgeCharge.amount, 4.26)
                 XCTAssertEqual(surgeCharge.type, "surge")
                 
-                guard let chargeAdjustments = receipt.chargeAdjustments else {
-                    XCTAssert(false)
-                    return
-                }
+                let chargeAdjustments = receipt.chargeAdjustments
                 
                 XCTAssertEqual(chargeAdjustments.count, 3)
                 XCTAssertEqual(chargeAdjustments[0].name, "Promotion")
@@ -563,10 +556,7 @@ class ObjectMappingTests: XCTestCase {
                 
                 XCTAssertEqual(receipt.requestID, "b5512127-a134-4bf4-b1ba-fe9f48f56d9d")
                 
-                guard let charges = receipt.charges else {
-                    XCTAssert(false)
-                    return
-                }
+                let charges = receipt.charges
                 
                 XCTAssertEqual(charges.count, 3)
                 XCTAssertEqual(charges[0].name, "Base Fare")
@@ -581,10 +571,7 @@ class ObjectMappingTests: XCTestCase {
                 
                 XCTAssertNil(receipt.surgeCharge)
                 
-                guard let chargeAdjustments = receipt.chargeAdjustments else {
-                    XCTAssert(false)
-                    return
-                }
+                let chargeAdjustments = receipt.chargeAdjustments
                 
                 XCTAssertEqual(chargeAdjustments.count, 3)
                 XCTAssertEqual(chargeAdjustments[0].name, "Promotion")
@@ -643,7 +630,7 @@ class ObjectMappingTests: XCTestCase {
                     return
                 }
                 
-                XCTAssertEqual(map.path, "https://trip.uber.com/abc123")
+                XCTAssertEqual(map.path, URL(string: "https://trip.uber.com/abc123")!)
                 XCTAssertEqual(map.requestID, "b5512127-a134-4bf4-b1ba-fe9f48f56d9d")
                 
                 return

--- a/source/UberRidesTests/ObjectMappingTests.swift
+++ b/source/UberRidesTests/ObjectMappingTests.swift
@@ -23,7 +23,6 @@
 //  THE SOFTWARE.
 
 import XCTest
-import ObjectMapper
 @testable import UberRides
 
 class ObjectMappingTests: XCTestCase {
@@ -46,8 +45,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getProductID", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
-                let product = ModelMapper<UberProduct>().mapFromJSON(JSONString)
+                let product = try? JSONDecoder.uberDecoder.decode(UberProduct.self, from: jsonData)
                 XCTAssertNotNil(product)
                 XCTAssertEqual(product!.productID, "d4abaae7-f4d6-4152-91cc-77523e8165a4")
                 XCTAssertEqual(product!.name, "UberBLACK")
@@ -81,12 +79,12 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getProductID", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                var JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
+                let JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
                 
                 // Represent some bad JSON
-                JSONString = JSONString.replacingOccurrences(of: "[", with: "")
-                
-                let product = ModelMapper<UberProducts>().mapFromJSON(JSONString)
+                let jsonData = JSONString.replacingOccurrences(of: "[", with: "").data(using: .utf8)!
+
+                let product = try? JSONDecoder.uberDecoder.decode(UberProducts.self, from: jsonData)
                 XCTAssertNil(product)
             }
         }
@@ -99,8 +97,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getProducts", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
-                let products = ModelMapper<UberProducts>().mapFromJSON(JSONString)
+                let products = try? JSONDecoder.uberDecoder.decode(UberProducts.self, from: jsonData)
                 XCTAssertNotNil(products)
                 XCTAssertNotNil(products!.list)
                 XCTAssertEqual(products!.list!.count, 5)
@@ -120,12 +117,12 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getProducts", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                var JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
+                let JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
                 
                 // Represent some bad JSON
-                JSONString = JSONString.replacingOccurrences(of: "[", with: "")
-                
-                let products = ModelMapper<UberProducts>().mapFromJSON(JSONString)
+                let jsonData = JSONString.replacingOccurrences(of: "[", with: "").data(using: .utf8)!
+
+                let products = try? JSONDecoder.uberDecoder.decode(UberProducts.self, from: jsonData)
                 XCTAssertNil(products)
             }
         }
@@ -138,8 +135,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getTimeEstimates", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
-                let timeEstimates = ModelMapper<TimeEstimates>().mapFromJSON(JSONString)
+                let timeEstimates = try? JSONDecoder.uberDecoder.decode(TimeEstimates.self, from: jsonData)
                 XCTAssertNotNil(timeEstimates)
                 XCTAssertNotNil(timeEstimates!.list)
                 
@@ -162,12 +158,12 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getTimeEstimates", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                var JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
+                let JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
                 
                 // Represent some bad JSON
-                JSONString = JSONString.replacingOccurrences(of: "[", with: "")
-                
-                let timeEstimates = ModelMapper<TimeEstimates>().mapFromJSON(JSONString)
+                let jsonData = JSONString.replacingOccurrences(of: "[", with: "").data(using: .utf8)!
+
+                let timeEstimates = try? JSONDecoder.uberDecoder.decode(TimeEstimates.self, from: jsonData)
                 XCTAssertNil(timeEstimates)
             }
         }
@@ -180,8 +176,12 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getPriceEstimates", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
-                let priceEstimates = ModelMapper<PriceEstimates>().mapFromJSON(JSONString)
+                var priceEstimates: PriceEstimates?
+                do {
+                    priceEstimates = try JSONDecoder.uberDecoder.decode(PriceEstimates.self, from: jsonData)
+                } catch let e {
+                    XCTFail(e.localizedDescription)
+                }
                 XCTAssertNotNil(priceEstimates)
                 XCTAssertNotNil(priceEstimates!.list)
                 
@@ -207,12 +207,12 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getPriceEstimates", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                var JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
+                let JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
                 
                 // Represent some bad JSON
-                JSONString = JSONString.replacingOccurrences(of: "[", with: "")
-                
-                let priceEstimates = ModelMapper<PriceEstimates>().mapFromJSON(JSONString)
+                let jsonData = JSONString.replacingOccurrences(of: "[", with: "").data(using: .utf8)!
+
+                let priceEstimates = try? JSONDecoder.uberDecoder.decode(PriceEstimates.self, from: jsonData)
                 XCTAssertNil(priceEstimates)
             }
         }
@@ -225,8 +225,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getHistory", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
-                let userActivity = ModelMapper<TripHistory>().mapFromJSON(JSONString)
+                let userActivity = try? JSONDecoder.uberDecoder.decode(TripHistory.self, from: jsonData)
                 XCTAssertNotNil(userActivity)
                 XCTAssertNotNil(userActivity!.history)
                 XCTAssertEqual(userActivity!.count, 1)
@@ -260,12 +259,12 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getHistory", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                var JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
+                let JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
                 
                 // Represent some bad JSON
-                JSONString = JSONString.replacingOccurrences(of: "[", with: "")
-                
-                let userActivity = ModelMapper<TripHistory>().mapFromJSON(JSONString)
+                let jsonData = JSONString.replacingOccurrences(of: "[", with: "").data(using: .utf8)!
+
+                let userActivity = try? JSONDecoder.uberDecoder.decode(TripHistory.self, from: jsonData)
                 XCTAssertNil(userActivity)
             }
         }
@@ -278,8 +277,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getMe", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding:  String.Encoding.utf8)!
-                let userProfile = ModelMapper<UserProfile>().mapFromJSON(JSONString)
+                let userProfile = try? JSONDecoder.uberDecoder.decode(UserProfile.self, from: jsonData)
                 XCTAssertNotNil(userProfile)
                 XCTAssertEqual(userProfile!.firstName, "Uber")
                 XCTAssertEqual(userProfile!.lastName, "Developer")
@@ -298,10 +296,10 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getMe", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                var JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
-                JSONString = JSONString.replacingOccurrences(of: "{", with: "")
-                
-                let userProfile = ModelMapper<UserProfile>().mapFromJSON(JSONString)
+                let JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
+                let jsonData = JSONString.replacingOccurrences(of: "{", with: "").data(using: .utf8)!
+
+                let userProfile = try? JSONDecoder.uberDecoder.decode(UserProfile.self, from: jsonData)
                 XCTAssertNil(userProfile)
             }
         }
@@ -314,8 +312,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "postRequests", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding:  String.Encoding.utf8)!
-                guard let trip = ModelMapper<Ride>().mapFromJSON(JSONString) else {
+                guard let trip = try? JSONDecoder.uberDecoder.decode(Ride.self, from: jsonData) else {
                     XCTAssert(false)
                     return
                 }
@@ -339,8 +336,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getRequest", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding:  String.Encoding.utf8)!
-                guard let trip = ModelMapper<Ride>().mapFromJSON(JSONString) else {
+                guard let trip = try? JSONDecoder.uberDecoder.decode(Ride.self, from: jsonData) else {
                     XCTAssert(false)
                     return
                 }
@@ -387,8 +383,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "requestEstimate", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding:  String.Encoding.utf8)!
-                let estimate = ModelMapper<RideEstimate>().mapFromJSON(JSONString)
+                let estimate = try? JSONDecoder.uberDecoder.decode(RideEstimate.self, from: jsonData)
                 XCTAssertNotNil(estimate)
                 XCTAssertEqual(estimate!.pickupEstimate, 2)
                 
@@ -408,8 +403,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "requestEstimateNoCars", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding: String.Encoding.utf8)!
-                let estimate = ModelMapper<RideEstimate>().mapFromJSON(JSONString)
+                let estimate = try? JSONDecoder.uberDecoder.decode(RideEstimate.self, from: jsonData)
                 XCTAssertNotNil(estimate)
                 XCTAssertEqual(estimate!.pickupEstimate, -1)
                 
@@ -432,8 +426,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "place", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding:  String.Encoding.utf8)!
-                guard let place = ModelMapper<Place>().mapFromJSON(JSONString) else {
+                guard let place = try? JSONDecoder.uberDecoder.decode(Place.self, from: jsonData) else {
                     XCTAssert(false)
                     return
                 }
@@ -453,8 +446,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "getPaymentMethods", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding:  String.Encoding.utf8)!
-                guard let paymentMethods = ModelMapper<PaymentMethods>().mapFromJSON(JSONString) else {
+                guard let paymentMethods = try? JSONDecoder.uberDecoder.decode(PaymentMethods.self, from: jsonData) else {
                     XCTAssert(false)
                     return
                 }
@@ -496,8 +488,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "rideReceipt", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding:  String.Encoding.utf8)!
-                guard let receipt = ModelMapper<RideReceipt>().mapFromJSON(JSONString) else {
+                guard let receipt = try? JSONDecoder.uberDecoder.decode(RideReceipt.self, from: jsonData) else {
                     XCTAssert(false)
                     return
                 }
@@ -565,8 +556,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "rideReceiptNullSurgeTotalOwed", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding:  String.Encoding.utf8)!
-                guard let receipt = ModelMapper<RideReceipt>().mapFromJSON(JSONString) else {
+                guard let receipt = try? JSONDecoder.uberDecoder.decode(RideReceipt.self, from: jsonData) else {
                     XCTAssert(false)
                     return
                 }
@@ -630,9 +620,9 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "rideReceipt", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                var JSONString = String(data: jsonData, encoding:  String.Encoding.utf8)!
-                JSONString = JSONString.replacingOccurrences(of: "[", with: "")
-                let receipt = ModelMapper<RideReceipt>().mapFromJSON(JSONString)
+                let JSONString = String(data: jsonData, encoding:  String.Encoding.utf8)!
+                let jsonData = JSONString.replacingOccurrences(of: "[", with: "").data(using: .utf8)!
+                let receipt = try? JSONDecoder.uberDecoder.decode(RideReceipt.self, from: jsonData)
                 XCTAssertNil(receipt)
                 return
             }
@@ -648,8 +638,7 @@ class ObjectMappingTests: XCTestCase {
         let bundle = Bundle(for: ObjectMappingTests.self)
         if let path = bundle.path(forResource: "rideMap", ofType: "json") {
             if let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-                let JSONString = String(data: jsonData, encoding:  String.Encoding.utf8)!
-                guard let map = ModelMapper<RideMap>().mapFromJSON(JSONString) else {
+                guard let map = try? JSONDecoder.uberDecoder.decode(RideMap.self, from: jsonData) else {
                     XCTAssert(false)
                     return
                 }

--- a/source/UberRidesTests/RequestButtonTests.swift
+++ b/source/UberRidesTests/RequestButtonTests.swift
@@ -81,10 +81,10 @@ class RequestButtonTests: XCTestCase {
             }
             XCTAssert(foundUserAgent)
         }
-        
+
         let testIdentifier = "testAccessTokenIdentifier"
-        let testToken = AccessToken(JSON: ["access_token" : "testTokenString"])
-        _ = TokenManager.save(accessToken: testToken!, tokenIdentifier: testIdentifier)
+        let testToken = AccessToken(tokenString: "testTokenString")
+        _ = TokenManager.save(accessToken: testToken, tokenIdentifier: testIdentifier)
         defer {
             _ = TokenManager.deleteToken(identifier: testIdentifier)
         }

--- a/source/UberRidesTests/RequestLayerTests.swift
+++ b/source/UberRidesTests/RequestLayerTests.swift
@@ -134,7 +134,7 @@ class RequestLayerTests: XCTestCase {
             XCTAssertTrue(response.error is RidesClientError)
             XCTAssertNotNil(response.error!.meta)
             
-            let meta = response.error!.meta! as! [String: [String: String]]
+                let meta = response.error!.meta! as! [String: [String: String]]
             XCTAssertEqual(meta["surge_confirmation"]!["href"], "api.uber.com/v1/surge-confirmations/abc")
             XCTAssertEqual(meta["surge_confirmation"]!["surge_confirmation_id"], "abc")
             

--- a/source/UberRidesTests/RideRequestViewControllerTests.swift
+++ b/source/UberRidesTests/RideRequestViewControllerTests.swift
@@ -66,8 +66,8 @@ class RideRequestViewControllerTests: XCTestCase {
             expectation = true
         }
         let testIdentifier = "testAccessTokenIdentifier"
-        let testToken = AccessToken(JSON: ["access_token" : "testTokenString"])
-        _ = TokenManager.save(accessToken: testToken!, tokenIdentifier: testIdentifier)
+        let testToken = AccessToken(tokenString: "testTokenString")
+        _ = TokenManager.save(accessToken: testToken, tokenIdentifier: testIdentifier)
         defer {
             _ = TokenManager.deleteToken(identifier: testIdentifier)
         }
@@ -159,7 +159,7 @@ class RideRequestViewControllerTests: XCTestCase {
         var expectation = false
         
         let testIdentifier = "testAccessTokenIdentifier"
-        let testToken = AccessToken(JSON: ["access_token" : "test"])
+        let testToken = AccessToken(tokenString: "test")
         
         _ = TokenManager.deleteToken(identifier: testIdentifier)
         let loginManger = LoginManager(accessTokenIdentifier: testIdentifier, keychainAccessGroup: Configuration.shared.defaultKeychainAccessGroup, loginType: .native)
@@ -319,8 +319,8 @@ class RideRequestViewControllerTests: XCTestCase {
         }
         
         let testIdentifier = "testAccessTokenIdentifier"
-        let testToken = AccessToken(JSON: ["access_token" : "testTokenString"])
-        _ = TokenManager.save(accessToken: testToken!, tokenIdentifier: testIdentifier)
+        let testToken = AccessToken(tokenString: "testTokenString")
+        _ = TokenManager.save(accessToken: testToken, tokenIdentifier: testIdentifier)
         defer {
             _ = TokenManager.deleteToken(identifier: testIdentifier)
         }
@@ -366,8 +366,8 @@ class RideRequestViewControllerTests: XCTestCase {
         }
         
         let testIdentifier = "testAccessTokenIdentifier"
-        let testToken = AccessToken(JSON: ["access_token" : "testTokenString"])
-        _ = TokenManager.save(accessToken: testToken!, tokenIdentifier: testIdentifier)
+        let testToken = AccessToken(tokenString: "testTokenString")
+        _ = TokenManager.save(accessToken: testToken, tokenIdentifier: testIdentifier)
         defer {
             _ = TokenManager.deleteToken(identifier: testIdentifier)
         }
@@ -392,8 +392,8 @@ class RideRequestViewControllerTests: XCTestCase {
             expectation = true
         }
         let testIdentifier = "testAccessTokenIdentifier"
-        let testToken = AccessToken(JSON: ["access_token" : "testTokenString"])
-        _ = TokenManager.save(accessToken: testToken!, tokenIdentifier: testIdentifier)
+        let testToken = AccessToken(tokenString: "testTokenString")
+        _ = TokenManager.save(accessToken: testToken, tokenIdentifier: testIdentifier)
         defer {
             _ = TokenManager.deleteToken(identifier: testIdentifier)
         }
@@ -434,8 +434,8 @@ class RideRequestViewControllerTests: XCTestCase {
             XCTAssertTrue(type(of: viewController) == UIAlertController.self)
         }
         let testIdentifier = "testAccessTokenIdentifier"
-        let testToken = AccessToken(JSON: ["access_token" : "testTokenString"])
-        _ = TokenManager.save(accessToken: testToken!, tokenIdentifier: testIdentifier)
+        let testToken = AccessToken(tokenString: "testTokenString")
+        _ = TokenManager.save(accessToken: testToken, tokenIdentifier: testIdentifier)
         defer {
             _ = TokenManager.deleteToken(identifier: testIdentifier)
         }

--- a/source/UberRidesTests/RideRequestViewTests.swift
+++ b/source/UberRidesTests/RideRequestViewTests.swift
@@ -81,9 +81,7 @@ class RideRequestViewTests: XCTestCase {
      Test that no exception is thrown for authorization if custom access token is passed.
      */
     func testAuthorizeWithCustomAccessToken() {
-        let tokenString = "accessToken1234"
-        let tokenData = ["access_token" : tokenString]
-        let token = AccessToken(JSON: tokenData)
+        let token = AccessToken(tokenString: "accessToken1234")
         let view = RideRequestView(rideParameters: RideParameters(), accessToken: token, frame: CGRect.zero)
         XCTAssertNotNil(view.accessToken)
         XCTAssertEqual(view.accessToken, token)
@@ -93,12 +91,7 @@ class RideRequestViewTests: XCTestCase {
      Test that authorization passes with token in token manager.
      */
     func testAuthorizeWithTokenManagerAccessToken() {
-        let tokenString = "accessToken1234"
-        let tokenData = ["access_token" : tokenString]
-        guard let token = AccessToken(JSON: tokenData) else {
-            XCTAssert(false)
-            return
-        }
+        let token = AccessToken(tokenString: "accessToken1234")
         _ = TokenManager.save(accessToken: token)
         
         let view = RideRequestView()
@@ -112,9 +105,7 @@ class RideRequestViewTests: XCTestCase {
      Test that load is successful when access token is set after initialization.
      */
     func testAuthorizeWithTokenSetAfterInitialization() {
-        let tokenString = "accessToken1234"
-        let tokenData = ["access_token" : tokenString]
-        let token = AccessToken(JSON: tokenData)
+        let token = AccessToken(tokenString: "accessToken1234")
         let view = RideRequestView()
         view.accessToken = token
         XCTAssertNotNil(view.accessToken)
@@ -163,8 +154,8 @@ class RideRequestViewTests: XCTestCase {
         
         let testIdentifier = "testAccessTokenIdentifier"
         _ = TokenManager.deleteToken(identifier: testIdentifier)
-        let testToken = AccessToken(JSON: ["access_token" : "testTokenString"])
-        _ = TokenManager.save(accessToken: testToken!, tokenIdentifier: testIdentifier)
+        let testToken = AccessToken(tokenString: "testTokenString")
+        _ = TokenManager.save(accessToken: testToken, tokenIdentifier: testIdentifier)
         defer {
             _ = TokenManager.deleteToken(identifier: testIdentifier)
         }

--- a/source/UberRidesTests/RidesClientTests.swift
+++ b/source/UberRidesTests/RidesClientTests.swift
@@ -354,7 +354,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "get place")
-        let testPlace = Place.Home
+        let testPlace = Place.home
         
         client.fetchPlace(placeID: testPlace, completion: { place, response in
             guard let place = place else {
@@ -417,7 +417,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "get place not found error")
-        let testPlace = Place.Home
+        let testPlace = Place.home
         
         client.fetchPlace(placeID: testPlace, completion: { place, response in
             XCTAssertNil(place)
@@ -447,7 +447,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.work)
         client.updateRideDetails(requestID: "requestID1234", rideParameters: params, completion: { response in
             XCTAssertNil(response.error)
             XCTAssertEqual(response.statusCode, 204)
@@ -465,7 +465,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.work)
         client.updateRideDetails(requestID: "requestID1234", rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -489,7 +489,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.work)
         client.updateRideDetails(requestID: "requestID1234", rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -513,7 +513,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.work)
         client.updateRideDetails(requestID: "requestID1234", rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -537,7 +537,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.work)
         client.updateCurrentRide(rideParameters: params, completion: { response in
             XCTAssertNil(response.error)
             XCTAssertEqual(response.statusCode, 204)
@@ -555,7 +555,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.work)
         client.updateCurrentRide(rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -579,7 +579,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.work)
         client.updateCurrentRide(rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -603,7 +603,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.work)
         client.updateCurrentRide(rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -627,7 +627,7 @@ class RidesClientTests: XCTestCase {
         }
         
         let expectation = self.expectation(description: "update ride")
-        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.Work)
+        let params = RideParameters(pickupPlaceID: nil, dropoffPlaceID: Place.work)
         client.updateCurrentRide(rideParameters: params, completion: { response in
             guard let error = response.error else {
                 XCTAssert(false)
@@ -860,10 +860,11 @@ class RidesClientTests: XCTestCase {
         
         let expectation = self.expectation(description: "Refresh token completion")
         client.refreshAccessToken(usingRefreshToken: refreshToken, completion: { accessToken, response in
-            guard let accessToken = accessToken, let scopes = accessToken.grantedScopes else {
+            guard let accessToken = accessToken else {
                 XCTAssert(false)
                 return
             }
+            let scopes = accessToken.grantedScopes
             
             XCTAssertEqual(accessToken.tokenString, "Access999Token")
             XCTAssertEqual(accessToken.refreshToken, "888RefreshToken")
@@ -910,11 +911,7 @@ class RidesClientTests: XCTestCase {
      and the token exists
      */
     func testGetAccessTokenSuccess_defaultId_defaultGroup() {
-        let tokenData = [ "access_token" : "testAccessToken" ]
-        guard let token = AccessToken(JSON: tokenData) else {
-            XCTAssert(false)
-            return
-        }
+        let token = AccessToken(tokenString: "testAccessToken")
 
         let keychainHelper = KeychainWrapper()
         
@@ -950,11 +947,7 @@ class RidesClientTests: XCTestCase {
      and the token exists
      */
     func testGetAccessTokenSuccess_customId_defaultGroup() {
-        let tokenData = [ "access_token" : "testAccessToken" ]
-        guard let token = AccessToken(JSON: tokenData) else {
-            XCTAssert(false)
-            return
-        }
+        let token = AccessToken(tokenString: "testAccessToken")
         let keychainHelper = KeychainWrapper()
         
         let tokenKey = "newTokenKey"

--- a/source/UberRidesTests/RidesClientTests.swift
+++ b/source/UberRidesTests/RidesClientTests.swift
@@ -812,7 +812,7 @@ class RidesClientTests: XCTestCase {
             }
             
             XCTAssertEqual(map.requestID, "b5512127-a134-4bf4-b1ba-fe9f48f56d9d")
-            XCTAssertEqual(map.path, "https://trip.uber.com/abc123")
+            XCTAssertEqual(map.path, URL(string: "https://trip.uber.com/abc123")!)
             
             XCTAssertEqual(response.statusCode, 200)
             expectation.fulfill()

--- a/source/UberRidesTests/TokenManagerTests.swift
+++ b/source/UberRidesTests/TokenManagerTests.swift
@@ -37,8 +37,7 @@ class TokenManagerTests: XCTestCase {
         Configuration.bundle = Bundle(for: type(of: self))
         keychain = KeychainWrapper()
         notificationFired = false
-        let tokenData = ["access_token" : "testTokenString"]
-        token = AccessToken(JSON: tokenData)
+        token = AccessToken(tokenString: "testTokenString")
     }
     
     override func tearDown() {


### PR DESCRIPTION
One of the benefits of Swift 4 is that it defines a new set of object serialization/deserialization APIs. Since the SDK currently depends on `ObjectMapper`, a 3rd party library, for its JSON handling, I thought it'd be a good idea to move off `ObjectMapper` to the `Codable` APIs. 

Also, the models were all previously optionals. This makes the SDK harder to use, so I went through the models and added the correct nullability according to documentation and test responses we have.

*Note*: For primitive types, we do not make them optional. This is because Objective-C will not import optional primitives, and these properties will be inaccessible. 

As an alternative, we could use the correct nullability for primitives and attempt to use this workaround to expose objective-c only properties. See [Stack Overflow post](https://stackoverflow.com/questions/32384715/how-to-expose-swift-functions-only-to-objc)

See: 
* https://github.com/apple/swift-evolution/blob/master/proposals/0166-swift-archival-serialization.md
* http://benscheirman.com/2017/06/ultimate-guide-to-json-parsing-with-swift-4/