### PR TITLE
Change open access control to public

### DIFF
--- a/source/UberRides/AppStoreDeeplink.swift
+++ b/source/UberRides/AppStoreDeeplink.swift
@@ -27,7 +27,7 @@ import Foundation
 /**
  *  A Deeplinking object for authenticating a user via the native Uber app
  */
-@objc(UBSDKAppStoreDeeplink) open class AppStoreDeeplink: BaseDeeplink {
+@objc(UBSDKAppStoreDeeplink) public class AppStoreDeeplink: BaseDeeplink {
     
     /**
      Initializes an App Store Deeplink to bring the user to the appstore

--- a/source/UberRides/AuthenticationDeeplink.swift
+++ b/source/UberRides/AuthenticationDeeplink.swift
@@ -27,7 +27,7 @@ import Foundation
 /**
  *  A Deeplinking object for authenticating a user via the native Uber app
  */
-@objc(UBSDKAuthenticationDeeplink) open class AuthenticationDeeplink: BaseDeeplink {
+@objc(UBSDKAuthenticationDeeplink) public class AuthenticationDeeplink: BaseDeeplink {
 
     /**
      Initializes an Authentication Deeplink to request the provided scopes

--- a/source/UberRides/BaseDeeplink.swift
+++ b/source/UberRides/BaseDeeplink.swift
@@ -27,21 +27,21 @@ import Foundation
 /**
  *  A Deeplinking object for authenticating a user via the native Uber app
  */
-@objc(UBSDKBaseDeeplink) open class BaseDeeplink: NSObject, Deeplinking {
+@objc(UBSDKBaseDeeplink) public class BaseDeeplink: NSObject, Deeplinking {
     
     /// The scheme for the auth deeplink
-    open var scheme: String
+    public var scheme: String
     
     /// The domain for the auth deeplink
-    open var domain: String
+    public var domain: String
     
     /// The path for the auth deeplink
-    open var path: String
+    public var path: String
     
     /// The array of query items the deeplink will include
-    open var queryItems: [URLQueryItem]?
+    public var queryItems: [URLQueryItem]?
     
-    open let deeplinkURL: URL
+    public let deeplinkURL: URL
     
     private var waitingOnSystemPromptResponse = false
     private var checkingSystemPromptResponse = false
@@ -74,7 +74,7 @@ import Foundation
      - parameter completion: The completion block to execute once the deeplink has
      executed. Passes in True if the url was successfully opened, false otherwise.
      */
-    @objc open func execute(completion: ((NSError?) -> ())? = nil) {
+    @objc public func execute(completion: ((NSError?) -> ())? = nil) {
 
         let usingIOS9 = ProcessInfo().isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 9, minorVersion: 0, patchVersion: 0))
         

--- a/source/UberRides/Configuration.swift
+++ b/source/UberRides/Configuration.swift
@@ -82,17 +82,17 @@ private let callbackURIStringKey = "URIString"
  default values for Application-wide configuration properties. All properties are 
  configurable via the respective setter method
 */
-@objc(UBSDKConfiguration) open class Configuration : NSObject {
+@objc(UBSDKConfiguration) public class Configuration : NSObject {
     // MARK : Variables
-    @objc open static var shared: Configuration = Configuration()
+    @objc public static var shared: Configuration = Configuration()
     
     /// The .plist file to use, default is Info.plist
-    @objc open static var plistName = "Info"
+    @objc public static var plistName = "Info"
     
     /// The bundle that contains the .plist file. Default is the mainBundle()
-    @objc open static var bundle = Bundle.main
+    @objc public static var bundle = Bundle.main
     
-    @objc open var processPool = WKProcessPool()
+    @objc public var processPool = WKProcessPool()
 
     /**
      Gets the client ID of this app. Defaults to the value stored in your Application's
@@ -100,7 +100,7 @@ private let callbackURIStringKey = "URIString"
 
      - returns: The string to use for the Client ID
      */
-    @objc open var clientID: String
+    @objc public var clientID: String
 
     private var callbackURIs = [CallbackURIType: String]()
 
@@ -110,7 +110,7 @@ private let callbackURIStringKey = "URIString"
 
      - returns: The app's name
      */
-    @objc open var appDisplayName: String
+    @objc public var appDisplayName: String
 
     /**
      Gets the Server Token of this app. Defaults to the value stored in your Appication's
@@ -120,7 +120,7 @@ private let callbackURIStringKey = "URIString"
 
      - returns: The string Representing your app's server token
      */
-    @objc open var serverToken: String?
+    @objc public var serverToken: String?
 
     /**
      Gets the default keychain access group to save access tokens to. Advanced setting
@@ -128,7 +128,7 @@ private let callbackURIStringKey = "URIString"
 
      - returns: The default keychain access group to use
      */
-    @objc open var defaultKeychainAccessGroup: String = ""
+    @objc public var defaultKeychainAccessGroup: String = ""
 
     /**
      Gets the default key to use when saving access tokens to the keychain. Defaults
@@ -136,14 +136,14 @@ private let callbackURIStringKey = "URIString"
 
      - returns: The default access token identifier to use
      */
-    @objc open var defaultAccessTokenIdentifier: String = "RidesAccessTokenKey"
+    @objc public var defaultAccessTokenIdentifier: String = "RidesAccessTokenKey"
 
     /**
      Returns if sandbox is enabled or not
 
      - returns: true if Sandbox is enabled, false otherwise
      */
-    @objc open var isSandbox: Bool = false
+    @objc public var isSandbox: Bool = false
 
     /**
      Returns if the fallback to use Authorization Code Grant is enabled. If true,
@@ -152,7 +152,7 @@ private let callbackURIStringKey = "URIString"
 
      - returns: true if fallback enabled, false otherwise
      */
-    @objc open var useFallback: Bool = true
+    @objc public var useFallback: Bool = true
 
     public override init() {
         self.clientID = ""
@@ -174,7 +174,7 @@ private let callbackURIStringKey = "URIString"
     }
     
     /// The current version of the SDK as a string
-    @objc open var sdkVersion: String {
+    @objc public var sdkVersion: String {
         guard let version = Bundle(for: Configuration.self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
             return "Unknown"
         }
@@ -184,7 +184,7 @@ private let callbackURIStringKey = "URIString"
     /**
      Resets all of the Configuration's values to default
      */
-    @objc open static func restoreDefaults() {
+    @objc public static func restoreDefaults() {
         shared = Configuration()
     }
     
@@ -196,7 +196,7 @@ private let callbackURIStringKey = "URIString"
      
      - returns: The string to use for the Callback URI
     */
-    @objc open func getCallbackURIString() -> String {
+    @objc public func getCallbackURIString() -> String {
         return getCallbackURIString(for: .general)
     }
     
@@ -211,7 +211,7 @@ private let callbackURIStringKey = "URIString"
      
      - returns: The callbackURIString for the the requested type
      */
-    @objc open func getCallbackURIString(for type: CallbackURIType) -> String {
+    @objc public func getCallbackURIString(for type: CallbackURIType) -> String {
         if callbackURIs[type] == nil {
             let defaultCallbacks = parseCallbackURIs()
             var fallback = defaultCallbacks[type] ?? callbackURIs[.general]
@@ -235,7 +235,7 @@ private let callbackURIStringKey = "URIString"
      
      - parameter callbackURIString: The callback URI String to use
     */
-    @objc open func setCallbackURIString(_ callbackURIString: String?) {
+    @objc public func setCallbackURIString(_ callbackURIString: String?) {
         setCallbackURIString(callbackURIString, type: .general)
     }
     
@@ -249,7 +249,7 @@ private let callbackURIStringKey = "URIString"
      - parameter callbackURIString: The callback URI String to use
      - parameter type:              The Callback URI Type to use
      */
-    @objc open func setCallbackURIString(_ callbackURIString: String?, type: CallbackURIType) {
+    @objc public func setCallbackURIString(_ callbackURIString: String?, type: CallbackURIType) {
         var callbackURIs = self.callbackURIs
         callbackURIs[type] = callbackURIString
         self.callbackURIs = callbackURIs

--- a/source/UberRides/DeeplinkRequestingBehavior.swift
+++ b/source/UberRides/DeeplinkRequestingBehavior.swift
@@ -21,7 +21,7 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-@objc(UBSDKDeeplinkRequestingBehavior) open class DeeplinkRequestingBehavior : NSObject, RideRequesting {
+@objc(UBSDKDeeplinkRequestingBehavior) public class DeeplinkRequestingBehavior : NSObject, RideRequesting {
         
     /**
      Requests a ride using a RequestDeeplink that is constructed using the provided
@@ -30,7 +30,7 @@
      - parameter rideParameters: The RideParameters to use for building and executing 
      the deeplink
      */
-    @objc open func requestRide(parameters rideParameters: RideParameters?) {
+    @objc public func requestRide(parameters rideParameters: RideParameters?) {
         guard let rideParameters = rideParameters else {
             return
         }

--- a/source/UberRides/LoginButton.swift
+++ b/source/UberRides/LoginButton.swift
@@ -53,30 +53,30 @@ import UIKit
 }
 
 /// Button to handle logging in to Uber
-@objc(UBSDKLoginButton) open class LoginButton: UberButton {
+@objc(UBSDKLoginButton) public class LoginButton: UberButton {
     
     let horizontalCenterPadding: CGFloat = 50
     let loginVerticalPadding: CGFloat = 15
     let loginHorizontalEdgePadding: CGFloat = 15
 
     /// The LoginButtonDelegate for this button
-    @objc open weak var delegate: LoginButtonDelegate?
+    @objc public weak var delegate: LoginButtonDelegate?
     
     /// The LoginManager to use for log in
-    @objc open var loginManager: LoginManager {
+    @objc public var loginManager: LoginManager {
         didSet {
             refreshContent()
         }
     }
     
     /// The RidesScopes to request
-    @objc open var scopes: [RidesScope]
+    @objc public var scopes: [RidesScope]
     
     /// The view controller to present login over. Used
-    @objc open var presentingViewController: UIViewController?
+    @objc public var presentingViewController: UIViewController?
     
     /// The current LoginButtonState of this button (signed in / signed out)
-    @objc open var buttonState: LoginButtonState {
+    @objc public var buttonState: LoginButtonState {
         if let _ = TokenManager.fetchToken(identifier: accessTokenIdentifier, accessGroup: keychainAccessGroup) {
             return .signedIn
         } else {
@@ -117,7 +117,7 @@ import UIKit
     /**
      Setup the LoginButton by adding  a target to the button and setting the login completion block
      */
-    override open func setup() {
+    override public func setup() {
         super.setup()
         NotificationCenter.default.addObserver(self, selector: #selector(refreshContent), name: Notification.Name(rawValue: TokenManager.tokenManagerDidSaveTokenNotification), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(refreshContent), name: Notification.Name(rawValue: TokenManager.tokenManagerDidDeleteTokenNotification), object: nil)
@@ -131,7 +131,7 @@ import UIKit
     /**
      Updates the content of the button. Sets the image icon and font, as well as the text
      */
-    override open func setContent() {
+    override public func setContent() {
         super.setContent()
         
         let buttonFont = UIFont.systemFont(ofSize: 13)
@@ -149,7 +149,7 @@ import UIKit
     /**
      Adds the layout constraints for the Login button.
      */
-    override open func setConstraints() {
+    override public func setConstraints() {
         
         uberTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         uberImageView.translatesAutoresizingMaskIntoConstraints = false
@@ -177,7 +177,7 @@ import UIKit
     
     //Mark: UIView
     
-    override open func sizeThatFits(_ size: CGSize) -> CGSize {
+    override public func sizeThatFits(_ size: CGSize) -> CGSize {
         let sizeThatFits = super.sizeThatFits(size)
         
         let iconSizeThatFits = uberImageView.image?.size ?? CGSize.zero
@@ -191,7 +191,7 @@ import UIKit
         return CGSize(width: sizeThatFits.width + horizontalCenterPadding, height: height)
     }
     
-    override open func updateConstraints() {
+    override public func updateConstraints() {
         refreshContent()
         super.updateConstraints()
     }

--- a/source/UberRides/ModalRideRequestViewController.swift
+++ b/source/UberRides/ModalRideRequestViewController.swift
@@ -23,9 +23,9 @@
 //  THE SOFTWARE.
 
 /// Modal View Controller to use for presenting a RideRequestViewController. Handles errors & closing the modal for you
-@objc(UBSDKModalRideRequestViewController) open class ModalRideRequestViewController : ModalViewController {
+@objc(UBSDKModalRideRequestViewController) public class ModalRideRequestViewController : ModalViewController {
     /// The RideRequestViewController this modal is wrapping
-    @objc open internal(set) var rideRequestViewController : RideRequestViewController
+    @objc public internal(set) var rideRequestViewController : RideRequestViewController
     
     /**
      Initializer for the ModalRideRequestViewController. Wraps the provided RideRequestViewController
@@ -48,7 +48,7 @@
 
     // MARK: UIViewController
 
-    open override var supportedInterfaceOrientations : UIInterfaceOrientationMask {
+    public override var supportedInterfaceOrientations : UIInterfaceOrientationMask {
         return [.portrait, .portraitUpsideDown]
     }
 }

--- a/source/UberRides/ModalViewController.swift
+++ b/source/UberRides/ModalViewController.swift
@@ -65,11 +65,11 @@ Possible Styles for the ModalViewController
 }
 
 /// Convenience to wrap a ViewController in a UINavigationController and add the appropriate buttons. Allows you to modally present a view controller w/ Uber branding.
-@objc(UBSDKModalViewController) open class ModalViewController : UIViewController {
+@objc(UBSDKModalViewController) public class ModalViewController : UIViewController {
     /// The ModalViewControllerDelegate
-    @objc open var delegate: ModalViewControllerDelegate?
+    @objc public var delegate: ModalViewControllerDelegate?
     
-    @objc open var colorStyle: ModalViewControllerColorStyle = .default {
+    @objc public var colorStyle: ModalViewControllerColorStyle = .default {
         didSet {
             setupStyle()
         }
@@ -124,7 +124,7 @@ Possible Styles for the ModalViewController
     
     //MARK: View Lifecycle
     
-    open override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
         
         self.addChildViewController(wrappedNavigationController)
@@ -133,7 +133,7 @@ Possible Styles for the ModalViewController
         self.wrappedNavigationController.didMove(toParentViewController: self)
     }
     
-    open override func viewDidDisappear(_ animated: Bool) {
+    public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         self.delegate?.modalViewControllerDidDismiss(self)
     }
@@ -143,12 +143,12 @@ Possible Styles for the ModalViewController
     /**
      Function to dimiss the modalViewController.
     */
-    @objc open func dismiss() {
+    @objc public func dismiss() {
         self.delegate?.modalViewControllerWillDismiss(self)
         self.dismiss(animated: true, completion: nil)
     }
     
-    open override var preferredStatusBarStyle : UIStatusBarStyle {
+    public override var preferredStatusBarStyle : UIStatusBarStyle {
         switch colorStyle {
         case .light:
             return UIStatusBarStyle.default

--- a/source/UberRides/Model/RidesScope.swift
+++ b/source/UberRides/Model/RidesScope.swift
@@ -97,13 +97,13 @@ import UIKit
 /**
  *  Object representing an access scope to the Uber API
  */
-@objc(UBSDKRidesScope) open class RidesScope : NSObject {
+@objc(UBSDKRidesScope) public class RidesScope : NSObject {
     /// The RidesScopeType of this RidesScope
-    @objc open let ridesScopeType: RidesScopeType
+    @objc public let ridesScopeType: RidesScopeType
     /// The ScopeType of this RidesScope (General / Privileged)
-    @objc open let scopeType : ScopeType
+    @objc public let scopeType : ScopeType
     /// The String raw value of the scope
-    @objc open let rawValue : String
+    @objc public let rawValue : String
     
     @objc public init(ridesScopeType: RidesScopeType) {
         self.ridesScopeType = ridesScopeType
@@ -111,7 +111,7 @@ import UIKit
         rawValue = ridesScopeType.toString()
     }
     
-    override open func isEqual(_ object: Any?) -> Bool {
+    override public func isEqual(_ object: Any?) -> Bool {
         if let object = object as? RidesScope {
             return self.ridesScopeType == object.ridesScopeType
         } else {
@@ -119,7 +119,7 @@ import UIKit
         }
     }
     
-    override open var hash: Int {
+    override public var hash: Int {
         return ridesScopeType.rawValue.hashValue
     }
     

--- a/source/UberRides/OAuth/AuthorizationCodeGrantAuthenticator.swift
+++ b/source/UberRides/OAuth/AuthorizationCodeGrantAuthenticator.swift
@@ -24,8 +24,8 @@
 
 import UIKit
 
-@objc(UBSDKAuthorizationCodeGrantAuthenticator) open class AuthorizationCodeGrantAuthenticator: LoginViewAuthenticator {
-    @objc open var state: String?
+@objc(UBSDKAuthorizationCodeGrantAuthenticator) public class AuthorizationCodeGrantAuthenticator: LoginViewAuthenticator {
+    @objc public var state: String?
     
     @objc public init(presentingViewController: UIViewController, scopes: [RidesScope], state: String?) {
         self.state = state

--- a/source/UberRides/OAuth/BaseAuthenticator.swift
+++ b/source/UberRides/OAuth/BaseAuthenticator.swift
@@ -25,22 +25,22 @@
 import UIKit
 
 /// Base class for authorization flows that use the LoginView.
-@objc(UBSDKBaseAuthenticator) open class BaseAuthenticator: NSObject, UberAuthenticating {
+@objc(UBSDKBaseAuthenticator) public class BaseAuthenticator: NSObject, UberAuthenticating {
     
     /// Optional identifier for saving the access token in keychain
-    @objc open var accessTokenIdentifier: String?
+    @objc public var accessTokenIdentifier: String?
     
     /// Optional access group for saving the access token in keychain
-    @objc open var keychainAccessGroup: String?
+    @objc public var keychainAccessGroup: String?
     
     /// Completion block for when login has completed
-    @objc open var loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?
+    @objc public var loginCompletion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?
     
     /// Scopes to request during login
-    @objc open var scopes: [RidesScope]
+    @objc public var scopes: [RidesScope]
     
     /// The Callback URL Type to use for this authentication method
-    @objc open var callbackURIType: CallbackURIType = .general
+    @objc public var callbackURIType: CallbackURIType = .general
     
     @objc init(scopes: [RidesScope]) {
         self.scopes = scopes

--- a/source/UberRides/OAuth/ImplicitGrantAuthenticator.swift
+++ b/source/UberRides/OAuth/ImplicitGrantAuthenticator.swift
@@ -27,7 +27,7 @@ import UIKit
 /**
  *  Defines the implicit grant authorization flow where access token is extracted from redirect fragment.
  */
-@objc(UBSDKImplicitGrantAuthenticator) open class ImplicitGrantAuthenticator: LoginViewAuthenticator {
+@objc(UBSDKImplicitGrantAuthenticator) public class ImplicitGrantAuthenticator: LoginViewAuthenticator {
     
     override var endpoint: UberAPI {
         return OAuth.implicitLogin(clientID: Configuration.shared.clientID, scopes: self.scopes, redirect: Configuration.shared.getCallbackURIString(for: .implicit))

--- a/source/UberRides/OAuth/LoginManager.swift
+++ b/source/UberRides/OAuth/LoginManager.swift
@@ -25,10 +25,10 @@
 
 
 /// Manages user login via SSO, authorization code grant, or implicit grant.
-@objc(UBSDKLoginManager) open class LoginManager: NSObject, LoginManaging {
+@objc(UBSDKLoginManager) public class LoginManager: NSObject, LoginManaging {
     
     /// Optional state to use for explcit grant authorization
-    @objc open var state: String?
+    @objc public var state: String?
     
     var accessTokenIdentifier: String
     var keychainAccessGroup: String
@@ -114,7 +114,7 @@
      - parameter presentingViewController: The presenting view controller present the login view controller over.
      - parameter completion:               The LoginManagerRequestTokenHandler completion handler for login success/failure.
      */
-    @objc open func login(requestedScopes scopes: [RidesScope], presentingViewController: UIViewController? = nil, completion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)? = nil) {
+    @objc public func login(requestedScopes scopes: [RidesScope], presentingViewController: UIViewController? = nil, completion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)? = nil) {
         guard !loggingIn else {
             completion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .unavailable))
             return
@@ -167,7 +167,7 @@
      
      - returns: true if the url was meant to be handled by the SDK, false otherwise
      */
-    open func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
+    public func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
         guard let source = sourceApplication, source.hasPrefix("com.ubercab"),
         let nativeAuthenticator = authenticator as? NativeAuthenticator else {
             return false
@@ -190,7 +190,7 @@
      - returns: true if the url was meant to be handled by the SDK, false otherwise
      */
     @available(iOS 9.0, *)
-    open func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool {
+    public func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool {
         let sourceApplication = options[UIApplicationOpenURLOptionsKey.sourceApplication] as? String
         let annotation = options[.annotation] as Any
 
@@ -201,7 +201,7 @@
      Called via the RidesAppDelegate when the application becomes active. Used to determine
      if a user abandons Native login without getting an access token.
      */
-    open func applicationDidBecomeActive() {
+    public func applicationDidBecomeActive() {
         if loggingIn {
             self.handleLoginCanceled()
         }

--- a/source/UberRides/OAuth/LoginView.swift
+++ b/source/UberRides/OAuth/LoginView.swift
@@ -26,9 +26,9 @@ import Foundation
 import WebKit
 
 /// Login Web View class. Wrapper around a WKWebView to handle Login flow for Implicit Grant
-@objc(UBSDKLoginView) open class LoginView: UIView {
+@objc(UBSDKLoginView) public class LoginView: UIView {
     
-    @objc open var loginAuthenticator: LoginViewAuthenticator
+    @objc public var loginAuthenticator: LoginViewAuthenticator
     
     var clientID = Configuration.shared.clientID
     let webView: WKWebView
@@ -90,7 +90,7 @@ import WebKit
     /**
     Loads the login page
     */
-    @objc open func load() {
+    @objc public func load() {
         // Create URL for request
         guard let request = Request(session: nil, endpoint: loginAuthenticator.endpoint) else {
             loginAuthenticator.loginCompletion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType:.invalidRequest))
@@ -106,7 +106,7 @@ import WebKit
      Stops loading the login page and clears the view.
      If the login page has already loaded, calling this still clears the view.
      */
-    @objc open func cancelLoad() {
+    @objc public func cancelLoad() {
         webView.stopLoading()
         if let url = URL(string: "about:blank") {
             webView.load(URLRequest(url: url))

--- a/source/UberRides/OAuth/LoginViewAuthenticator.swift
+++ b/source/UberRides/OAuth/LoginViewAuthenticator.swift
@@ -25,10 +25,10 @@
 import UIKit
 
 /// Base class for authorization flows that use the LoginView.
-@objc open class LoginViewAuthenticator: BaseAuthenticator {
+@objc public class LoginViewAuthenticator: BaseAuthenticator {
     
     /// View controller that will present the login
-    @objc open var presentingViewController: UIViewController
+    @objc public var presentingViewController: UIViewController
     
     /// Endpoint to hit for authorization request.
     var endpoint: UberAPI {

--- a/source/UberRides/OAuth/NativeAuthenticator.swift
+++ b/source/UberRides/OAuth/NativeAuthenticator.swift
@@ -27,10 +27,10 @@ import Foundation
 /**
  * UberAuthenticating object for authenticating a user via the Native Uber app
  */
-@objc(UBSSONativeAuthenticator) open class NativeAuthenticator: BaseAuthenticator {
+@objc(UBSSONativeAuthenticator) public class NativeAuthenticator: BaseAuthenticator {
     
     /// The completion block to call when the deeplink is completed. Bool indicates if the deeplink was successful
-    @objc open var deeplinkCompletion: ((NSError?) -> ())?
+    @objc public var deeplinkCompletion: ((NSError?) -> ())?
 
     
     var deeplink: Deeplinking

--- a/source/UberRides/RequestDeeplink.swift
+++ b/source/UberRides/RequestDeeplink.swift
@@ -29,7 +29,7 @@ import UIKit
 /**
  *  Builds and executes a deeplink to the native Uber app to request a ride.
  */
-@objc(UBSDKRequestDeeplink) open class RequestDeeplink: BaseDeeplink {
+@objc(UBSDKRequestDeeplink) public class RequestDeeplink: BaseDeeplink {
     
     private let parameters: RideParameters
     private let clientID: String

--- a/source/UberRides/RideRequestButton.swift
+++ b/source/UberRides/RideRequestButton.swift
@@ -46,18 +46,18 @@ import CoreLocation
 }
 
 /// RequestButton implements a button on the touch screen to request a ride.
-@objc(UBSDKRideRequestButton) open class RideRequestButton: UberButton {
+@objc(UBSDKRideRequestButton) public class RideRequestButton: UberButton {
     /// Delegate is informed of events that occur with request button.
-    @objc open var delegate: RideRequestButtonDelegate?
+    @objc public var delegate: RideRequestButtonDelegate?
     
     /// The RideParameters object this button will use to make a request
-    @objc open var rideParameters: RideParameters
+    @objc public var rideParameters: RideParameters
     
     /// The RideRequesting object the button will use to make a request
-    @objc open var requestBehavior: RideRequesting
+    @objc public var requestBehavior: RideRequesting
     
     /// The RidesClient used for retrieving metadata for the button.
-    @objc open var client: RidesClient?
+    @objc public var client: RidesClient?
     
     static let sourceString = "button"
     
@@ -162,7 +162,7 @@ import CoreLocation
     /**
      Setup the RideRequestButton by adding  a target to the button and setting the login completion block
      */
-    override open func setup() {
+    override public func setup() {
         super.setup()
         addTarget(self, action: #selector(uberButtonTapped(_:)), for: .touchUpInside)
         sizeToFit()
@@ -171,7 +171,7 @@ import CoreLocation
     /**
      Adds the Metadata Label to the button
      */
-    override open func addSubviews() {
+    override public func addSubviews() {
         super.addSubviews()
         addSubview(uberMetadataLabel)
     }
@@ -179,7 +179,7 @@ import CoreLocation
     /**
      Updates the content of the button. Sets the image icon and font, as well as the text
      */
-    override open func setContent() {
+    override public func setContent() {
         super.setContent()
         
         uberMetadataLabel.numberOfLines = 2
@@ -199,7 +199,7 @@ import CoreLocation
     /**
      Adds the layout constraints for the ride request button.
      */
-    override open func setConstraints() {
+    override public func setConstraints() {
         
         uberTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         uberImageView.translatesAutoresizingMaskIntoConstraints = false
@@ -256,7 +256,7 @@ import CoreLocation
     
     //Mark: UIView
     
-    override open func sizeThatFits(_ size: CGSize) -> CGSize {
+    override public func sizeThatFits(_ size: CGSize) -> CGSize {
         let logoSize = uberImageView.image?.size ?? CGSize.zero
         let titleSize = uberTitleLabel.intrinsicContentSize
         let metadataSize = uberMetadataLabel.intrinsicContentSize
@@ -276,7 +276,7 @@ import CoreLocation
     /**
      Manual refresh for the ride information on the button. The product ID must be set in order to show any metadata.
      */
-    @objc open func loadRideInformation() {
+    @objc public func loadRideInformation() {
         guard client != nil else {
             delegate?.rideRequestButton(self, didReceiveError: createValidationFailedError())
             return

--- a/source/UberRides/RideRequestView.swift
+++ b/source/UberRides/RideRequestView.swift
@@ -39,15 +39,15 @@ import CoreLocation
 }
 
 /// A view that shows the embedded Uber experience. 
-@objc(UBSDKRideRequestView) open class RideRequestView: UIView {
+@objc(UBSDKRideRequestView) public class RideRequestView: UIView {
     /// The RideRequestViewDelegate of this view.
-    @objc open var delegate: RideRequestViewDelegate?
+    @objc public var delegate: RideRequestViewDelegate?
     
     /// The access token used to authorize the web view
-    @objc open var accessToken: AccessToken?
+    @objc public var accessToken: AccessToken?
     
     /// Ther RideParameters to use for prefilling the RideRequestView
-    @objc open var rideParameters: RideParameters
+    @objc public var rideParameters: RideParameters
     
     var webView: WKWebView
     let redirectURL = "uberconnect://oauth"
@@ -144,7 +144,7 @@ import CoreLocation
      Load the Uber Ride Request Widget view.
      Requires that the access token has been retrieved.
      */
-    @objc open func load() {
+    @objc public func load() {
         guard let accessToken = accessToken else {
             self.delegate?.rideRequestView(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.accessTokenMissing))
             return
@@ -171,7 +171,7 @@ import CoreLocation
      Stop loading the Ride Request Widget View and clears the view.
      If the view has already loaded, calling this still clears the view.
     */
-    @objc open func cancelLoad() {
+    @objc public func cancelLoad() {
         webView.stopLoading()
         if let url = URL(string: "about:blank") {
             webView.load(URLRequest(url: url))

--- a/source/UberRides/RideRequestViewController.swift
+++ b/source/UberRides/RideRequestViewController.swift
@@ -41,12 +41,12 @@ import MapKit
 }
 
 // View controller to wrap the RideRequestView
-@objc (UBSDKRideRequestViewController) open class RideRequestViewController: UIViewController {
+@objc (UBSDKRideRequestViewController) public class RideRequestViewController: UIViewController {
     /// The RideRequestViewControllerDelegate to handle the errors
-    @objc open var delegate: RideRequestViewControllerDelegate?
+    @objc public var delegate: RideRequestViewControllerDelegate?
     
     /// The LoginManager to use for managing the login process
-    @objc open var loginManager: LoginManager {
+    @objc public var loginManager: LoginManager {
         didSet {
             accessTokenIdentifier = loginManager.accessTokenIdentifier
             keychainAccessGroup = loginManager.keychainAccessGroup
@@ -110,7 +110,7 @@ import MapKit
     
     // MARK: View Lifecycle
     
-    open override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
         self.edgesForExtendedLayout = UIRectEdge()
         self.view.backgroundColor = UIColor.white
@@ -119,13 +119,13 @@ import MapKit
         setupLoginView()
     }
     
-    open override func viewDidAppear(_ animated: Bool) {
+    public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         self.load()
     }
     
-    open override func viewWillDisappear(_ animated: Bool) {
+    public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         stopLoading()
         accessTokenWasUnauthorizedOnPreviousAttempt = false
@@ -133,7 +133,7 @@ import MapKit
     
     // MARK: UIViewController
     
-    open override var supportedInterfaceOrientations : UIInterfaceOrientationMask {
+    public override var supportedInterfaceOrientations : UIInterfaceOrientationMask {
         return [.portrait, .portraitUpsideDown]
     }
     

--- a/source/UberRides/RideRequestViewRequestingBehavior.swift
+++ b/source/UberRides/RideRequestViewRequestingBehavior.swift
@@ -24,17 +24,17 @@
 
 
 /// A RideRequesting object for requesting a ride via the RideRequestViewController
-@objc(UBSDKRideRequestViewRequestingBehavior) open class RideRequestViewRequestingBehavior : NSObject {
+@objc(UBSDKRideRequestViewRequestingBehavior) public class RideRequestViewRequestingBehavior : NSObject {
     
     /// The UIViewController to present the RideRequestViewController over
-    @objc unowned open var presentingViewController: UIViewController
+    @objc unowned public var presentingViewController: UIViewController
     
     /**
      The LoginManager to use with the RideRequestViewController. Uses the
      accessTokenIdentifier & keychainAccessGroup to get an AccessToken. Will be used
      to log a user in, if necessary
      */
-    @objc open var loginManager: LoginManager {
+    @objc public var loginManager: LoginManager {
         get {
             return self.modalRideRequestViewController.rideRequestViewController.loginManager
         }
@@ -44,7 +44,7 @@
     }
     
     /// The ModalRideRequestViewController that is created by this behavior, only exists after requestRide() is called
-    @objc open internal(set) var modalRideRequestViewController: ModalRideRequestViewController
+    @objc public internal(set) var modalRideRequestViewController: ModalRideRequestViewController
     
     /**
      Creates the RideRequestViewRequestingBehavior with the given presenting view controller.

--- a/source/UberRides/RidesAppDelegate.swift
+++ b/source/UberRides/RidesAppDelegate.swift
@@ -27,7 +27,7 @@
  Designed to mimic methods from your application's AppDelegate and should
  be called inside their corresponding methods
  */
-@objc(UBSDKRidesAppDelegate) open class RidesAppDelegate : NSObject {
+@objc(UBSDKRidesAppDelegate) public class RidesAppDelegate : NSObject {
     
     //MARK: Class variables
     
@@ -35,7 +35,7 @@
     
     //MARK: Public variables
     
-    @objc open var loginManager : LoginManaging?
+    @objc public var loginManager : LoginManaging?
     
     //Mark: NSObject
     
@@ -67,7 +67,7 @@
      communicate information to the receiving app As passed to the corresponding AppDelegate method
      - returns: true if the URL was intended for the Rides SDK, false otherwise
      */
-    @objc open func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
+    @objc public func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
         guard let manager = loginManager else {
             return false
         }
@@ -79,7 +79,7 @@
         return urlHandled
     }
     
-    @objc open func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    @objc public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
         guard let options = launchOptions, let launchURL = options[UIApplicationLaunchOptionsKey.url] as? URL else {
             return false
         }

--- a/source/UberRides/RidesClient.swift
+++ b/source/UberRides/RidesClient.swift
@@ -26,7 +26,7 @@
 import CoreLocation
 
 /// API client for the Uber Rides API.
-@objc(UBSDKRidesClient) open class RidesClient: NSObject {
+@objc(UBSDKRidesClient) public class RidesClient: NSObject {
     
     /// Application client ID. Required for every instance of RidesClient.
     var clientID: String = Configuration.shared.clientID
@@ -140,7 +140,7 @@ import CoreLocation
      
      - returns: an AccessToken object, or nil if one can't be located
      */
-    @objc open func fetchAccessToken() -> AccessToken? {
+    @objc public func fetchAccessToken() -> AccessToken? {
         guard let accessToken = TokenManager.fetchToken(identifier: accessTokenIdentifier, accessGroup: keychainAccessGroup) else {
             return nil
         }
@@ -152,7 +152,7 @@ import CoreLocation
      
      - returns: true if a server token exists, false otherwise.
      */
-    @objc open var hasServerToken: Bool {
+    @objc public var hasServerToken: Bool {
         return serverToken != nil
     }
     
@@ -203,7 +203,7 @@ import CoreLocation
      - parameter location:  coordinates of pickup location
      - parameter completion: completion handler for returned products.
      */
-    @objc open func fetchProducts(pickupLocation location: CLLocation, completion:@escaping (_ products: [Product], _ response: Response) -> Void) {
+    @objc public func fetchProducts(pickupLocation location: CLLocation, completion:@escaping (_ products: [Product], _ response: Response) -> Void) {
         let endpoint = Products.getAll(location: location)
         apiCall(endpoint, completion: { response in
             var products: UberProducts?
@@ -225,7 +225,7 @@ import CoreLocation
      - parameter productID:  string representing product ID.
      - parameter completion: completion handler for returned product.
      */
-    @objc open func fetchProduct(productID: String, completion:@escaping (_ product: Product?, _ response: Response) -> Void) {
+    @objc public func fetchProduct(productID: String, completion:@escaping (_ product: Product?, _ response: Response) -> Void) {
         let endpoint = Products.getProduct(productID: productID)
         apiCall(endpoint, completion: { response in
             var product: Product?
@@ -244,7 +244,7 @@ import CoreLocation
      - parameter productID:  optional string representing the productID.
      - parameter completion: completion handler for returned estimates.
      */
-    @objc open func fetchTimeEstimates(pickupLocation location: CLLocation, productID: String? = nil, completion:@escaping (_ timeEstimates: [TimeEstimate], _ response: Response) -> Void) {
+    @objc public func fetchTimeEstimates(pickupLocation location: CLLocation, productID: String? = nil, completion:@escaping (_ timeEstimates: [TimeEstimate], _ response: Response) -> Void) {
         let endpoint = Estimates.time(location: location, productID: productID)
         apiCall(endpoint, completion: { response in
             var timeEstimates: TimeEstimates?
@@ -267,7 +267,7 @@ import CoreLocation
      - parameter dropoffLocation:  coordinates of dropoff location
      - parameter completion:       completion handler for returned estimates.
      */
-    @objc open func fetchPriceEstimates(pickupLocation: CLLocation, dropoffLocation: CLLocation, completion:@escaping (_ priceEstimates: [PriceEstimate], _ response: Response) -> Void) {
+    @objc public func fetchPriceEstimates(pickupLocation: CLLocation, dropoffLocation: CLLocation, completion:@escaping (_ priceEstimates: [PriceEstimate], _ response: Response) -> Void) {
         let endpoint = Estimates.price(startLocation: pickupLocation,
                                        endLocation: dropoffLocation)
         apiCall(endpoint, completion: { response in
@@ -291,7 +291,7 @@ import CoreLocation
      - parameter limit:      number of items to retrieve. Default is 5, maximum is 50.
      - parameter completion: completion handler for returned user trip history.
      */
-    @objc open func fetchTripHistory(offset: Int = 0, limit: Int = 5, completion:@escaping (_ tripHistory: TripHistory?, _ response: Response) -> Void) {
+    @objc public func fetchTripHistory(offset: Int = 0, limit: Int = 5, completion:@escaping (_ tripHistory: TripHistory?, _ response: Response) -> Void) {
         let endpoint = History.get(offset: offset, limit: limit)
         apiCall(endpoint, completion: { response in
             var history: TripHistory?
@@ -308,7 +308,7 @@ import CoreLocation
     
     - parameter completion: completion handler for returned user profile.
     */
-    @objc open func fetchUserProfile(completion:@escaping (_ profile: UserProfile?, _ response: Response) -> Void) {
+    @objc public func fetchUserProfile(completion:@escaping (_ profile: UserProfile?, _ response: Response) -> Void) {
         let endpoint = Me.userProfile
         apiCall(endpoint, completion: { response in
             var userProfile: UserProfile?
@@ -326,7 +326,7 @@ import CoreLocation
      - parameter parameters: RideParameters object containing paramaters for the request.
      - parameter completion:  completion handler for returned request information.
      */
-    @objc open func requestRide(parameters: RideParameters, completion:@escaping (_ ride: Ride?, _ response: Response) -> Void) {
+    @objc public func requestRide(parameters: RideParameters, completion:@escaping (_ ride: Ride?, _ response: Response) -> Void) {
         let endpoint = Requests.make(rideParameters: parameters)
         apiCallForRideResponse(endpoint, completion: completion)
     }
@@ -336,7 +336,7 @@ import CoreLocation
      
      - parameter completion: completion handler for returned ride information.
      */
-    @objc open func fetchCurrentRide(completion: @escaping (_ ride: Ride?, _ response: Response) -> Void) {
+    @objc public func fetchCurrentRide(completion: @escaping (_ ride: Ride?, _ response: Response) -> Void) {
         let endpoint = Requests.getCurrent
         apiCallForRideResponse(endpoint, completion: completion)
     }
@@ -347,7 +347,7 @@ import CoreLocation
      - parameter requestID:  unique identifier representing a Request.
      - parameter completion: completion handler for returned trip information.
      */
-    @objc open func fetchRideDetails(requestID: String, completion:@escaping (_ ride: Ride? , _ response: Response) -> Void) {
+    @objc public func fetchRideDetails(requestID: String, completion:@escaping (_ ride: Ride? , _ response: Response) -> Void) {
         let endpoint = Requests.getRequest(requestID: requestID)
         apiCallForRideResponse(endpoint, completion: completion)
     }
@@ -358,7 +358,7 @@ import CoreLocation
      - parameter rideParameters: RideParameters object containing necessary information.
      - parameter completion:  completion handler for returned estimate.
      */
-    @objc open func fetchRideRequestEstimate(parameters: RideParameters, completion:@escaping (_ estimate: RideEstimate?, _ response: Response) -> Void) {
+    @objc public func fetchRideRequestEstimate(parameters: RideParameters, completion:@escaping (_ estimate: RideEstimate?, _ response: Response) -> Void) {
         let endpoint = Requests.estimate(rideParameters: parameters)
         apiCall(endpoint, completion: { response in
             var estimate: RideEstimate? = nil
@@ -375,7 +375,7 @@ import CoreLocation
      
      - parameter completion: completion handler for returned payment method list as well as last used payment method.
      */
-    @objc open func fetchPaymentMethods(completion:@escaping (_ methods: [PaymentMethod], _ lastUsed: PaymentMethod?, _ response: Response) -> Void) {
+    @objc public func fetchPaymentMethods(completion:@escaping (_ methods: [PaymentMethod], _ lastUsed: PaymentMethod?, _ response: Response) -> Void) {
         let endpoint = Payment.getMethods
         apiCall(endpoint, completion: { response in
             var paymentMethods = [PaymentMethod]()
@@ -398,7 +398,7 @@ import CoreLocation
      - parameter placeID:    the name of the place to retrieve. Only home and work are acceptable.
      - parameter completion: completion handler for returned place.
      */
-    @objc open func fetchPlace(placeID: String, completion:@escaping (_ place: Place?, _ response: Response) -> Void) {
+    @objc public func fetchPlace(placeID: String, completion:@escaping (_ place: Place?, _ response: Response) -> Void) {
         let endpoint = Places.getPlace(placeID: placeID)
         apiCall(endpoint, completion: { response in
             var place: Place? = nil
@@ -417,7 +417,7 @@ import CoreLocation
      - parameter address:    the address of the place that should be tied to the given placeID.
      - parameter completion: completion handler for response.
      */
-    @objc open func updatePlace(placeID: String, withAddress address: String, completion:@escaping (_ place: Place?, _ response: Response) -> Void) {
+    @objc public func updatePlace(placeID: String, withAddress address: String, completion:@escaping (_ place: Place?, _ response: Response) -> Void) {
         let endpoint = Places.putPlace(placeID: placeID, address: address)
         apiCall(endpoint, completion: { response in
             var place: Place?
@@ -436,7 +436,7 @@ import CoreLocation
      - parameter rideParameters: the RideParameters object containing the updated parameters.
      - parameter completion:  completion handler for response.
      */
-    @objc open func updateRideDetails(requestID: String?, rideParameters: RideParameters, completion:@escaping (_ response: Response) -> Void) {
+    @objc public func updateRideDetails(requestID: String?, rideParameters: RideParameters, completion:@escaping (_ response: Response) -> Void) {
         guard let requestID = requestID else {
             updateCurrentRide(rideParameters: rideParameters, completion: completion)
             return
@@ -454,7 +454,7 @@ import CoreLocation
      - parameter rideParameters: RideParameters object with updated ride parameters.
      - parameter completion:  completion handler for response.
      */
-    @objc open func updateCurrentRide(rideParameters: RideParameters, completion:@escaping (_ response: Response) -> Void) {
+    @objc public func updateCurrentRide(rideParameters: RideParameters, completion:@escaping (_ response: Response) -> Void) {
         let endpoint = Requests.patchCurrent(rideParameters: rideParameters)
         apiCall(endpoint, completion: { response in
             completion(response)
@@ -467,7 +467,7 @@ import CoreLocation
      - parameter requestID:  request ID of the ride. If nil, current ride will be canceled.
      - parameter completion: completion handler for response.
      */
-    @objc open func cancelRide(requestID: String?, completion:@escaping (_ response: Response) -> Void) {
+    @objc public func cancelRide(requestID: String?, completion:@escaping (_ response: Response) -> Void) {
         guard let requestID = requestID else {
             cancelCurrentRide(completion: completion)
             return
@@ -484,7 +484,7 @@ import CoreLocation
      
      - parameter completion: completion handler for response
      */
-    @objc open func cancelCurrentRide(completion:@escaping (_ response: Response) -> Void) {
+    @objc public func cancelCurrentRide(completion:@escaping (_ response: Response) -> Void) {
         let endpoint = Requests.deleteCurrent
         apiCall(endpoint, completion: { response in
             completion(response)
@@ -497,7 +497,7 @@ import CoreLocation
      - parameter requestID:  unique identifier representing a ride request
      - parameter completion: completion handler for receipt
      */
-    @objc open func fetchRideReceipt(requestID: String, completion:@escaping (_ rideReceipt: RideReceipt?, _ response: Response) -> Void) {
+    @objc public func fetchRideReceipt(requestID: String, completion:@escaping (_ rideReceipt: RideReceipt?, _ response: Response) -> Void) {
         let endpoint = Requests.rideReceipt(requestID: requestID)
         apiCall(endpoint, completion: { response in
             var receipt: RideReceipt?
@@ -515,7 +515,7 @@ import CoreLocation
      - parameter requestID:  unique identifier representing a request
      - parameter completion: completion handler for map
      */
-    @objc open func fetchRideMap(requestID: String, completion:@escaping (_ map: RideMap?, _ response: Response) -> Void) {
+    @objc public func fetchRideMap(requestID: String, completion:@escaping (_ map: RideMap?, _ response: Response) -> Void) {
         let endpoint = Requests.rideMap(requestID: requestID)
         apiCall(endpoint, completion: { response in
             var map: RideMap?
@@ -534,7 +534,7 @@ import CoreLocation
      - parameter refreshToken: The Refresh Token String from an SSO access token
      - parameter completion:   completion handler for the new access token
      */
-    @objc open func refreshAccessToken(usingRefreshToken refreshToken: String, completion:@escaping (_ accessToken: AccessToken?, _ response: Response) -> Void) {
+    @objc public func refreshAccessToken(usingRefreshToken refreshToken: String, completion:@escaping (_ accessToken: AccessToken?, _ response: Response) -> Void) {
         let endpoint = OAuth.refresh(clientID: clientID, refreshToken: refreshToken)
         apiCall(endpoint) { response in
             var accessToken: AccessToken?

--- a/source/UberRides/UberButton.swift
+++ b/source/UberRides/UberButton.swift
@@ -25,7 +25,7 @@
 import UIKit
 
 /// Base class for Uber buttons that sets up colors and some constraints.
-@objc(UBSDKUberButton) open class UberButton: UIButton {
+@objc(UBSDKUberButton) public class UberButton: UIButton {
     let cornerRadius: CGFloat = 8
     let horizontalEdgePadding: CGFloat = 16
     let imageLabelPadding: CGFloat = 8
@@ -34,13 +34,13 @@ import UIKit
     let uberImageView: UIImageView = UIImageView()
     let uberTitleLabel: UILabel = UILabel()
     
-    open var colorStyle: RequestButtonColorStyle = .black {
+    public var colorStyle: RequestButtonColorStyle = .black {
         didSet {
             colorStyleDidUpdate(colorStyle)
         }
     }
     
-    override open var isHighlighted: Bool {
+    override public var isHighlighted: Bool {
         didSet {
             updateColors(isHighlighted)
         }
@@ -62,7 +62,7 @@ import UIKit
      Function responsible for the initial setup of the button. 
      Calls addSubviews(), setContent(), and setConstraints()
      */
-    @objc open func setup() {
+    @objc public func setup() {
         addSubviews()
         setContent()
         setConstraints()
@@ -72,7 +72,7 @@ import UIKit
      Function responsible for adding all the subviews to the button. Subclasses
      should override this method and add any necessary subviews.
      */
-    @objc open func addSubviews() {
+    @objc public func addSubviews() {
         addSubview(uberImageView)
         addSubview(uberTitleLabel)
     }
@@ -81,7 +81,7 @@ import UIKit
      Function responsible for updating content on the button. Subclasses should
      override and do any necessary view setup
      */
-    @objc open func setContent() {
+    @objc public func setContent() {
         clipsToBounds = true
         layer.cornerRadius = cornerRadius
     }
@@ -90,7 +90,7 @@ import UIKit
      Function responsible for adding autolayout constriants on the button. Subclasses
      should override and add any additional autolayout constraints
      */
-    @objc open func setConstraints() {
+    @objc public func setConstraints() {
         
         uberTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         uberImageView.translatesAutoresizingMaskIntoConstraints = false
@@ -105,7 +105,7 @@ import UIKit
         addConstraints(verticalContraints)
     }
     
-    override open func sizeThatFits(_ size: CGSize) -> CGSize {
+    override public func sizeThatFits(_ size: CGSize) -> CGSize {
         let logoSize = uberImageView.image?.size ?? CGSize.zero
         let titleSize = uberTitleLabel.intrinsicContentSize
         

--- a/source/UberRidesTests/RidesMocks.swift
+++ b/source/UberRidesTests/RidesMocks.swift
@@ -316,7 +316,7 @@ class DeeplinkRequestingBehaviorMock: DeeplinkRequestingBehavior {
     }
 
     @available(iOS 9.0, *)
-    open func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool {
+    public func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool {
         let sourceApplication = options[UIApplicationOpenURLOptionsKey.sourceApplication] as? String
         let annotation = options[.annotation] as Any
 


### PR DESCRIPTION
Currently, we have a hodgepodge between `public` and `open` APIs. 

Since `open` allows external developers to subclass, and we haven't explicitly designed for this situation, we should leave these classes as `public` for now. 