### PR TITLE
Swift 4 Example Projects

### DIFF
--- a/examples/Obj-C SDK/Obj-C SDK.xcodeproj/project.pbxproj
+++ b/examples/Obj-C SDK/Obj-C SDK.xcodeproj/project.pbxproj
@@ -23,8 +23,6 @@
 		DCD806081CFE35EF00EF6EB1 /* UBSDKLoginButtonView.m in Sources */ = {isa = PBXBuildFile; fileRef = DCD806071CFE35EF00EF6EB1 /* UBSDKLoginButtonView.m */; };
 		DCEB80921D078DE300899810 /* UberRides.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCEB80911D078DE300899810 /* UberRides.framework */; };
 		DCEB80931D078DE300899810 /* UberRides.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DCEB80911D078DE300899810 /* UberRides.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		DCEB80951D078DE800899810 /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCEB80941D078DE800899810 /* ObjectMapper.framework */; };
-		DCEB80961D078DE800899810 /* ObjectMapper.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DCEB80941D078DE800899810 /* ObjectMapper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DCEC0CAA1CB5D7780086C6D7 /* UBSDKExampleTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DCEC0CA91CB5D7780086C6D7 /* UBSDKExampleTableViewController.m */; };
 		DCEC0CAD1CB5DCB10086C6D7 /* UBSDKRideRequestWidgetExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DCEC0CAC1CB5DCB10086C6D7 /* UBSDKRideRequestWidgetExampleViewController.m */; };
 		DCEC0CB01CB5E3D30086C6D7 /* UBSDKImplicitGrantExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DCEC0CAF1CB5E3D30086C6D7 /* UBSDKImplicitGrantExampleViewController.m */; };
@@ -54,7 +52,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				DCEB80961D078DE800899810 /* ObjectMapper.framework in Embed Frameworks */,
 				DCEB80931D078DE300899810 /* UberRides.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -100,7 +97,6 @@
 		DCD806061CFE35EF00EF6EB1 /* UBSDKLoginButtonView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UBSDKLoginButtonView.h; sourceTree = "<group>"; };
 		DCD806071CFE35EF00EF6EB1 /* UBSDKLoginButtonView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UBSDKLoginButtonView.m; sourceTree = "<group>"; };
 		DCEB80911D078DE300899810 /* UberRides.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UberRides.framework; path = Carthage/Build/iOS/UberRides.framework; sourceTree = "<group>"; };
-		DCEB80941D078DE800899810 /* ObjectMapper.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ObjectMapper.framework; path = Carthage/Build/iOS/ObjectMapper.framework; sourceTree = "<group>"; };
 		DCEC0CA81CB5D7780086C6D7 /* UBSDKExampleTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UBSDKExampleTableViewController.h; sourceTree = "<group>"; };
 		DCEC0CA91CB5D7780086C6D7 /* UBSDKExampleTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UBSDKExampleTableViewController.m; sourceTree = "<group>"; };
 		DCEC0CAB1CB5DCB10086C6D7 /* UBSDKRideRequestWidgetExampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UBSDKRideRequestWidgetExampleViewController.h; sourceTree = "<group>"; };
@@ -114,7 +110,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DCEB80951D078DE800899810 /* ObjectMapper.framework in Frameworks */,
 				DCEB80921D078DE300899810 /* UberRides.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -139,7 +134,6 @@
 		28A6CFC4B4A38C240D740F18 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				DCEB80941D078DE800899810 /* ObjectMapper.framework */,
 				DCEB80911D078DE300899810 /* UberRides.framework */,
 			);
 			name = Frameworks;
@@ -329,6 +323,7 @@
 				TargetAttributes = {
 					AC0404EC1BFB82CC00AC1501 = {
 						CreatedOnToolsVersion = 7.1;
+						DevelopmentTeam = 5F83KRY2FH;
 					};
 					AC0405051BFB82CC00AC1501 = {
 						CreatedOnToolsVersion = 7.1;
@@ -398,7 +393,6 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/UberRides.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/ObjectMapper.framework",
 			);
 			name = "Copy Carthage Frameworks";
 			outputPaths = (
@@ -571,6 +565,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = 5F83KRY2FH;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -590,6 +585,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = 5F83KRY2FH;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/examples/Obj-C SDK/Obj-C SDK/AppDelegate.m
+++ b/examples/Obj-C SDK/Obj-C SDK/AppDelegate.m
@@ -36,14 +36,8 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
     
-    // Uncomment if your app is registered in China
-    //[UBSDKConfiguration setRegion:RegionChina];
-    
     //Make requests to sandbox for development
-    [UBSDKConfiguration setSandboxEnabled:YES];
-    
-    //Handle incoming SSO Requests
-    [[UBSDKRidesAppDelegate sharedInstance] application:application didFinishLaunchingWithOptions:launchOptions];
+    [[UBSDKConfiguration shared] setIsSandbox:YES];
     
     return YES;
 }
@@ -70,9 +64,10 @@
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
 
+
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options {
     //Check & handle incoming SSO URL
-    BOOL handledUberURL = [[UBSDKRidesAppDelegate sharedInstance] application:app openURL:url sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey] annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
+    BOOL handledUberURL = [[UBSDKRidesAppDelegate shared] application:app open:url sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey] annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
     
     return handledUberURL;
 }

--- a/examples/Obj-C SDK/Obj-C SDK/Info.plist
+++ b/examples/Obj-C SDK/Obj-C SDK/Info.plist
@@ -18,6 +18,17 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.uber.sdk.Obj-C-SDK</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationQueriesSchemes</key>
@@ -47,20 +58,14 @@
 	<array>
 		<dict>
 			<key>URIString</key>
-			<string>callback://your_callback_uri</string>
+			<string>com.uber.sdk.Obj-C-SDK://oauth/consumer</string>
 			<key>UberCallbackURIType</key>
 			<string>General</string>
 		</dict>
-		<dict>
-			<key>URIString</key>
-			<string>callback://optional_authorization_code_uri</string>
-			<key>UberCallbackURIType</key>
-			<string>AuthorizationCode</string>
-		</dict>
 	</array>
 	<key>UberClientID</key>
-	<string>YOUR_CLIENT_ID</string>
+	<string>fNuupfZ-F6YinKzoGLSo_ktxipTx0M-5</string>
 	<key>UberDisplayName</key>
-	<string>YOUR_APP_NAME</string>
+	<string>Rides SDK Demo App</string>
 </dict>
 </plist>

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKDeeplinkExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKDeeplinkExampleViewController.m
@@ -96,10 +96,12 @@
     [builder setProductID:@"a1111c8c-c720-46c3-8534-2fcdd730040d"];
     
     CLLocation *pickupLocation = [[CLLocation alloc] initWithLatitude:37.770 longitude:-122.466];
-    [builder setPickupLocation:pickupLocation nickname:@"California Academy of Sciences"];
+    [builder setPickupLocation:pickupLocation];
+    [builder setPickupNickname:@"California Academy of Sciences"];
     
     CLLocation *dropoffLocation = [[CLLocation alloc] initWithLatitude:37.791 longitude:-122.405];
-    [builder setDropoffLocation:dropoffLocation nickname:@"Pier 39"];
+    [builder setDropoffLocation:dropoffLocation];
+    [builder setDropoffNickname:@"Pier 39"];
     
     return [builder build];
 }

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKImplicitGrantExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKImplicitGrantExampleViewController.m
@@ -70,7 +70,7 @@ static NSString *const historyCellReuseIdentifier = @"HistoryCell";
     [self.view addSubview:tableView];
     _tableView = tableView;
     
-    NSArray<UBSDKRidesScope *> *requestedScopes = @[ UBSDKRidesScope.RideWidgets, UBSDKRidesScope.Profile, UBSDKRidesScope.Places, UBSDKRidesScope.History ];
+    NSArray<UBSDKRidesScope *> *requestedScopes = @[ UBSDKRidesScope.rideWidgets, UBSDKRidesScope.profile, UBSDKRidesScope.places, UBSDKRidesScope.history ];
     
     UBSDKLoginButtonView *loginButtonView = [[UBSDKLoginButtonView alloc] initWithFrame:self.view.frame
                                                                                        scopes:requestedScopes
@@ -107,7 +107,7 @@ static NSString *const historyCellReuseIdentifier = @"HistoryCell";
     // Examples of various data that can be retrieved
     
     // Retrieves a user profile for the current logged in user
-    [self.ridesClient fetchUserProfile:^(UBSDKUserProfile * _Nullable profile, UBSDKResponse *response) {
+    [self.ridesClient fetchUserProfileWithCompletion:^(UBSDKUserProfile * _Nullable profile, UBSDKResponse *response) {
         if (response.statusCode == 401) {
             [self resetAccessToken];
         } else if (profile) {
@@ -119,24 +119,24 @@ static NSString *const historyCellReuseIdentifier = @"HistoryCell";
     }];
     
     // Gets the address assigned as the "home" address for current user
-    [self.ridesClient fetchPlace:UBSDKPlace.Home completion:^(UBSDKPlace * _Nullable place, UBSDKResponse *response) {
+    [self.ridesClient fetchPlaceWithPlaceID:UBSDKPlace.home completion:^(UBSDKPlace * _Nullable place, UBSDKResponse *response) {
         if (response.statusCode == 401) {
             [self resetAccessToken];
-        } else {
+        } else if (place) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                [self.places setObject:place forKey:UBSDKPlace.Home];
+                [self.places setObject:place forKey:UBSDKPlace.home];
                 [self.tableView reloadData];
             });
         }
     }];
     
     // Gets the address assigned as the "work" address for current user
-    [self.ridesClient fetchPlace:UBSDKPlace.Work completion:^(UBSDKPlace * _Nullable place, UBSDKResponse *response) {
+    [self.ridesClient fetchPlaceWithPlaceID:UBSDKPlace.work completion:^(UBSDKPlace * _Nullable place, UBSDKResponse *response) {
         if (response.statusCode == 401) {
             [self resetAccessToken];
-        } else {
+        } else if (place) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                [self.places setObject:place forKey:UBSDKPlace.Work];
+                [self.places setObject:place forKey:UBSDKPlace.work];
                 [self.tableView reloadData];
             });
         }
@@ -210,14 +210,14 @@ static NSString *const historyCellReuseIdentifier = @"HistoryCell";
             UBSDKPlace *place;
             switch (indexPath.row) {
                 case 0:
-                    if ([self.places objectForKey:UBSDKPlace.Home]) {
-                        place = [self.places objectForKey:UBSDKPlace.Home];
-                        placeText = UBSDKPlace.Home.capitalizedString;
+                    if ([self.places objectForKey:UBSDKPlace.home]) {
+                        place = [self.places objectForKey:UBSDKPlace.home];
+                        placeText = UBSDKPlace.home.capitalizedString;
                         break;
                     }
                 case 1:
-                    place = [self.places objectForKey:UBSDKPlace.Work];
-                    placeText = UBSDKPlace.Work.capitalizedString;
+                    place = [self.places objectForKey:UBSDKPlace.work];
+                    placeText = UBSDKPlace.work.capitalizedString;
                     break;
             }
             
@@ -281,12 +281,12 @@ static NSString *const historyCellReuseIdentifier = @"HistoryCell";
     NSString *placeID;
     switch (indexPath.row) {
         case 0:
-            if ([self.places objectForKey:UBSDKPlace.Home]) {
-                placeID = UBSDKPlace.Home;
+            if ([self.places objectForKey:UBSDKPlace.home]) {
+                placeID = UBSDKPlace.home;
                 break;
             }
         case 1:
-            placeID = UBSDKPlace.Work;
+            placeID = UBSDKPlace.work;
             break;
     }
     
@@ -305,8 +305,8 @@ static NSString *const historyCellReuseIdentifier = @"HistoryCell";
         if (!addressTextField || !addressTextField.text) {
             return;
         }
-        
-        [self.ridesClient updatePlace:placeID withAddress:addressTextField.text completion:^(UBSDKPlace * _Nullable place, UBSDKResponse * _Nonnull response) {
+
+        [self.ridesClient updatePlaceWithPlaceID:placeID withAddress:addressTextField.text completion:^(UBSDKPlace * _Nullable place, UBSDKResponse * _Nonnull response) {
             [self.places setObject:place forKey:placeID];
             [self.tableView reloadData];
         }];

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKNativeLoginExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKNativeLoginExampleViewController.m
@@ -67,7 +67,7 @@
 - (void)_initialSetup {
     _loginManager = [[UBSDKLoginManager alloc] initWithLoginType:UBSDKLoginTypeNative];
     
-    NSArray<UBSDKRidesScope *> *scopes = @[UBSDKRidesScope.Profile, UBSDKRidesScope.Places, UBSDKRidesScope.Request];
+    NSArray<UBSDKRidesScope *> *scopes = @[UBSDKRidesScope.profile, UBSDKRidesScope.places, UBSDKRidesScope.request];
     
     _blackLoginButton = ({
         UBSDKLoginButton *loginButton = [[UBSDKLoginButton alloc] initWithFrame:CGRectZero scopes:scopes loginManager:_loginManager];
@@ -153,7 +153,7 @@
 #pragma mark - Actions
 
 - (void)_loginButtonAction:(UIButton *)button {
-    NSArray<UBSDKRidesScope *> *requestedScopes = @[ UBSDKRidesScope.RideWidgets, UBSDKRidesScope.Profile, UBSDKRidesScope.Places ];
+    NSArray<UBSDKRidesScope *> *requestedScopes = @[ UBSDKRidesScope.rideWidgets, UBSDKRidesScope.profile, UBSDKRidesScope.places ];
     
     [self.loginManager loginWithRequestedScopes:requestedScopes presentingViewController:self completion:^(UBSDKAccessToken * _Nullable accessToken, NSError * _Nullable error) {
         if (accessToken) {

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKRideRequestWidgetExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKRideRequestWidgetExampleViewController.m
@@ -93,7 +93,6 @@
 
 - (UBSDKRideParameters *)_buildRideParameters {
     UBSDKRideParametersBuilder *parameterBuilder = [[UBSDKRideParametersBuilder alloc] init];
-    [parameterBuilder setPickupToCurrentLocation];
     return [parameterBuilder build];
 }
 

--- a/examples/Swift SDK/Cartfile
+++ b/examples/Swift SDK/Cartfile
@@ -1,1 +1,1 @@
-github "https://github.com/uber/rides-ios-sdk.git" "swift-3-dev"
+github "https://github.com/uber/rides-ios-sdk.git" "swift-4"

--- a/examples/Swift SDK/Swift SDK.xcodeproj/project.pbxproj
+++ b/examples/Swift SDK/Swift SDK.xcodeproj/project.pbxproj
@@ -23,8 +23,6 @@
 		DCD806181CFE983B00EF6EB1 /* NativeLoginExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD806171CFE983B00EF6EB1 /* NativeLoginExampleViewController.swift */; };
 		DCEB808A1D078BCA00899810 /* UberRides.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCEB80891D078BCA00899810 /* UberRides.framework */; };
 		DCEB808B1D078BCA00899810 /* UberRides.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DCEB80891D078BCA00899810 /* UberRides.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		DCEB808D1D078BD200899810 /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCEB808C1D078BD200899810 /* ObjectMapper.framework */; };
-		DCEB808E1D078BD200899810 /* ObjectMapper.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DCEB808C1D078BD200899810 /* ObjectMapper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,7 +49,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				DCEB808E1D078BD200899810 /* ObjectMapper.framework in Embed Frameworks */,
 				DCEB808B1D078BCA00899810 /* UberRides.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -89,7 +86,6 @@
 		DCD806151CFE7F4300EF6EB1 /* ButtonExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonExampleViewController.swift; sourceTree = "<group>"; };
 		DCD806171CFE983B00EF6EB1 /* NativeLoginExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeLoginExampleViewController.swift; sourceTree = "<group>"; };
 		DCEB80891D078BCA00899810 /* UberRides.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UberRides.framework; path = Carthage/Build/iOS/UberRides.framework; sourceTree = "<group>"; };
-		DCEB808C1D078BD200899810 /* ObjectMapper.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ObjectMapper.framework; path = Carthage/Build/iOS/ObjectMapper.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,7 +93,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DCEB808D1D078BD200899810 /* ObjectMapper.framework in Frameworks */,
 				DCEB808A1D078BCA00899810 /* UberRides.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -131,7 +126,6 @@
 		823B0AE4697BBA3B456C5C93 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				DCEB808C1D078BD200899810 /* ObjectMapper.framework */,
 				DCEB80891D078BCA00899810 /* UberRides.framework */,
 			);
 			name = Frameworks;
@@ -267,18 +261,18 @@
 				TargetAttributes = {
 					AC0404A31BFAD0C800AC1501 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 0900;
 					};
 					AC0404B71BFAD0C800AC1501 = {
 						CreatedOnToolsVersion = 7.1;
 						DevelopmentTeam = 36UPBWHAQE;
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 0900;
 						TestTargetID = AC0404A31BFAD0C800AC1501;
 					};
 					AC0404C21BFAD0C800AC1501 = {
 						CreatedOnToolsVersion = 7.1;
 						DevelopmentTeam = 36UPBWHAQE;
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 0900;
 						TestTargetID = AC0404A31BFAD0C800AC1501;
 					};
 				};
@@ -338,7 +332,6 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/UberRides.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/ObjectMapper.framework",
 			);
 			name = "Copy Carthage Frameworks";
 			outputPaths = (
@@ -525,7 +518,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.sdk.Swift-SDK";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -543,7 +537,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.sdk.Swift-SDK";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -555,7 +550,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.sdk.Swift-SDKTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swift SDK.app/Swift SDK";
 			};
 			name = Debug;
@@ -568,7 +564,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.sdk.Swift-SDKTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swift SDK.app/Swift SDK";
 			};
 			name = Release;
@@ -580,7 +577,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.sdk.Swift-SDKUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = "Swift SDK";
 				USES_XCTRUNNER = YES;
 			};
@@ -593,7 +591,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.sdk.Swift-SDKUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = "Swift SDK";
 				USES_XCTRUNNER = YES;
 			};

--- a/examples/Swift SDK/Swift SDK.xcodeproj/project.pbxproj
+++ b/examples/Swift SDK/Swift SDK.xcodeproj/project.pbxproj
@@ -261,6 +261,7 @@
 				TargetAttributes = {
 					AC0404A31BFAD0C800AC1501 = {
 						CreatedOnToolsVersion = 7.1;
+						DevelopmentTeam = 5F83KRY2FH;
 						LastSwiftMigration = 0900;
 					};
 					AC0404B71BFAD0C800AC1501 = {
@@ -509,6 +510,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 5F83KRY2FH;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -528,6 +530,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 5F83KRY2FH;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",

--- a/examples/Swift SDK/Swift SDK/AppDelegate.swift
+++ b/examples/Swift SDK/Swift SDK/AppDelegate.swift
@@ -37,10 +37,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         //Configuration.setRegion(.China)
         
         // Make requests to sandbox by default
-        Configuration.setSandboxEnabled(true)
+        Configuration.shared.isSandbox = true
         
         // Handle incoming SSO Requests
-        _ = RidesAppDelegate.sharedInstance.application(application, didFinishLaunchingWithOptions: launchOptions)
+        _ = RidesAppDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
         return true
     }
 
@@ -68,14 +68,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     @available(iOS 9, *)
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool {
-        
-        let handledUberURL = RidesAppDelegate.sharedInstance.application(app, openURL: url, sourceApplication: options[UIApplicationOpenURLOptionsKey.sourceApplication] as? String, annotation: options[UIApplicationOpenURLOptionsKey.annotation] as AnyObject?)
+        let handledUberURL = RidesAppDelegate.shared.application(app, open: url, sourceApplication: options[UIApplicationOpenURLOptionsKey.sourceApplication] as? String, annotation: options[UIApplicationOpenURLOptionsKey.annotation] as Any)
         
         return handledUberURL
     }
     
     func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
-        let handledUberURL = RidesAppDelegate.sharedInstance.application(application, openURL: url, sourceApplication: sourceApplication, annotation: annotation as AnyObject?)
+        let handledUberURL = RidesAppDelegate.shared.application(application, open: url, sourceApplication: sourceApplication, annotation: annotation)
         
         return handledUberURL
     }

--- a/examples/Swift SDK/Swift SDK/AuthorizationCodeGrantExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/AuthorizationCodeGrantExampleViewController.swift
@@ -78,7 +78,7 @@ class AuthorizationCodeGrantExampleViewController: AuthorizationBaseViewControll
         // Define which scopes we're requesting
         // Need to be authorized on your developer dashboard at developer.uber.com
         // Privileged scopes can be used by anyone in sandbox for your own account but must be approved for production
-        let requestedScopes = [RidesScope.Request, RidesScope.AllTrips]
+        let requestedScopes = [RidesScope.request, RidesScope.allTrips]
         // Use your loginManager to login with the requested scopes, viewcontroller to present over, and completion block
         loginManager.login(requestedScopes: requestedScopes, presentingViewController: self) { (accessToken, error) -> () in
             // Error

--- a/examples/Swift SDK/Swift SDK/AuthorizationCodeGrantExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/AuthorizationCodeGrantExampleViewController.swift
@@ -121,13 +121,15 @@ class AuthorizationCodeGrantExampleViewController: AuthorizationBaseViewControll
         let pickupLocation = CLLocation(latitude: 37.770, longitude: -122.466)
         let dropoffLocation = CLLocation(latitude: 37.791, longitude: -122.405)
 
-        let parameters = RideParameters(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation)
-        parameters.pickupNickname = "California Academy of Sciences"
-        parameters.dropoffNickname = "Pier 39"
-        parameters.productID = "a1111c8c-c720-46c3-8534-2fcdd730040d"
+        let builder = RideParametersBuilder()
+        builder.pickupLocation = pickupLocation
+        builder.pickupNickname = "California Academy of Sciences"
+        builder.dropoffLocation = dropoffLocation
+        builder.dropoffNickname = "Pier 39"
+        builder.productID = "a1111c8c-c720-46c3-8534-2fcdd730040d"
 
         // Use the POST /v1/requests endpoint to make a ride request (in sandbox)
-        ridesClient.requestRide(parameters: parameters, completion: { ride, response in
+        ridesClient.requestRide(parameters: builder.build(), completion: { ride, response in
             DispatchQueue.main.async(execute: {
                 self.checkError(response)
                 if let ride = ride {

--- a/examples/Swift SDK/Swift SDK/DeeplinkExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/DeeplinkExampleViewController.swift
@@ -61,12 +61,14 @@ open class DeeplinkExampleViewController: ButtonExampleViewController {
         let pickupLocation = CLLocation(latitude: 37.770, longitude: -122.466)
         let dropoffLocation = CLLocation(latitude: 37.791, longitude: -122.405)
 
-        let parameters = RideParameters(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation)
-        parameters.pickupNickname = "California Academy of Sciences"
-        parameters.dropoffNickname = "Pier 39"
-        parameters.productID = "a1111c8c-c720-46c3-8534-2fcdd730040d"
+        let builder = RideParametersBuilder()
+        builder.pickupLocation = pickupLocation
+        builder.pickupNickname = "California Academy of Sciences"
+        builder.dropoffLocation = dropoffLocation
+        builder.dropoffNickname = "Pier 39"
+        builder.productID = "a1111c8c-c720-46c3-8534-2fcdd730040d"
         
-        whiteRequestButton.rideParameters = parameters
+        whiteRequestButton.rideParameters = builder.build()
     }
     
     fileprivate func addBlackRequestButtonConstraints() {

--- a/examples/Swift SDK/Swift SDK/DeeplinkExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/DeeplinkExampleViewController.swift
@@ -58,14 +58,15 @@ open class DeeplinkExampleViewController: ButtonExampleViewController {
         whiteRequestButton.requestBehavior = deeplinkBehavior
         
         whiteRequestButton.colorStyle = .white
-        var parameterBuilder = RideParametersBuilder()
-        parameterBuilder = parameterBuilder.setProductID("a1111c8c-c720-46c3-8534-2fcdd730040d")
         let pickupLocation = CLLocation(latitude: 37.770, longitude: -122.466)
-        parameterBuilder = parameterBuilder.setPickupLocation(pickupLocation, nickname: "California Academy of Sciences")
         let dropoffLocation = CLLocation(latitude: 37.791, longitude: -122.405)
-        parameterBuilder = parameterBuilder.setDropoffLocation(dropoffLocation, nickname: "Pier 39")
+
+        let parameters = RideParameters(pickupLocation: pickupLocation, dropoffLocation: dropoffLocation)
+        parameters.pickupNickname = "California Academy of Sciences"
+        parameters.dropoffNickname = "Pier 39"
+        parameters.productID = "a1111c8c-c720-46c3-8534-2fcdd730040d"
         
-        whiteRequestButton.rideParameters = parameterBuilder.build()
+        whiteRequestButton.rideParameters = parameters
     }
     
     fileprivate func addBlackRequestButtonConstraints() {

--- a/examples/Swift SDK/Swift SDK/ImplicitGrantExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/ImplicitGrantExampleViewController.swift
@@ -84,7 +84,7 @@ class ImplicitGrantExampleViewController: AuthorizationBaseViewController {
     @IBAction func login(_ sender: AnyObject) {
         // Define which scopes we're requesting
         // Need to be authorized on your developer dashboard at developer.uber.com
-        let requestedScopes = [RidesScope.RideWidgets, RidesScope.Profile, RidesScope.Places, RidesScope.History, RidesScope.Places]
+        let requestedScopes = [RidesScope.rideWidgets, RidesScope.profile, RidesScope.places, RidesScope.history, RidesScope.places]
         // Use your loginManager to login with the requested scopes, viewcontroller to present over, and completion block
         loginManager.login(requestedScopes: requestedScopes, presentingViewController: self) { (accessToken, error) -> () in
             if accessToken != nil {

--- a/examples/Swift SDK/Swift SDK/ImplicitGrantExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/ImplicitGrantExampleViewController.swift
@@ -116,7 +116,7 @@ class ImplicitGrantExampleViewController: AuthorizationBaseViewController {
         }
         
         // Gets the address assigned as the "home" address for current user
-        ridesClient.fetchPlace(Place.Home) { place, response in
+        ridesClient.fetchPlace(placeID: Place.home) { place, response in
             self.checkError(response)
             DispatchQueue.main.async {
                 self.places[self.homePlaceRow] = place
@@ -125,7 +125,7 @@ class ImplicitGrantExampleViewController: AuthorizationBaseViewController {
         }
         
         // Gets the address assigned as the "work" address for current user
-        ridesClient.fetchPlace(Place.Work) { place, response in
+        ridesClient.fetchPlace(placeID: Place.work) { place, response in
             self.checkError(response)
             DispatchQueue.main.async {
                 self.places[self.workPlaceRow] = place
@@ -209,11 +209,9 @@ extension ImplicitGrantExampleViewController: UITableViewDataSource {
             return cell
         case HistorySection:
             let trip = history[indexPath.row]
-            guard let startCity = trip.startCity?.name,
-                let startTime = trip.startTime,
-                let endTime = trip.endTime else {
-                fallthrough
-            }
+            let startCity = trip.startCity.name
+            let startTime = trip.startTime
+            let endTime = trip.endTime
             
             let cell = tableView.dequeueReusableCell(withIdentifier: HistoryCell) ??
                 UITableViewCell(style: .default, reuseIdentifier: HistoryCell)
@@ -245,9 +243,8 @@ extension ImplicitGrantExampleViewController: UITableViewDelegate {
         
         let alertController = UIAlertController(title: "Update Place Address", message: nil, preferredStyle: .alert)
         alertController.addTextField(configurationHandler: { (textField) in
-            if let place = self.places[indexPath.row],
-                let address = place.address {
-                textField.placeholder = address
+            if let place = self.places[indexPath.row] {
+                textField.placeholder = place.address
             }
         })
         
@@ -259,8 +256,8 @@ extension ImplicitGrantExampleViewController: UITableViewDelegate {
                 return
             }
             
-            let placeID = indexPath.row == self.homePlaceRow ? Place.Home : Place.Work
-            self.ridesClient.updatePlace(placeID, withAddress: address) { place, response in
+            let placeID = indexPath.row == self.homePlaceRow ? Place.home : Place.work
+            self.ridesClient.updatePlace(placeID: placeID, withAddress: address) { place, response in
                 if response.error == nil, let place = place {
                     DispatchQueue.main.async {
                         self.places[indexPath.row] = place

--- a/examples/Swift SDK/Swift SDK/Info.plist
+++ b/examples/Swift SDK/Swift SDK/Info.plist
@@ -2,11 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>uberauth</string>
-		<string>uber</string>
-	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -23,10 +18,28 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>callback</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>uberauth</string>
+		<string>uber</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>We use your location to make specifying a pickup spot easy as pie</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,26 +54,24 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UberClientID</key>
-	<string>YOUR_CLIENT_ID</string>
-	<key>UberDisplayName</key>
-	<string>YOUR_APP_NAME</string>
 	<key>UberCallbackURIs</key>
 	<array>
 		<dict>
-			<key>UberCallbackURIType</key>
-			<string>General</string>
 			<key>URIString</key>
 			<string>callback://your_callback_uri</string>
+			<key>UberCallbackURIType</key>
+			<string>General</string>
 		</dict>
 		<dict>
-			<key>UberCallbackURIType</key>
-			<string>AuthorizationCode</string>
 			<key>URIString</key>
 			<string>callback://optional_authorization_code_uri</string>
+			<key>UberCallbackURIType</key>
+			<string>AuthorizationCode</string>
 		</dict>
 	</array>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>We use your location to make specifying a pickup spot easy as pie</string>
+	<key>UberClientID</key>
+	<string>fNuupfZ-F6YinKzoGLSo_ktxipTx0M-5</string>
+	<key>UberDisplayName</key>
+	<string>Rides SDK Demo App</string>
 </dict>
 </plist>

--- a/examples/Swift SDK/Swift SDK/Info.plist
+++ b/examples/Swift SDK/Swift SDK/Info.plist
@@ -25,7 +25,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>callback</string>
+				<string>com.uber.sdk.Swift-SDK</string>
 			</array>
 		</dict>
 	</array>
@@ -58,15 +58,9 @@
 	<array>
 		<dict>
 			<key>URIString</key>
-			<string>callback://your_callback_uri</string>
+			<string>com.uber.sdk.Swift-SDK://oauth/consumer</string>
 			<key>UberCallbackURIType</key>
 			<string>General</string>
-		</dict>
-		<dict>
-			<key>URIString</key>
-			<string>callback://optional_authorization_code_uri</string>
-			<key>UberCallbackURIType</key>
-			<string>AuthorizationCode</string>
 		</dict>
 	</array>
 	<key>UberClientID</key>

--- a/examples/Swift SDK/Swift SDK/NativeLoginExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/NativeLoginExampleViewController.swift
@@ -35,7 +35,8 @@ open class NativeLoginExampleViewController: ButtonExampleViewController, LoginB
     let whiteLoginButton: LoginButton
     
     override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        scopes = [.Profile, .Places, .Request]
+        scopes = [.profile, .places, .request]
+        
         loginManager = LoginManager(loginType: .native)
         blackLoginButton = LoginButton(frame: CGRect.zero, scopes: scopes, loginManager: loginManager)
         whiteLoginButton = LoginButton(frame: CGRect.zero, scopes: scopes, loginManager: loginManager)

--- a/examples/Swift SDK/Swift SDK/RideRequestWidgetExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/RideRequestWidgetExampleViewController.swift
@@ -67,7 +67,7 @@ class RideRequestWidgetExampleViewController: ButtonExampleViewController {
         let requestBehavior = RideRequestViewRequestingBehavior(presentingViewController: self, loginManager: loginManager)
         requestBehavior.modalRideRequestViewController.delegate = self
         
-        let rideParameters = RideParameters()
+        let rideParameters = RideParametersBuilder().build()
 
         let accessTokenString = "access_token_string"
         let token = AccessToken(tokenString: accessTokenString)

--- a/examples/Swift SDK/Swift SDK/RideRequestWidgetExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/RideRequestWidgetExampleViewController.swift
@@ -67,7 +67,7 @@ class RideRequestWidgetExampleViewController: ButtonExampleViewController {
         let requestBehavior = RideRequestViewRequestingBehavior(presentingViewController: self, loginManager: loginManager)
         requestBehavior.modalRideRequestViewController.delegate = self
         
-        let rideParameters = RideParametersBuilder().build()
+        let rideParameters = RideParameters()
         
         return RideRequestButton(rideParameters: rideParameters, requestingBehavior: requestBehavior)
     }

--- a/examples/Swift SDK/Swift SDK/RideRequestWidgetExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/RideRequestWidgetExampleViewController.swift
@@ -68,6 +68,17 @@ class RideRequestWidgetExampleViewController: ButtonExampleViewController {
         requestBehavior.modalRideRequestViewController.delegate = self
         
         let rideParameters = RideParameters()
+
+        let accessTokenString = "access_token_string"
+        let token = AccessToken(tokenString: accessTokenString)
+        if TokenManager.save(accessToken: token){
+            // Success
+        } else {
+            // Unable to save
+        }
+
+        TokenManager.fetchToken()
+        TokenManager.deleteToken()
         
         return RideRequestButton(rideParameters: rideParameters, requestingBehavior: requestBehavior)
     }

--- a/source/UberRides/Model/RideParameters.swift
+++ b/source/UberRides/Model/RideParameters.swift
@@ -164,7 +164,7 @@ import MapKit
     /// The source to use for attributing the ride. Used internal to the SDK.
     @objc var source: String?
 
-    public func build() -> RideParameters {
+    @objc public func build() -> RideParameters {
         return RideParameters(productID: productID,
                               pickupLocation: pickupLocation,
                               pickupNickname: pickupNickname,

--- a/source/UberRides/Model/RidesScope.swift
+++ b/source/UberRides/Model/RidesScope.swift
@@ -124,28 +124,28 @@ import UIKit
     }
     
     /// Convenience variable for the AllTrips scope
-    @objc public static let AllTrips = RidesScope(ridesScopeType: .allTrips)
+    @objc public static let allTrips = RidesScope(ridesScopeType: .allTrips)
     
     /// Convenience variable for the History scope
-    @objc public static let History = RidesScope(ridesScopeType: .history)
+    @objc public static let history = RidesScope(ridesScopeType: .history)
     
     /// Convenience variable for the HistoryLite scope
-    @objc public static let HistoryLite = RidesScope(ridesScopeType: .historyLite)
+    @objc public static let historyLite = RidesScope(ridesScopeType: .historyLite)
     
     /// Convenience variable for the Places scope
-    @objc public static let Places = RidesScope(ridesScopeType: .places)
+    @objc public static let places = RidesScope(ridesScopeType: .places)
     
     /// Convenience variable for the Profile scope
-    @objc public static let Profile = RidesScope(ridesScopeType: .profile)
+    @objc public static let profile = RidesScope(ridesScopeType: .profile)
     
     /// Convenience variable for the Request scope
-    @objc public static let Request = RidesScope(ridesScopeType: .request)
+    @objc public static let request = RidesScope(ridesScopeType: .request)
     
     /// Convenience variable for the RequestReceipt scope
-    @objc public static let RequestReceipt = RidesScope(ridesScopeType: .requestReceipt)
+    @objc public static let requestReceipt = RidesScope(ridesScopeType: .requestReceipt)
     
     /// Convenience variable for the RideWidgets scope
-    @objc public static let RideWidgets = RidesScope(ridesScopeType: .rideWidgets)
+    @objc public static let rideWidgets = RidesScope(ridesScopeType: .rideWidgets)
     
 }
 

--- a/source/UberRides/RideRequestViewController.swift
+++ b/source/UberRides/RideRequestViewController.swift
@@ -54,8 +54,8 @@ import MapKit
     }
     
     lazy var rideRequestView: RideRequestView = RideRequestView()
-    lazy var loginView: LoginView = LoginView(loginAuthenticator: ImplicitGrantAuthenticator(presentingViewController: self, scopes: [.RideWidgets]))
-    lazy var nativeAuthenticator = NativeAuthenticator(scopes: [.RideWidgets])
+    lazy var loginView: LoginView = LoginView(loginAuthenticator: ImplicitGrantAuthenticator(presentingViewController: self, scopes: [.rideWidgets]))
+    lazy var nativeAuthenticator = NativeAuthenticator(scopes: [.rideWidgets])
 
     static let sourceString = "ride_request_widget"
 
@@ -221,7 +221,7 @@ import MapKit
     }
     
     private func setupImplicitLoginView() {
-        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: self, scopes: [.RideWidgets])
+        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: self, scopes: [.rideWidgets])
         loginBehavior.loginCompletion = { token, error in
             guard let token = token, error == nil else {
                 if error?.code == RidesAuthenticationErrorType.networkError.rawValue {

--- a/source/UberRides/UberButton.swift
+++ b/source/UberRides/UberButton.swift
@@ -34,7 +34,7 @@ import UIKit
     let uberImageView: UIImageView = UIImageView()
     let uberTitleLabel: UILabel = UILabel()
     
-    public var colorStyle: RequestButtonColorStyle = .black {
+    @objc public var colorStyle: RequestButtonColorStyle = .black {
         didSet {
             colorStyleDidUpdate(colorStyle)
         }

--- a/source/UberRidesTests/AuthenticationDeeplinkTests.swift
+++ b/source/UberRidesTests/AuthenticationDeeplinkTests.swift
@@ -57,7 +57,7 @@ class AuthenticationDeeplinkTests: XCTestCase {
     }
     
     func testDeeplinkURL() {
-        let scopes = [RidesScope.AllTrips, RidesScope.Profile]
+        let scopes = [RidesScope.allTrips, RidesScope.profile]
         let authenticationDeeplink = AuthenticationDeeplink(scopes:scopes)
         let expectedURLPrefix = "uberauth://connect?"
         

--- a/source/UberRidesTests/AuthenticationURLUtilityTests.swift
+++ b/source/UberRidesTests/AuthenticationURLUtilityTests.swift
@@ -43,7 +43,7 @@ class AuthenticationURLUtilityTests: XCTestCase {
     
     func testBuildQueryParameters_withSingleScope() {
         
-        let scopes = [RidesScope.RideWidgets]
+        let scopes = [RidesScope.rideWidgets]
         
         let expectedScopes = scopes.toRidesScopeString()
         let expectedClientID = "testClientID"
@@ -70,7 +70,7 @@ class AuthenticationURLUtilityTests: XCTestCase {
     
     func testBuildQueryParameters_withMultipleScopes() {
         
-        let scopes = [RidesScope.RideWidgets, RidesScope.AllTrips, RidesScope.History]
+        let scopes = [RidesScope.rideWidgets, RidesScope.allTrips, RidesScope.history]
         
         let expectedScopes = scopes.toRidesScopeString()
         let expectedClientID = "testClientID"

--- a/source/UberRidesTests/BaseAuthenticatorTests.swift
+++ b/source/UberRidesTests/BaseAuthenticatorTests.swift
@@ -54,7 +54,7 @@ class BaseAuthenticatorTests: XCTestCase {
     }
     
     func testBaseAuthenticator_correctlySavesScopes() {
-        let scopes = [RidesScope.Profile, RidesScope.AllTrips]
+        let scopes = [RidesScope.profile, RidesScope.allTrips]
         let baseAuthenticator = BaseAuthenticator(scopes: scopes)
         XCTAssertEqual(scopes, baseAuthenticator.scopes);
     }

--- a/source/UberRidesTests/LoginButtonTests.swift
+++ b/source/UberRidesTests/LoginButtonTests.swift
@@ -90,7 +90,7 @@ class LoginButtonTests : XCTestCase {
         loginManager.executeLoginClosure = {
             expectation.fulfill()
         }
-        let loginButton = LoginButton(frame: CGRect.zero, scopes: [.Profile], loginManager: loginManager)
+        let loginButton = LoginButton(frame: CGRect.zero, scopes: [.profile], loginManager: loginManager)
         
         loginButton.presentingViewController = UIViewController()
         XCTAssertNotNil(loginButton)
@@ -112,7 +112,7 @@ class LoginButtonTests : XCTestCase {
         XCTAssertTrue(keychain.setObject(token, key: identifier))
         
         let loginManager = LoginManager(accessTokenIdentifier: identifier, keychainAccessGroup: nil, loginType: .implicit)
-        let loginButton = LoginButton(frame: CGRect.zero, scopes: [.Profile], loginManager: loginManager)
+        let loginButton = LoginButton(frame: CGRect.zero, scopes: [.profile], loginManager: loginManager)
         
         loginButton.presentingViewController = UIViewController()
         XCTAssertNotNil(loginButton)

--- a/source/UberRidesTests/LoginManagerTests.swift
+++ b/source/UberRidesTests/LoginManagerTests.swift
@@ -51,7 +51,7 @@ class LoginManagerTests: XCTestCase {
         let loginManagerMock = LoginManagerPartialMock(loginType: .native)
         loginManagerMock.executeLoginClosure = executeLoginClosure
         
-        loginManagerMock.login(requestedScopes: [.Profile], presentingViewController: nil, completion: nil)
+        loginManagerMock.login(requestedScopes: [.profile], presentingViewController: nil, completion: nil)
         guard let authenticator = loginManagerMock.authenticator as? NativeAuthenticator else {
             XCTFail("Expected NativeAuthenticator")
             return
@@ -68,7 +68,7 @@ class LoginManagerTests: XCTestCase {
         let loginManagerMock = LoginManagerPartialMock(loginType: .native)
         loginManagerMock.executeLoginClosure = executeLoginClosure
         
-        loginManagerMock.login(requestedScopes: [.Profile], presentingViewController: nil, completion: nil)
+        loginManagerMock.login(requestedScopes: [.profile], presentingViewController: nil, completion: nil)
         guard let authenticator = loginManagerMock.authenticator as? NativeAuthenticator else {
             XCTFail("Expected NativeAuthenticator")
             return
@@ -94,7 +94,7 @@ class LoginManagerTests: XCTestCase {
         
         let presentingViewController = UIViewController()
         
-        loginManagerMock.login(requestedScopes: [.Profile], presentingViewController: presentingViewController, completion: nil)
+        loginManagerMock.login(requestedScopes: [.profile], presentingViewController: presentingViewController, completion: nil)
         guard let authenticator = loginManagerMock.authenticator as? ImplicitGrantAuthenticator else {
             XCTFail("Expected ImplicitGrantAuthenticator")
             return
@@ -118,7 +118,7 @@ class LoginManagerTests: XCTestCase {
         
         let presentingViewController = UIViewController()
         
-        loginManagerMock.login(requestedScopes: [.Profile], presentingViewController: presentingViewController, completion: nil)
+        loginManagerMock.login(requestedScopes: [.profile], presentingViewController: presentingViewController, completion: nil)
         guard let authenticator = loginManagerMock.authenticator as? AuthorizationCodeGrantAuthenticator else {
             XCTFail("Expected AuthorizationCodeGrantAuthenticator")
             return
@@ -147,7 +147,7 @@ class LoginManagerTests: XCTestCase {
         loginManagerMock.executeLoginClosure = executeLoginClosure
         loginManagerMock.loggingIn = true
         
-        loginManagerMock.login(requestedScopes: [.Profile], presentingViewController: nil, completion: loginCompletion)
+        loginManagerMock.login(requestedScopes: [.profile], presentingViewController: nil, completion: loginCompletion)
         
         waitForExpectations(timeout: 0.2, handler: nil)
     }
@@ -169,7 +169,7 @@ class LoginManagerTests: XCTestCase {
         loginManagerMock.executeLoginClosure = executeLoginClosure
         
         
-        loginManagerMock.login(requestedScopes: [.Profile], presentingViewController: nil, completion: loginCompletion)
+        loginManagerMock.login(requestedScopes: [.profile], presentingViewController: nil, completion: loginCompletion)
         
         XCTAssertNil(loginManagerMock.authenticator)
         XCTAssertFalse(loginManagerMock.loggingIn)
@@ -194,7 +194,7 @@ class LoginManagerTests: XCTestCase {
         loginManagerMock.executeLoginClosure = executeLoginClosure
         
         
-        loginManagerMock.login(requestedScopes: [.Profile], presentingViewController: nil, completion: loginCompletion)
+        loginManagerMock.login(requestedScopes: [.profile], presentingViewController: nil, completion: loginCompletion)
         
         XCTAssertNil(loginManagerMock.authenticator)
         XCTAssertFalse(loginManagerMock.loggingIn)
@@ -249,7 +249,7 @@ class LoginManagerTests: XCTestCase {
             return true
         }
         
-        let authenticatorMock = NativeAuthenticatorPartialMock(scopes: [.Profile])
+        let authenticatorMock = NativeAuthenticatorPartialMock(scopes: [.profile])
         authenticatorMock.handleRedirectClosure = handleRedirectClosure
         loginManager.authenticator = authenticatorMock
         
@@ -276,7 +276,7 @@ class LoginManagerTests: XCTestCase {
         let loginManager = LoginManager(loginType: .native)
         loginManager.loggingIn = true
         
-        let nativeAuthenticatorMock = NativeAuthenticatorPartialMock(scopes: [.Profile])
+        let nativeAuthenticatorMock = NativeAuthenticatorPartialMock(scopes: [.profile])
         nativeAuthenticatorMock.loginCompletion = loginCompletion
         loginManager.authenticator = nativeAuthenticatorMock
         loginManager.applicationDidBecomeActive()
@@ -304,7 +304,7 @@ class LoginManagerTests: XCTestCase {
         loginManagerMock.executeLoginClosure = executeLoginClosure
         
         
-        loginManagerMock.login(requestedScopes: [.Profile], presentingViewController: nil, completion: loginCompletion)
+        loginManagerMock.login(requestedScopes: [.profile], presentingViewController: nil, completion: loginCompletion)
         
         loginManagerMock.authenticator?.loginCompletion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidRequest))
         
@@ -316,7 +316,7 @@ class LoginManagerTests: XCTestCase {
         let expectationAuthorizationCode = expectation(description: "executeLogin Authorization Code called")
         
         Configuration.shared.useFallback = true
-        let scopes = [RidesScope.Request]
+        let scopes = [RidesScope.request]
         
         let loginManagerMock = LoginManagerPartialMock(loginType: .native)
         
@@ -346,7 +346,7 @@ class LoginManagerTests: XCTestCase {
         let expectationNative = expectation(description: "executeLogin Native called")
         let expectationAuthorizationCode = expectation(description: "executeLogin Authorization Code called")
         
-        let scopes = [RidesScope.Profile]
+        let scopes = [RidesScope.profile]
         
         let loginManagerMock = LoginManagerPartialMock(loginType: .native)
         
@@ -406,7 +406,7 @@ class LoginManagerTests: XCTestCase {
         loginManagerMock.executeLoginClosure = executeLoginClosure
         
         
-        loginManagerMock.login(requestedScopes: [.Profile], presentingViewController: viewController, completion: loginCompletion)
+        loginManagerMock.login(requestedScopes: [.profile], presentingViewController: viewController, completion: loginCompletion)
         
         loginManagerMock.authenticator?.loginCompletion?(nil, RidesAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidRequest))
         

--- a/source/UberRidesTests/OAuthTests.swift
+++ b/source/UberRidesTests/OAuthTests.swift
@@ -54,7 +54,7 @@ class OAuthTests: XCTestCase {
     func testParseAccessTokenFromRedirect() {
         testExpectation = expectation(description: "success access token")
         redirectURI = Configuration.shared.getCallbackURIString(for: .implicit)
-        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
+        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
@@ -77,7 +77,7 @@ class OAuthTests: XCTestCase {
     func testParseEmptyAccessTokenFromRedirect() {
         testExpectation = expectation(description: "empty access token")
         redirectURI = Configuration.shared.getCallbackURIString(for: .implicit)
-        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
+        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
@@ -101,7 +101,7 @@ class OAuthTests: XCTestCase {
     func testMismatchingRedirectError() {
         testExpectation = expectation(description: "errors")
         redirectURI = Configuration.shared.getCallbackURIString(for: .implicit)
-        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
+        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
@@ -126,7 +126,7 @@ class OAuthTests: XCTestCase {
     func testInvalidRedirectError() {
         testExpectation = expectation(description: "errors")
         redirectURI = Configuration.shared.getCallbackURIString(for: .implicit)
-        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
+        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
@@ -151,7 +151,7 @@ class OAuthTests: XCTestCase {
     func testInvalidClientIDError() {
         testExpectation = expectation(description: "errors")
         redirectURI = Configuration.shared.getCallbackURIString(for: .implicit)
-        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
+        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
@@ -176,7 +176,7 @@ class OAuthTests: XCTestCase {
     func testInvalidScopeError() {
         testExpectation = expectation(description: "errors")
         redirectURI = Configuration.shared.getCallbackURIString(for: .implicit)
-        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
+        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
@@ -201,7 +201,7 @@ class OAuthTests: XCTestCase {
     func testInvalidParametersError() {
         testExpectation = expectation(description: "errors")
         redirectURI = Configuration.shared.getCallbackURIString(for: .implicit)
-        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
+        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
@@ -226,7 +226,7 @@ class OAuthTests: XCTestCase {
     func testServerError() {
         testExpectation = expectation(description: "errors")
         redirectURI = Configuration.shared.getCallbackURIString(for: .implicit)
-        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
+        let loginBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.profile])
         loginBehavior.loginCompletion = loginCompletion()
         let loginView = LoginView(loginAuthenticator: loginBehavior)
         
@@ -306,7 +306,7 @@ class OAuthTests: XCTestCase {
      */
     func testImplicitGrantAuthenticator_withScopes_returnsCorrectEndpoint() {
         redirectURI = Configuration.shared.getCallbackURIString(for: .implicit)
-        let scopes = [RidesScope.Profile]
+        let scopes = [RidesScope.profile]
         let expectedPath = "/oauth/v2/authorize"
         let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: scopes)
         
@@ -326,7 +326,7 @@ class OAuthTests: XCTestCase {
     func testImplicitGrantRedirect_shouldReturnFalse_forNonRedirectUrlRequest() {
         redirectURI = Configuration.shared.getCallbackURIString(for: .implicit)
         let request = URLRequest(url: URL(string: "test://notRedirect")!)
-        let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
+        let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.profile])
         implicitGrantBehavior.loginCompletion = { accessToken, error in
             XCTAssert(false)
         }
@@ -337,7 +337,7 @@ class OAuthTests: XCTestCase {
     func testAuthorizationCodeGrantRedirect_shouldReturnFalse_forNonRedirectUrlRequest() {
         redirectURI = Configuration.shared.getCallbackURIString(for: .authorizationCode)
         let request = URLRequest(url: URL(string: "test://notRedirect")!)
-        let authorizationCodeGrantAuthenticator = AuthorizationCodeGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile], state: "state")
+        let authorizationCodeGrantAuthenticator = AuthorizationCodeGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.profile], state: "state")
         authorizationCodeGrantAuthenticator.loginCompletion = { accessToken, error in
             XCTAssert(false)
         }
@@ -354,7 +354,7 @@ class OAuthTests: XCTestCase {
         }
         let request = URLRequest(url: url)
         testExpectation = expectation(description: "call login completion")
-        let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
+        let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.profile])
         implicitGrantBehavior.loginCompletion = { accessToken, error in
             XCTAssertNil(error)
             XCTAssertNotNil(accessToken)
@@ -374,7 +374,7 @@ class OAuthTests: XCTestCase {
         let request = URLRequest(url: URL(string: redirectURI)!)
         let loginCompletionExpectation = expectation(description: "call login completion")
         let executeLoginExpectation = expectation(description: "execute login")
-        let authorizationCodeGrantAuthenticator = AuthorizationCodeGrantAuthenticatorMock(presentingViewController: UIViewController(), scopes: [.Profile], state: "state", expectation: executeLoginExpectation)
+        let authorizationCodeGrantAuthenticator = AuthorizationCodeGrantAuthenticatorMock(presentingViewController: UIViewController(), scopes: [.profile], state: "state", expectation: executeLoginExpectation)
         authorizationCodeGrantAuthenticator.loginCompletion = { accessToken, error in
             XCTAssertNil(error)
             XCTAssertNil(accessToken)
@@ -402,7 +402,7 @@ class OAuthTests: XCTestCase {
         }
         let request = URLRequest(url: requestURL)
         let loginCompletionExpectation = expectation(description: "call login completion")
-        let authorizationCodeGrantAuthenticator = AuthorizationCodeGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
+        let authorizationCodeGrantAuthenticator = AuthorizationCodeGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.profile])
         authorizationCodeGrantAuthenticator.loginCompletion = { accessToken, error in
             if let error = error {
                 XCTAssertEqual(RidesAuthenticationErrorType.serverError.rawValue, error.code)
@@ -424,7 +424,7 @@ class OAuthTests: XCTestCase {
         redirectURI = Configuration.shared.getCallbackURIString(for: .implicit)
         let request = URLRequest(url: URL(string: "\(redirectURI)?error=mismatching_redirect_uri")!)
         testExpectation = expectation(description: "call login completion with error")
-        let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.Profile])
+        let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewController(), scopes: [.profile])
         implicitGrantBehavior.loginCompletion = { accessToken, error in
             XCTAssertNil(accessToken)
             guard let error = error else {
@@ -448,7 +448,7 @@ class OAuthTests: XCTestCase {
         redirectURI = Configuration.shared.getCallbackURIString(for: .implicit)
         testExpectation = expectation(description: "present login")
     
-        let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewControllerMock(expectation: testExpectation), scopes: [.Profile])
+        let implicitGrantBehavior = ImplicitGrantAuthenticator(presentingViewController: UIViewControllerMock(expectation: testExpectation), scopes: [.profile])
         implicitGrantBehavior.login()
         
         waitForExpectations(timeout: timeout, handler: { error in
@@ -460,7 +460,7 @@ class OAuthTests: XCTestCase {
         redirectURI = Configuration.shared.getCallbackURIString(for: .authorizationCode)
         testExpectation = expectation(description: "present login")
         
-        let implicitGrantBehavior = AuthorizationCodeGrantAuthenticator(presentingViewController: UIViewControllerMock(expectation: testExpectation), scopes: [.Profile], state: "state")
+        let implicitGrantBehavior = AuthorizationCodeGrantAuthenticator(presentingViewController: UIViewControllerMock(expectation: testExpectation), scopes: [.profile], state: "state")
         implicitGrantBehavior.login()
         
         waitForExpectations(timeout: timeout, handler: { error in

--- a/source/UberRidesTests/OauthEndpointTests.swift
+++ b/source/UberRidesTests/OauthEndpointTests.swift
@@ -45,7 +45,7 @@ class OauthEndpointTests: XCTestCase {
     func testLogin_withSandboxEnabled() {
         Configuration.shared.isSandbox = true
         
-        let scopes = [ RidesScope.Profile, RidesScope.History ]
+        let scopes = [ RidesScope.profile, RidesScope.history ]
         let expectedHost = "https://login.uber.com"
         let expectedPath = "/oauth/v2/authorize"
         let expectedScopes = scopes.toRidesScopeString()
@@ -70,7 +70,7 @@ class OauthEndpointTests: XCTestCase {
     func testLogin_withSandboxDisabled() {
         Configuration.shared.isSandbox = false
         
-        let scopes = [ RidesScope.Profile, RidesScope.History ]
+        let scopes = [ RidesScope.profile, RidesScope.history ]
         let expectedHost = "https://login.uber.com"
         let expectedPath = "/oauth/v2/authorize"
         let expectedScopes = scopes.toRidesScopeString()
@@ -93,7 +93,7 @@ class OauthEndpointTests: XCTestCase {
     }
 
     func testLogin_forAuthorizationCodeGrant_defaultSettings() {
-        let scopes = [ RidesScope.AllTrips, RidesScope.History ]
+        let scopes = [ RidesScope.allTrips, RidesScope.history ]
         let expectedHost = "https://login.uber.com"
         let expectedPath = "/oauth/v2/authorize"
         let expectedScopes = scopes.toRidesScopeString()

--- a/source/UberRidesTests/RidesScopeExtensionsTests.swift
+++ b/source/UberRidesTests/RidesScopeExtensionsTests.swift
@@ -29,9 +29,9 @@ class RidesScopeExtensionsTests: XCTestCase {
 
     func testRidesScopeToString_withValidScopes()
     {
-        let scopes : [RidesScope] = Array(arrayLiteral: RidesScope.Profile, RidesScope.Places)
+        let scopes : [RidesScope] = Array(arrayLiteral: RidesScope.profile, RidesScope.places)
         
-        let expectedString = "\(RidesScope.Profile.rawValue) \(RidesScope.Places.rawValue)"
+        let expectedString = "\(RidesScope.profile.rawValue) \(RidesScope.places.rawValue)"
         let scopeString = scopes.toRidesScopeString()
         
         XCTAssertEqual(expectedString, scopeString)
@@ -49,7 +49,7 @@ class RidesScopeExtensionsTests: XCTestCase {
     
     func testRidesScopeToString_withValidScopesUsingSet()
     {
-        let scopes : Set<RidesScope> = Set<RidesScope>(arrayLiteral: RidesScope.Profile, RidesScope.Places)
+        let scopes : Set<RidesScope> = Set<RidesScope>(arrayLiteral: RidesScope.profile, RidesScope.places)
         
         let scopeString = scopes.toRidesScopeString()
         
@@ -76,9 +76,9 @@ class RidesScopeExtensionsTests: XCTestCase {
     
     func testStringToRidesScope_withValidScopes()
     {
-        let expectedScopes : [RidesScope] = Array(arrayLiteral: RidesScope.Profile, RidesScope.Places)
+        let expectedScopes : [RidesScope] = Array(arrayLiteral: RidesScope.profile, RidesScope.places)
         
-        let scopeString = "\(RidesScope.Profile.rawValue) \(RidesScope.Places.rawValue)"
+        let scopeString = "\(RidesScope.profile.rawValue) \(RidesScope.places.rawValue)"
 
         let scopes = scopeString.toRidesScopesArray()
         
@@ -109,9 +109,9 @@ class RidesScopeExtensionsTests: XCTestCase {
     
     func testStringToRidesScope_withInvalidAndValidScopes()
     {
-        let expectedScopes : [RidesScope] = Array(arrayLiteral: RidesScope.Places)
+        let expectedScopes : [RidesScope] = Array(arrayLiteral: RidesScope.places)
         
-        let scopeString = "not actual values \(RidesScope.Places.rawValue)"
+        let scopeString = "not actual values \(RidesScope.places.rawValue)"
         
         let scopes = scopeString.toRidesScopesArray()
         
@@ -120,7 +120,7 @@ class RidesScopeExtensionsTests: XCTestCase {
     
     func testStringToRidesScope_caseInsensitive()
     {
-        let expectedScopes : [RidesScope] = Array(arrayLiteral: RidesScope.Places, RidesScope.History)
+        let expectedScopes : [RidesScope] = Array(arrayLiteral: RidesScope.places, RidesScope.history)
         
         let scopeString = "plAcEs HISTORY"
         


### PR DESCRIPTION
Update sample projects so they work against the new SDK.

Fixes some oversights found in the SDK while updating the sample projects. Namely:

* Missing `@objc` annotation
* Incorrect capitalization for enum-style things.

Also adds a default Client ID for the sample projects so people can compile & go. 