### PR TITLE
Driver smsNumber maked optional

### DIFF
--- a/source/UberRides/Model/Driver.swift
+++ b/source/UberRides/Model/Driver.swift
@@ -39,7 +39,7 @@
     @objc public private(set) var phoneNumber: String
 
     /// The formatted phone number for sending a SMS to the driver.
-    @objc public private(set) var smsNumber: String
+    @objc public private(set) var smsNumber: String?
     
     /// The driver's star rating out of 5 stars.
     @objc public private(set) var rating: Double
@@ -48,7 +48,7 @@
         case name        = "name"
         case pictureURL  = "picture_url"
         case phoneNumber = "phone_number"
-        case smsNumber = "sms_number"
+        case smsNumber   = "sms_number"
         case rating      = "rating"
     }
 
@@ -57,7 +57,7 @@
         name = try container.decode(String.self, forKey: .name)
         pictureURL = try container.decode(URL.self, forKey: .pictureURL)
         phoneNumber = try container.decode(String.self, forKey: .phoneNumber)
-        smsNumber = try container.decode(String.self, forKey: .smsNumber)
+        smsNumber = try container.decodeIfPresent(String.self, forKey: .smsNumber)
         rating = try container.decode(Double.self, forKey: .rating)
     }
 }


### PR DESCRIPTION
Fixed a bug that caused a problem with loading the current ride because of null value for a driver sms number that we've received from API in Sandbox. Before that fix, when ride was in "accepted" state, we've received a json from API where sms number was null, so we were getting nil ride when calling "fetchCurrentRide" function because UberRides was decoding this json, and trying to get value for non optional String.