### PR TITLE
Move deeplink state management to dedicated manager class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Change Log
 
+# [0.8.0] TBD
+
+0.8 separates the Uber Rides SDK into two modules, `UberRides` and `UberCore`. It also contains a number of authentication-related changes to simplify the Login with Uber flows. 
+
+When migrating to 0.8, you may need to add `import UberCore` to files previously importing just `UberRides`, and rename usage of some classes below. 
+
+### Changes
+
+* `LoginManager` now uses `SFAuthenticationSession`, `SFSafariViewController`, or external Safari for web-based OAuth flows.
+* `Deeplinking` protocol simplified. Public properties from the previous protocol is now available under the `.url` property. 
+* `UberAuthenticating` protocol simplified. 
+
+### Moved to UberCore
+
+* `Configuration`
+* `Deeplinking`, `BaseDeeplink`, `AppStoreDeeplink`, 
+* `UberAPI` -> `APIEndpoint`
+* `RidesError` -> `UberError`
+* `RidesScope` -> `UberScope`
+* `UberAuthenticating`, `BaseAuthenticator`, `AuthorizationCodeGrantAuthenticator`, `ImplicitGrantAuthenticator`,  `NativeAuthenticator`
+
+### Removed
+
+* `LoginView` - initiate the login process via `LoginManager` instead.
+* `LoginViewAuthenticator` - initiate the login process via `LoginManager` instead.
+* `OAuthViewController` - initiate the login process via `LoginManager` instead.
+
 ## [0.7.0] 2017-09-15
 
 0.7 makes the Uber Rides iOS SDK compatible with iOS 11 and Swift 4.
@@ -216,9 +243,9 @@ All ride requests are now specified by a `RideParameters` object. It allows you 
 Currently available `requestingBehaviors` are:
 
 - `DeeplinkRequestingBehavior`
-	- Deeplinks into the Uber app to request a ride
+  - Deeplinks into the Uber app to request a ride
 - `RideRequestViewRequestingBehavior`
-	- Presents the **Ride Request Widget** modally in your app to provide and end to end Uber experience
+  - Presents the **Ride Request Widget** modally in your app to provide and end to end Uber experience
 
 ### Fixed
 
@@ -228,14 +255,14 @@ Currently available `requestingBehaviors` are:
 ### Breaking
 - `ClientID` must now be set in your app's `Info.plist` under the `UberClientID` key
 - `RequestButton` --> `RideRequestButton`
-	- Removed `init(colorStyle: RequestButtonColorStyle)` use `init(rideParameters: RideParameters, requestingBehavior: RideRequesting)`
-	- Removed all setting parameter methods (`setPickupLocation()`, `setDropoffLocation()`, ect) use a `RideParameters` object instead
-	- Removed `RequestButtonError`, only used to indicate no `ClientID` which is now handled by `Configuration`
-	- `uberButtonTapped()` no longer public
+  - Removed `init(colorStyle: RequestButtonColorStyle)` use `init(rideParameters: RideParameters, requestingBehavior: RideRequesting)`
+  - Removed all setting parameter methods (`setPickupLocation()`, `setDropoffLocation()`, ect) use a `RideParameters` object instead
+  - Removed `RequestButtonError`, only used to indicate no `ClientID` which is now handled by `Configuration`
+  - `uberButtonTapped()` no longer public
 - `RequestDeeplink`
-	- Removed `init(withClientID: String, fromSource: SourceParameter)` use `init(rideParameters: RideParameters)` instead
-	- Removed all setting parameter methods (`setPickupLocation()`, `setDropoffLocation`, ect) use a `RideParameters` object instead
-	- `SourceParameter` removed
+  - Removed `init(withClientID: String, fromSource: SourceParameter)` use `init(rideParameters: RideParameters)` instead
+  - Removed all setting parameter methods (`setPickupLocation()`, `setDropoffLocation`, ect) use a `RideParameters` object instead
+  - `SourceParameter` removed
 - Removed Carthage support
 
 

--- a/source/UberCore/Deeplinks/AppStoreDeeplink.swift
+++ b/source/UberCore/Deeplinks/AppStoreDeeplink.swift
@@ -23,7 +23,6 @@
 //  THE SOFTWARE.
 
 import Foundation
-import UberCore
 
 /**
  *  A Deeplinking object for authenticating a user via the native Uber app
@@ -48,6 +47,6 @@ import UberCore
         
         let queryItems = [clientIDQueryItem, userAgentQueryItem]
         
-        super.init(scheme: scheme, domain: domain, path: path, queryItems: queryItems)!
+        super.init(scheme: scheme, host: domain, path: path, queryItems: queryItems)!
     }
 }

--- a/source/UberCore/Deeplinks/DeeplinkManager.swift
+++ b/source/UberCore/Deeplinks/DeeplinkManager.swift
@@ -1,0 +1,122 @@
+//
+//  DeeplinkManager.swift
+//  UberCore
+//
+//  Copyright © 2016 Uber Technologies, Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+class DeeplinkManager {
+    static let shared = DeeplinkManager()
+
+    private var currentDeeplink: Deeplinking?
+    private var callbackWrapper: DeeplinkCompletionHandler?
+
+    private var waitingOnSystemPromptResponse = false
+    private var checkingSystemPromptResponse = false
+    private var promptTimer: Timer?
+    private var completionWrapper: ((NSError?) -> ()) = { _ in }
+
+    func open(_ deeplink: Deeplinking, completion: DeeplinkCompletionHandler? = nil) {
+        open(deeplink.url, completion: completion)
+    }
+
+    func open(_ url: URL, completion: DeeplinkCompletionHandler? = nil) {
+        if #available(iOS 9.0, *) {
+            executeOnIOS9(deeplink: url, callback: completion)
+        } else {
+            executeOnBelowIOS9(deeplink: url, callback: completion)
+        }
+    }
+
+    //Mark: Internal Interface
+
+    private func executeOnIOS9(deeplink url: URL, callback: DeeplinkCompletionHandler?) {
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActiveHandler), name: Notification.Name.UIApplicationWillResignActive, object: nil);
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActiveHandler), name: Notification.Name.UIApplicationDidBecomeActive, object: nil);
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackgroundHandler), name: Notification.Name.UIApplicationDidEnterBackground, object: nil)
+
+        callbackWrapper = { handled in
+            NotificationCenter.default.removeObserver(self)
+            self.promptTimer?.invalidate()
+            self.promptTimer = nil
+            self.checkingSystemPromptResponse = false
+            self.waitingOnSystemPromptResponse = false
+            callback?(handled)
+        }
+
+        var error: NSError?
+        if UIApplication.shared.canOpenURL(url) {
+            let openedURL = UIApplication.shared.openURL(url)
+            if !openedURL {
+                error = DeeplinkErrorFactory.errorForType(.unableToFollow)
+            }
+        } else {
+            error = DeeplinkErrorFactory.errorForType(.unableToOpen)
+        }
+
+        if error != nil {
+            callbackWrapper?(error)
+        }
+    }
+
+    private func executeOnBelowIOS9(deeplink url: URL, callback: DeeplinkCompletionHandler?) {
+        callbackWrapper = { handled in
+            callback?(handled)
+        }
+
+        var error: NSError?
+        if UIApplication.shared.canOpenURL(url) {
+            let openedURL = UIApplication.shared.openURL(url)
+            if !openedURL {
+                error = DeeplinkErrorFactory.errorForType(.unableToFollow)
+            }
+        } else {
+            error = DeeplinkErrorFactory.errorForType(.unableToOpen)
+        }
+
+        completionWrapper(error)
+    }
+
+    //Mark: App Lifecycle Notifications
+
+    @objc private func appWillResignActiveHandler(_ notification: Notification) {
+        if !waitingOnSystemPromptResponse {
+            waitingOnSystemPromptResponse = true
+        } else if checkingSystemPromptResponse {
+            completionWrapper(nil)
+        }
+    }
+
+    @objc private func appDidBecomeActiveHandler(_ notification: Notification) {
+        if waitingOnSystemPromptResponse {
+            checkingSystemPromptResponse = true
+            promptTimer = Timer.scheduledTimer(timeInterval: 0.25, target: self, selector: #selector(deeplinkHelper), userInfo: nil, repeats: false)
+        }
+    }
+
+    @objc private func appDidEnterBackgroundHandler(_ notification: Notification) {
+        completionWrapper(nil)
+    }
+
+    @objc private func deeplinkHelper() {
+        let error = DeeplinkErrorFactory.errorForType(.deeplinkNotFollowed)
+        completionWrapper(error)
+    }
+}

--- a/source/UberCore/Deeplinks/DeeplinkingProtocol.swift
+++ b/source/UberCore/Deeplinks/DeeplinkingProtocol.swift
@@ -22,25 +22,14 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+public typealias DeeplinkCompletionHandler = (NSError?) -> Void
+
 /**
  *  Protocol for defining a deeplink that can be executed to open an external app
  */
 @objc(UBSDKDeeplinking) public protocol Deeplinking {
-    
-    /// The deeplink scheme to use, where a deeplink takes the form scheme://domain/path?query
-    var scheme: String { get }
-    
-    /// The domain of the deeplink, where a deeplink takes the form scheme://domain/path?query
-    var domain: String { get }
-    
-    /// The path of the deeplink, where a deeplink takes the form scheme://domain/path?query
-    var path: String { get }
-    
-    /// The query parameter items for the deeplink, where a deeplink takes the form scheme://domain/path?query
-    var queryItems: [URLQueryItem]? { get }
-    
     /// The deeplink URL that the deeplink will execute
-    var deeplinkURL: URL { get }
+    var url: URL { get }
     
     /**
      Execute a deeplink to launch into an external app
@@ -54,5 +43,5 @@
      - parameter completion: The completion block to execute once the deeplink has
      executed. Passes in True if the url was successfully opened, false otherwise.
      */
-    @objc func execute(completion: ((NSError?) -> ())?)
+    @objc func execute(completion: DeeplinkCompletionHandler?)
 }

--- a/source/UberCoreTests/BaseDeeplinkTests.swift
+++ b/source/UberCoreTests/BaseDeeplinkTests.swift
@@ -52,23 +52,13 @@ class BaseDeeplinkTests: XCTestCase {
         urlComponents.path = testPath
         urlComponents.queryItems = testQueryItems
         let expectedURL = urlComponents.url
-        
-        guard let baseDeeplink = BaseDeeplink(scheme: testScheme, domain: testDomain, path: testPath, queryItems: testQueryItems) else {
+
+        guard let baseDeeplink = BaseDeeplink(scheme: testScheme, host: testDomain, path: testPath, queryItems: testQueryItems) else {
             XCTFail()
             return
         }
-        
-        
-        guard let queryItems = baseDeeplink.queryItems else {
-            XCTFail()
-            return
-        }
-        
-        XCTAssertEqual(baseDeeplink.scheme, testScheme)
-        XCTAssertEqual(baseDeeplink.domain, testDomain)
-        XCTAssertEqual(baseDeeplink.path, testPath)
-        XCTAssertEqual(queryItems, testQueryItems)
-        XCTAssertEqual(baseDeeplink.deeplinkURL, expectedURL)
+
+        XCTAssertEqual(baseDeeplink.url, expectedURL)
     }
 }
 


### PR DESCRIPTION
In the current SDK, deeplink objects are self-aware objects that manage their own state when executed.

This change turns deeplink objects into thin wrappers around the `URL` object, and separates out its state management (for performing the deeplink) into a manager singleton. This allows us to treat URLs as deeplinks (which they are, just for the Safari app). In addition, we get the ability to track deeplink success without necessarily having a `Deeplinking` object. 