### PR TITLE
Update Configuration to use `URL` for Callback URLs

### DIFF
--- a/source/UberCore/Configuration.swift
+++ b/source/UberCore/Configuration.swift
@@ -102,7 +102,7 @@ private let callbackURIStringKey = "URIString"
      */
     @objc public var clientID: String
 
-    private var callbackURIs = [CallbackURIType: String]()
+    private var callbackURIs = [CallbackURIType: URL]()
 
     /**
      Gets the display name of this app. Defaults to the value stored in your Appication's
@@ -152,7 +152,7 @@ private let callbackURIStringKey = "URIString"
 
      - returns: true if fallback enabled, false otherwise
      */
-    @objc public var useFallback: Bool = true
+    @objc public var useFallback: Bool = false
 
     public override init() {
         self.clientID = ""
@@ -191,17 +191,17 @@ private let callbackURIStringKey = "URIString"
     // MARK: Getters
     
     /**
-     Gets the callback URIString of this app. Defaults to the value stored in your Application's
+     Gets the callback URI of this app. Defaults to the value stored in your Application's
      plist if not set (UberCallbackURI)
      
      - returns: The string to use for the Callback URI
     */
-    @objc public func getCallbackURIString() -> String {
-        return getCallbackURIString(for: .general)
+    @objc public func getCallbackURI() -> URL {
+        return getCallbackURI(for: .general)
     }
     
     /**
-     Gets the callback URIString for the given CallbackURIType. Defaults to the value 
+     Gets the callback URI for the given CallbackURIType. Defaults to the value
      stored in your Applications' plist (under the UberCallbackURIs key). If the requested
      type is not defined in your plist, it will attempt to use the .General type. If the 
      .General type is not defined, it will attempt to use the value stored under the UberCallbackURI key.
@@ -209,16 +209,18 @@ private let callbackURIStringKey = "URIString"
      
      - parameter type: The CallbackURIType to get a callback string for
      
-     - returns: The callbackURIString for the the requested type
+     - returns: The callbackURI for the the requested type
      */
-    @objc public func getCallbackURIString(for type: CallbackURIType) -> String {
+    @objc public func getCallbackURI(for type: CallbackURIType) -> URL {
         if callbackURIs[type] == nil {
             let defaultCallbacks = parseCallbackURIs()
             var fallback = defaultCallbacks[type] ?? callbackURIs[.general]
             fallback = fallback ?? defaultCallbacks[.general]
-            fallback = fallback ?? getDefaultValue(callbackURIKey)
+            if let defaultValue = getDefaultValue(callbackURIKey) {
+                fallback = fallback ?? URL(string: defaultValue)
+            }
             guard let fallbackCallback = fallback else {
-                fatalConfigurationError("CallbackURIStrings[\(type.toString())]", key: callbackURIsKey)
+                fatalConfigurationError("CallbackURI[\(type.toString())]", key: callbackURIsKey)
             }
             callbackURIs[type] = fallbackCallback
         }
@@ -233,10 +235,10 @@ private let callbackURIStringKey = "URIString"
      If you're setting a custom value, be sure your app is configured to handle deeplinks
      from this URI & you've added it to the redirect URIs on your Uber developer dashboard
      
-     - parameter callbackURIString: The callback URI String to use
+     - parameter callbackURI: The callback URI String to use
     */
-    @objc public func setCallbackURIString(_ callbackURIString: String?) {
-        setCallbackURIString(callbackURIString, type: .general)
+    @objc public func setCallbackURI(_ callbackURI: URL?) {
+        setCallbackURI(callbackURI, type: .general)
     }
     
     /**
@@ -246,12 +248,12 @@ private let callbackURIStringKey = "URIString"
      If you're setting a custom value, be sure your app is configured to handle deeplinks
      from this URI & you've added it to the redirect URIs on your Uber developer dashboard
      
-     - parameter callbackURIString: The callback URI String to use
+     - parameter callbackURI: The callback URI String to use
      - parameter type:              The Callback URI Type to use
      */
-    @objc public func setCallbackURIString(_ callbackURIString: String?, type: CallbackURIType) {
+    @objc public func setCallbackURI(_ callbackURI: URL?, type: CallbackURIType) {
         var callbackURIs = self.callbackURIs
-        callbackURIs[type] = callbackURIString
+        callbackURIs[type] = callbackURI
         self.callbackURIs = callbackURIs
     }
 
@@ -261,18 +263,20 @@ private let callbackURIStringKey = "URIString"
     
     // MARK: Private
     
-    private func parseCallbackURIs() -> [CallbackURIType : String] {
-        guard let plist = getPlistDictionary(), let callbacks = plist[callbackURIsKey] as? [[String : AnyObject]] else {
-            return [CallbackURIType : String]()
+    private func parseCallbackURIs() -> [CallbackURIType : URL] {
+        guard let plist = getPlistDictionary(), let callbacks = plist[callbackURIsKey] as? [[String: AnyObject]] else {
+            return [CallbackURIType: URL]()
         }
-        var callbackURIs = [CallbackURIType : String]()
+        var callbackURIs = [CallbackURIType : URL]()
         
         for callbackObject in callbacks {
-            guard let callbackTypeString = callbackObject[callbackURIsTypeKey] as? String, let uriString = callbackObject[callbackURIStringKey] as? String else {
+            guard let callbackTypeString = callbackObject[callbackURIsTypeKey] as? String,
+                let uriString = callbackObject[callbackURIStringKey] as? String,
+                let uri = URL(string: uriString) else {
                 continue
             }
             let callbackType = CallbackURIType.fromString(callbackTypeString)
-            callbackURIs[callbackType] = uriString
+            callbackURIs[callbackType] = uri
         }
         return callbackURIs
     }

--- a/source/UberCore/Configuration.swift
+++ b/source/UberCore/Configuration.swift
@@ -199,6 +199,16 @@ private let callbackURIStringKey = "URIString"
     @objc public func getCallbackURI() -> URL {
         return getCallbackURI(for: .general)
     }
+
+    /**
+     Gets the callback URIString of this app. Defaults to the value stored in your Application's
+     plist if not set (UberCallbackURI)
+
+     - returns: The string to use for the Callback URI
+     */
+    @objc public func getCallbackURIString() -> String {
+        return getCallbackURI().absoluteString
+    }
     
     /**
      Gets the callback URI for the given CallbackURIType. Defaults to the value
@@ -225,6 +235,21 @@ private let callbackURIStringKey = "URIString"
             callbackURIs[type] = fallbackCallback
         }
         return callbackURIs[type]!
+    }
+
+    /**
+     Gets the callback URIString for the given CallbackURIType. Defaults to the value
+     stored in your Applications' plist (under the UberCallbackURIs key). If the requested
+     type is not defined in your plist, it will attempt to use the .General type. If the
+     .General type is not defined, it will attempt to use the value stored under the UberCallbackURI key.
+     Throws a fatal error if no value can be determined
+
+     - parameter type: The CallbackURIType to get a callback string for
+
+     - returns: The callbackURIString for the the requested type
+     */
+    @objc public func getCallbackURIString(for type: CallbackURIType) -> String {
+        return getCallbackURI(for: type).absoluteString
     }
     
     //MARK: Setters

--- a/source/UberCoreTests/ConfigurationTests.swift
+++ b/source/UberCoreTests/ConfigurationTests.swift
@@ -29,11 +29,11 @@ class ConfigurationTests: XCTestCase {
 
     private let defaultClientID = "testClientID"
     private let defaultDisplayName = "My Awesome App"
-    private let defaultCallbackString = "testURI://uberConnect"
-    private let defaultGeneralCallbackString = "testURI://uberConnectGeneral"
-    private let defaultAuthorizationCodeCallbackString = "testURI://uberConnectAuthorizationCode"
-    private let defaultImplicitCallbackString = "testURI://uberConnectImplicit"
-    private let defaultNativeCallbackString = "testURI://uberConnectNative"
+    private let defaultCallback = URL(string: "testURI://uberConnect")!
+    private let defaultGeneralCallback = URL(string: "testURI://uberConnectGeneral")!
+    private let defaultAuthorizationCodeCallback = URL(string: "testURI://uberConnectAuthorizationCode")!
+    private let defaultImplicitCallback = URL(string: "testURI://uberConnectImplicit")!
+    private let defaultNativeCallback = URL(string: "testURI://uberConnectNative")!
     private let defaultServerToken = "testServerToken"
     private let defaultAccessTokenIdentifier = "RidesAccessTokenKey"
     private let defaultSandbox = false
@@ -55,7 +55,7 @@ class ConfigurationTests: XCTestCase {
     func testConfiguration_restoreDefaults() {
         
         let newClientID = "newID"
-        let newCallback = "newCallback://"
+        let newCallback = URL(string: "newCallback://")!
         let newDisplay = "newDisplay://"
         let newServerToken = "newserver"
         let newGroup = "new group"
@@ -63,7 +63,7 @@ class ConfigurationTests: XCTestCase {
         let newSandbox = true
         
         Configuration.shared.clientID = newClientID
-        Configuration.shared.setCallbackURIString(newCallback)
+        Configuration.shared.setCallbackURI(newCallback)
         Configuration.shared.appDisplayName = newDisplay
         Configuration.shared.serverToken = newServerToken
         Configuration.shared.defaultKeychainAccessGroup = newGroup
@@ -71,7 +71,7 @@ class ConfigurationTests: XCTestCase {
         Configuration.shared.isSandbox = newSandbox
         
         XCTAssertEqual(newClientID, Configuration.shared.clientID)
-        XCTAssertEqual(newCallback, Configuration.shared.getCallbackURIString())
+        XCTAssertEqual(newCallback, Configuration.shared.getCallbackURI())
         XCTAssertEqual(newDisplay, Configuration.shared.appDisplayName)
         XCTAssertEqual(newServerToken, Configuration.shared.serverToken)
         XCTAssertEqual(newGroup, Configuration.shared.defaultKeychainAccessGroup)
@@ -83,7 +83,7 @@ class ConfigurationTests: XCTestCase {
         Configuration.bundle = Bundle.main
         
         XCTAssertEqual(Configuration.shared.clientID, defaultClientID)
-        XCTAssertEqual(defaultGeneralCallbackString, Configuration.shared.getCallbackURIString())
+        XCTAssertEqual(defaultGeneralCallback, Configuration.shared.getCallbackURI())
         XCTAssertEqual(defaultDisplayName, Configuration.shared.appDisplayName)
         XCTAssertEqual(defaultServerToken, Configuration.shared.serverToken)
         XCTAssertEqual("", Configuration.shared.defaultKeychainAccessGroup)
@@ -105,102 +105,102 @@ class ConfigurationTests: XCTestCase {
     
     //MARK: Callback URI String Tests
     
-    func testCallbackURIString_getDefault() {
-        XCTAssertEqual(defaultGeneralCallbackString, Configuration.shared.getCallbackURIString())
+    func testCallbackURI_getDefault() {
+        XCTAssertEqual(defaultGeneralCallback, Configuration.shared.getCallbackURI())
     }
     
-    func testCallbackURIString_overwriteDefault() {
-        let callbackURIString = "callback://test"
-        Configuration.shared.setCallbackURIString(callbackURIString)
+    func testCallbackURI_overwriteDefault() {
+        let callbackURI = URL(string: "callback://test")!
+        Configuration.shared.setCallbackURI(callbackURI)
         
-        XCTAssertEqual(callbackURIString, Configuration.shared.getCallbackURIString())
+        XCTAssertEqual(callbackURI, Configuration.shared.getCallbackURI())
     }
     
-    func testCallbackURIString_getDefault_getTypes() {
-        XCTAssertEqual(defaultGeneralCallbackString, Configuration.shared.getCallbackURIString(for: .general))
-        XCTAssertEqual(defaultAuthorizationCodeCallbackString, Configuration.shared.getCallbackURIString(for: .authorizationCode))
-        XCTAssertEqual(defaultImplicitCallbackString, Configuration.shared.getCallbackURIString(for: .implicit))
-        XCTAssertEqual(defaultNativeCallbackString, Configuration.shared.getCallbackURIString(for: .native))
+    func testCallbackURI_getDefault_getTypes() {
+        XCTAssertEqual(defaultGeneralCallback, Configuration.shared.getCallbackURI(for: .general))
+        XCTAssertEqual(defaultAuthorizationCodeCallback, Configuration.shared.getCallbackURI(for: .authorizationCode))
+        XCTAssertEqual(defaultImplicitCallback, Configuration.shared.getCallbackURI(for: .implicit))
+        XCTAssertEqual(defaultNativeCallback, Configuration.shared.getCallbackURI(for: .native))
     }
     
-    func testCallbackURIString_overwriteDefault_allTypes() {
-        let generalCallbackString = "testURI://uberConnectGeneralNew"
-        let authorizationCodeCallbackString = "testURI://uberConnectAuthorizationCodeNew"
-        let implicitCallbackString = "testURI://uberConnectImplicitNew"
-        let nativeCallbackString = "testURI://uberConnectNativeNew"
+    func testCallbackURI_overwriteDefault_allTypes() {
+        let generalCallback = URL(string: "testURI://uberConnectGeneralNew")!
+        let authorizationCodeCallback = URL(string: "testURI://uberConnectAuthorizationCodeNew")!
+        let implicitCallback = URL(string: "testURI://uberConnectImplicitNew")!
+        let nativeCallback = URL(string: "testURI://uberConnectNativeNew")!
         
-        Configuration.shared.setCallbackURIString(generalCallbackString, type: .general)
-        Configuration.shared.setCallbackURIString(authorizationCodeCallbackString, type: .authorizationCode)
-        Configuration.shared.setCallbackURIString(implicitCallbackString, type: .implicit)
-        Configuration.shared.setCallbackURIString(nativeCallbackString, type: .native)
+        Configuration.shared.setCallbackURI(generalCallback, type: .general)
+        Configuration.shared.setCallbackURI(authorizationCodeCallback, type: .authorizationCode)
+        Configuration.shared.setCallbackURI(implicitCallback, type: .implicit)
+        Configuration.shared.setCallbackURI(nativeCallback, type: .native)
         
-        XCTAssertEqual(generalCallbackString, Configuration.shared.getCallbackURIString(for: .general))
-        XCTAssertEqual(authorizationCodeCallbackString, Configuration.shared.getCallbackURIString(for: .authorizationCode))
-        XCTAssertEqual(implicitCallbackString, Configuration.shared.getCallbackURIString(for: .implicit))
-        XCTAssertEqual(nativeCallbackString, Configuration.shared.getCallbackURIString(for: .native))
+        XCTAssertEqual(generalCallback, Configuration.shared.getCallbackURI(for: .general))
+        XCTAssertEqual(authorizationCodeCallback, Configuration.shared.getCallbackURI(for: .authorizationCode))
+        XCTAssertEqual(implicitCallback, Configuration.shared.getCallbackURI(for: .implicit))
+        XCTAssertEqual(nativeCallback, Configuration.shared.getCallbackURI(for: .native))
     }
     
-    func testCallbackURIString_resetDefault_allTypes() {
-        let generalCallbackString = "testURI://uberConnectGeneralNew"
-        let authorizationCodeCallbackString = "testURI://uberConnectAuthorizationCodeNew"
-        let implicitCallbackString = "testURI://uberConnectImplicitNew"
-        let nativeCallbackString = "testURI://uberConnectNativeNew"
+    func testCallbackURI_resetDefault_allTypes() {
+        let generalCallback = URL(string: "testURI://uberConnectGeneralNew")!
+        let authorizationCodeCallback = URL(string: "testURI://uberConnectAuthorizationCodeNew")!
+        let implicitCallback = URL(string: "testURI://uberConnectImplicitNew")!
+        let nativeCallback = URL(string: "testURI://uberConnectNativeNew")!
         
-        Configuration.shared.setCallbackURIString(generalCallbackString, type: .general)
-        Configuration.shared.setCallbackURIString(authorizationCodeCallbackString, type: .authorizationCode)
-        Configuration.shared.setCallbackURIString(implicitCallbackString, type: .implicit)
-        Configuration.shared.setCallbackURIString(nativeCallbackString, type: .native)
+        Configuration.shared.setCallbackURI(generalCallback, type: .general)
+        Configuration.shared.setCallbackURI(authorizationCodeCallback, type: .authorizationCode)
+        Configuration.shared.setCallbackURI(implicitCallback, type: .implicit)
+        Configuration.shared.setCallbackURI(nativeCallback, type: .native)
         
-        Configuration.shared.setCallbackURIString(nil, type: .general)
-        Configuration.shared.setCallbackURIString(nil, type: .authorizationCode)
-        Configuration.shared.setCallbackURIString(nil, type: .implicit)
-        Configuration.shared.setCallbackURIString(nil, type: .native)
+        Configuration.shared.setCallbackURI(nil, type: .general)
+        Configuration.shared.setCallbackURI(nil, type: .authorizationCode)
+        Configuration.shared.setCallbackURI(nil, type: .implicit)
+        Configuration.shared.setCallbackURI(nil, type: .native)
         
-        XCTAssertEqual(defaultGeneralCallbackString, Configuration.shared.getCallbackURIString(for: .general))
-        XCTAssertEqual(defaultAuthorizationCodeCallbackString, Configuration.shared.getCallbackURIString(for: .authorizationCode))
-        XCTAssertEqual(defaultImplicitCallbackString, Configuration.shared.getCallbackURIString(for: .implicit))
-        XCTAssertEqual(defaultNativeCallbackString, Configuration.shared.getCallbackURIString(for: .native))
+        XCTAssertEqual(defaultGeneralCallback, Configuration.shared.getCallbackURI(for: .general))
+        XCTAssertEqual(defaultAuthorizationCodeCallback, Configuration.shared.getCallbackURI(for: .authorizationCode))
+        XCTAssertEqual(defaultImplicitCallback, Configuration.shared.getCallbackURI(for: .implicit))
+        XCTAssertEqual(defaultNativeCallback, Configuration.shared.getCallbackURI(for: .native))
     }
     
-    func testCallbackURIString_resetDefault_oneType() {
-        let generalCallbackString = "testURI://uberConnectGeneralNew"
-        let authorizationCodeCallbackString = "testURI://uberConnectAuthorizationCodeNew"
-        let implicitCallbackString = "testURI://uberConnectImplicitNew"
-        let nativeCallbackString = "testURI://uberConnectNativeNew"
+    func testCallbackURI_resetDefault_oneType() {
+        let generalCallback = URL(string: "testURI://uberConnectGeneralNew")!
+        let authorizationCodeCallback = URL(string: "testURI://uberConnectAuthorizationCodeNew")!
+        let implicitCallback = URL(string: "testURI://uberConnectImplicitNew")!
+        let nativeCallback = URL(string: "testURI://uberConnectNativeNew")!
         
-        Configuration.shared.setCallbackURIString(generalCallbackString, type: .general)
-        Configuration.shared.setCallbackURIString(authorizationCodeCallbackString, type: .authorizationCode)
-        Configuration.shared.setCallbackURIString(implicitCallbackString, type: .implicit)
-        Configuration.shared.setCallbackURIString(nativeCallbackString, type: .native)
+        Configuration.shared.setCallbackURI(generalCallback, type: .general)
+        Configuration.shared.setCallbackURI(authorizationCodeCallback, type: .authorizationCode)
+        Configuration.shared.setCallbackURI(implicitCallback, type: .implicit)
+        Configuration.shared.setCallbackURI(nativeCallback, type: .native)
 
-        Configuration.shared.setCallbackURIString(nil, type: .native)
+        Configuration.shared.setCallbackURI(nil, type: .native)
         
-        XCTAssertEqual(generalCallbackString, Configuration.shared.getCallbackURIString(for: .general))
-        XCTAssertEqual(authorizationCodeCallbackString, Configuration.shared.getCallbackURIString(for: .authorizationCode))
-        XCTAssertEqual(implicitCallbackString, Configuration.shared.getCallbackURIString(for: .implicit))
-        XCTAssertEqual(defaultNativeCallbackString, Configuration.shared.getCallbackURIString(for: .native))
+        XCTAssertEqual(generalCallback, Configuration.shared.getCallbackURI(for: .general))
+        XCTAssertEqual(authorizationCodeCallback, Configuration.shared.getCallbackURI(for: .authorizationCode))
+        XCTAssertEqual(implicitCallback, Configuration.shared.getCallbackURI(for: .implicit))
+        XCTAssertEqual(defaultNativeCallback, Configuration.shared.getCallbackURI(for: .native))
     }
     
-    func testCallbackURIStringFallback_whenCallbackURIsMissing() {
+    func testCallbackURIFallback_whenCallbackURIsMissing() {
         Configuration.bundle = Bundle(for: Configuration.self)
         Configuration.plistName = "testInfoMissingCallbacks"
         Configuration.restoreDefaults()
-        XCTAssertEqual(defaultCallbackString, Configuration.shared.getCallbackURIString(for: .general))
-        XCTAssertEqual(defaultCallbackString, Configuration.shared.getCallbackURIString(for: .authorizationCode))
-        XCTAssertEqual(defaultCallbackString, Configuration.shared.getCallbackURIString(for: .implicit))
-        XCTAssertEqual(defaultCallbackString, Configuration.shared.getCallbackURIString(for: .native))
+        XCTAssertEqual(defaultCallback, Configuration.shared.getCallbackURI(for: .general))
+        XCTAssertEqual(defaultCallback, Configuration.shared.getCallbackURI(for: .authorizationCode))
+        XCTAssertEqual(defaultCallback, Configuration.shared.getCallbackURI(for: .implicit))
+        XCTAssertEqual(defaultCallback, Configuration.shared.getCallbackURI(for: .native))
     }
     
-    func testCallbackURIStringFallbackUsesGeneralOverride_whenCallbackURIsMissing() {
+    func testCallbackURIFallbackUsesGeneralOverride_whenCallbackURIsMissing() {
         Configuration.bundle = Bundle(for: Configuration.self)
         Configuration.plistName = "testInfoMissingCallbacks"
         Configuration.restoreDefaults()
-        let override = "testURI://override"
-        Configuration.shared.setCallbackURIString(override, type: .general)
-        XCTAssertEqual(override, Configuration.shared.getCallbackURIString(for: .general))
-        XCTAssertEqual(override, Configuration.shared.getCallbackURIString(for: .authorizationCode))
-        XCTAssertEqual(override, Configuration.shared.getCallbackURIString(for: .implicit))
-        XCTAssertEqual(override, Configuration.shared.getCallbackURIString(for: .native))
+        let override = URL(string: "testURI://override")!
+        Configuration.shared.setCallbackURI(override, type: .general)
+        XCTAssertEqual(override, Configuration.shared.getCallbackURI(for: .general))
+        XCTAssertEqual(override, Configuration.shared.getCallbackURI(for: .authorizationCode))
+        XCTAssertEqual(override, Configuration.shared.getCallbackURI(for: .implicit))
+        XCTAssertEqual(override, Configuration.shared.getCallbackURI(for: .native))
     }
     
     //MARK: App Display Name Tests


### PR DESCRIPTION
Previously, the Configuration object kept track of Callback URIs as Strings. 

The correct type is `URL`, and upon the process of making changes to authenticators I decided to change this to `URL` across the board to reduce the need to convert between the two types. 

We also change the `useFallback` parameter to default false, as this parameter is only used to fall back to the Authorization Code flow. Since the end developer needs to set up a server to use Authorization Code flow, we make that usage opt-in. 