### PR TITLE
Update Sample Apps

### DIFF
--- a/examples/Obj-C SDK/Cartfile
+++ b/examples/Obj-C SDK/Cartfile
@@ -1,1 +1,0 @@
-github "uber/rides-ios-sdk" ~> 0.7

--- a/examples/Obj-C SDK/Obj-C SDK.xcodeproj/project.pbxproj
+++ b/examples/Obj-C SDK/Obj-C SDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3F2D7CE71D157B5789A37323 /* Pods_Obj_C_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE69176409DF6E866965BF58 /* Pods_Obj_C_SDK.framework */; };
 		AC0404F21BFB82CC00AC1501 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = AC0404F11BFB82CC00AC1501 /* main.m */; };
 		AC0404F51BFB82CC00AC1501 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AC0404F41BFB82CC00AC1501 /* AppDelegate.m */; };
 		AC0404F81BFB82CC00AC1501 /* UBSDKDeeplinkExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AC0404F71BFB82CC00AC1501 /* UBSDKDeeplinkExampleViewController.m */; };
@@ -21,8 +22,6 @@
 		DC44CE561CB72CB400E09AAC /* Localizations.bundle in Resources */ = {isa = PBXBuildFile; fileRef = DC44CE551CB72CB400E09AAC /* Localizations.bundle */; };
 		DC9B5B7E1D00CC1200FFD5DF /* UBSDKUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = DC9B5B7D1D00CC1200FFD5DF /* UBSDKUtility.m */; };
 		DCD806081CFE35EF00EF6EB1 /* UBSDKLoginButtonView.m in Sources */ = {isa = PBXBuildFile; fileRef = DCD806071CFE35EF00EF6EB1 /* UBSDKLoginButtonView.m */; };
-		DCEB80921D078DE300899810 /* UberRides.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCEB80911D078DE300899810 /* UberRides.framework */; };
-		DCEB80931D078DE300899810 /* UberRides.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DCEB80911D078DE300899810 /* UberRides.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DCEC0CAA1CB5D7780086C6D7 /* UBSDKExampleTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DCEC0CA91CB5D7780086C6D7 /* UBSDKExampleTableViewController.m */; };
 		DCEC0CAD1CB5DCB10086C6D7 /* UBSDKRideRequestWidgetExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DCEC0CAC1CB5DCB10086C6D7 /* UBSDKRideRequestWidgetExampleViewController.m */; };
 		DCEC0CB01CB5E3D30086C6D7 /* UBSDKImplicitGrantExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DCEC0CAF1CB5E3D30086C6D7 /* UBSDKImplicitGrantExampleViewController.m */; };
@@ -52,7 +51,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				DCEB80931D078DE300899810 /* UberRides.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -78,6 +76,7 @@
 		AC0405111BFB82CC00AC1501 /* Obj-C SDKUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Obj-C SDKUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC0405151BFB82CC00AC1501 /* Obj_C_SDKUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Obj_C_SDKUITests.m; sourceTree = "<group>"; };
 		AC0405171BFB82CC00AC1501 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CE69176409DF6E866965BF58 /* Pods_Obj_C_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Obj_C_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC1AE1C01CF906E200B8CFCB /* UBSDKButtonExampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UBSDKButtonExampleViewController.h; sourceTree = "<group>"; };
 		DC1AE1C11CF906E200B8CFCB /* UBSDKButtonExampleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UBSDKButtonExampleViewController.m; sourceTree = "<group>"; };
 		DC1AE1C31CF9137A00B8CFCB /* UBSDKNativeLoginExampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UBSDKNativeLoginExampleViewController.h; sourceTree = "<group>"; };
@@ -96,7 +95,6 @@
 		DC9B5B7D1D00CC1200FFD5DF /* UBSDKUtility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UBSDKUtility.m; sourceTree = "<group>"; };
 		DCD806061CFE35EF00EF6EB1 /* UBSDKLoginButtonView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UBSDKLoginButtonView.h; sourceTree = "<group>"; };
 		DCD806071CFE35EF00EF6EB1 /* UBSDKLoginButtonView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UBSDKLoginButtonView.m; sourceTree = "<group>"; };
-		DCEB80911D078DE300899810 /* UberRides.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UberRides.framework; path = Carthage/Build/iOS/UberRides.framework; sourceTree = "<group>"; };
 		DCEC0CA81CB5D7780086C6D7 /* UBSDKExampleTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UBSDKExampleTableViewController.h; sourceTree = "<group>"; };
 		DCEC0CA91CB5D7780086C6D7 /* UBSDKExampleTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UBSDKExampleTableViewController.m; sourceTree = "<group>"; };
 		DCEC0CAB1CB5DCB10086C6D7 /* UBSDKRideRequestWidgetExampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UBSDKRideRequestWidgetExampleViewController.h; sourceTree = "<group>"; };
@@ -110,7 +108,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DCEB80921D078DE300899810 /* UberRides.framework in Frameworks */,
+				3F2D7CE71D157B5789A37323 /* Pods_Obj_C_SDK.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -134,7 +132,7 @@
 		28A6CFC4B4A38C240D740F18 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				DCEB80911D078DE300899810 /* UberRides.framework */,
+				CE69176409DF6E866965BF58 /* Pods_Obj_C_SDK.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -261,11 +259,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = AC04051A1BFB82CC00AC1501 /* Build configuration list for PBXNativeTarget "Obj-C SDK" */;
 			buildPhases = (
+				DA2812E3F2C3469BD2EBA6F2 /* [CP] Check Pods Manifest.lock */,
 				AC0404E91BFB82CC00AC1501 /* Sources */,
 				AC0404EA1BFB82CC00AC1501 /* Frameworks */,
 				AC0404EB1BFB82CC00AC1501 /* Resources */,
 				AC0405781BFBB32500AC1501 /* Embed Frameworks */,
-				DCEB80901D078D3500899810 /* Copy Carthage Frameworks */,
+				15F8745A671B49A0061B3C79 /* [CP] Embed Pods Frameworks */,
+				507E844BE31547720AE5168A /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -386,20 +386,58 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		DCEB80901D078D3500899810 /* Copy Carthage Frameworks */ = {
+		15F8745A671B49A0061B3C79 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/UberRides.framework",
+				"${SRCROOT}/Pods/Target Support Files/Pods-Obj-C SDK/Pods-Obj-C SDK-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/UberCore/UberCore.framework",
+				"${BUILT_PRODUCTS_DIR}/UberRides/UberRides.framework",
 			);
-			name = "Copy Carthage Frameworks";
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/UberCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/UberRides.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Obj-C SDK/Pods-Obj-C SDK-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		507E844BE31547720AE5168A /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Obj-C SDK/Pods-Obj-C SDK-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DA2812E3F2C3469BD2EBA6F2 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Obj-C SDK-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -561,16 +599,13 @@
 		};
 		AC04051B1BFB82CC00AC1501 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 69772C0193161EB42F63FC6B /* Pods-Obj-C SDK.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = 5F83KRY2FH;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Obj-C SDK/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.sdk.Obj-C-SDK";
@@ -581,16 +616,13 @@
 		};
 		AC04051C1BFB82CC00AC1501 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 37530499F1568B296FCB29A9 /* Pods-Obj-C SDK.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = 5F83KRY2FH;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Obj-C SDK/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.sdk.Obj-C-SDK";

--- a/examples/Obj-C SDK/Obj-C SDK.xcworkspace/contents.xcworkspacedata
+++ b/examples/Obj-C SDK/Obj-C SDK.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Obj-C SDK.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/Obj-C SDK/Obj-C SDK/AppDelegate.m
+++ b/examples/Obj-C SDK/Obj-C SDK/AppDelegate.m
@@ -24,8 +24,8 @@
 
 #import "AppDelegate.h"
 
-#import <UberCore/UberCore-Swift.h>
-#import <UberRides/UberRides-Swift.h>
+@import UberCore;
+@import UberRides;
 
 @interface AppDelegate ()
 

--- a/examples/Obj-C SDK/Obj-C SDK/AppDelegate.m
+++ b/examples/Obj-C SDK/Obj-C SDK/AppDelegate.m
@@ -24,6 +24,7 @@
 
 #import "AppDelegate.h"
 
+#import <UberCore/UberCore-Swift.h>
 #import <UberRides/UberRides-Swift.h>
 
 @interface AppDelegate ()
@@ -64,12 +65,16 @@
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
 
-
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options {
     //Check & handle incoming SSO URL
-    BOOL handledUberURL = [[UBSDKRidesAppDelegate shared] application:app open:url sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey] annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
+    BOOL handledUberURL = [[UBSDKAppDelegate shared] application:app open:url sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey] annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
     
     return handledUberURL;
 }
 
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
+    BOOL handledURL = [[UBSDKAppDelegate shared] application:application open:url sourceApplication:sourceApplication annotation:annotation];
+    
+    return handledURL;
+}
 @end

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKDeeplinkExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKDeeplinkExampleViewController.m
@@ -25,6 +25,7 @@
 #import "UBSDKDeeplinkExampleViewController.h"
 #import "UBSDKLocalization.h"
 
+#import <UberCore/UberCore-Swift.h>
 #import <UberRides/UberRides-Swift.h>
 
 #import <CoreLocation/CoreLocation.h>
@@ -86,7 +87,7 @@
         UBSDKRideParameters *rideParameters = [self _buildRideParameters];
         id<UBSDKRideRequesting> deeplinkBehavior = [[UBSDKDeeplinkRequestingBehavior alloc] init];
         UBSDKRideRequestButton *rideRequestButton = [[UBSDKRideRequestButton alloc] initWithRideParameters:rideParameters requestingBehavior:deeplinkBehavior];
-        rideRequestButton.colorStyle = RequestButtonColorStyleWhite;
+        rideRequestButton.colorStyle = UberButtonColorStyleWhite;
         rideRequestButton;
     });
 }

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKDeeplinkExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKDeeplinkExampleViewController.m
@@ -25,8 +25,8 @@
 #import "UBSDKDeeplinkExampleViewController.h"
 #import "UBSDKLocalization.h"
 
-#import <UberCore/UberCore-Swift.h>
-#import <UberRides/UberRides-Swift.h>
+@import UberCore;
+@import UberRides;
 
 #import <CoreLocation/CoreLocation.h>
 

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKExampleTableViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKExampleTableViewController.m
@@ -31,8 +31,8 @@
 #import "UBSDKRideRequestWidgetExampleViewController.h"
 #import "UBSDKNativeLoginExampleViewController.h"
 
-#import <UberCore/UberCore-Swift.h>
-#import <UberRides/UberRides-Swift.h>
+@import UberCore;
+@import UberRides;
 
 @interface UBSDKExampleTableViewController ()
 

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKExampleTableViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKExampleTableViewController.m
@@ -31,6 +31,7 @@
 #import "UBSDKRideRequestWidgetExampleViewController.h"
 #import "UBSDKNativeLoginExampleViewController.h"
 
+#import <UberCore/UberCore-Swift.h>
 #import <UberRides/UberRides-Swift.h>
 
 @interface UBSDKExampleTableViewController ()

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKImplicitGrantExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKImplicitGrantExampleViewController.m
@@ -28,7 +28,7 @@
 #import "UBSDKLoginButtonView.h"
 #import "UBSDKUtility.h"
 
-#import <UberRides/UberRides-Swift.h>
+@import UberRides;
 
 typedef NS_ENUM(NSInteger, ImplicitGrantTableViewSection) {
     ImplicitGrantTableViewSectionProfile,

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKImplicitGrantExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKImplicitGrantExampleViewController.m
@@ -70,7 +70,7 @@ static NSString *const historyCellReuseIdentifier = @"HistoryCell";
     [self.view addSubview:tableView];
     _tableView = tableView;
     
-    NSArray<UBSDKUberScope *> *requestedScopes = @[ UBSDKUberScope.rideWidgets, UBSDKUberScope.profile, UBSDKUberScope.places, UBSDKUberScope.history ];
+    NSArray<UBSDKScope *> *requestedScopes = @[ UBSDKScope.rideWidgets, UBSDKScope.profile, UBSDKScope.places, UBSDKScope.history ];
     
     UBSDKLoginButtonView *loginButtonView = [[UBSDKLoginButtonView alloc] initWithFrame:self.view.frame
                                                                                        scopes:requestedScopes

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKImplicitGrantExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKImplicitGrantExampleViewController.m
@@ -70,7 +70,7 @@ static NSString *const historyCellReuseIdentifier = @"HistoryCell";
     [self.view addSubview:tableView];
     _tableView = tableView;
     
-    NSArray<UBSDKRidesScope *> *requestedScopes = @[ UBSDKRidesScope.rideWidgets, UBSDKRidesScope.profile, UBSDKRidesScope.places, UBSDKRidesScope.history ];
+    NSArray<UBSDKUberScope *> *requestedScopes = @[ UBSDKUberScope.rideWidgets, UBSDKUberScope.profile, UBSDKUberScope.places, UBSDKUberScope.history ];
     
     UBSDKLoginButtonView *loginButtonView = [[UBSDKLoginButtonView alloc] initWithFrame:self.view.frame
                                                                                        scopes:requestedScopes

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKLoginButtonView.h
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKLoginButtonView.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nonnull) UBSDKLoginButton *loginButton;
 
-- (instancetype)initWithFrame:(CGRect)frame scopes:(NSArray<UBSDKUberScope *> *)scopes loginType:(UBSDKLoginType)loginType;
+- (instancetype)initWithFrame:(CGRect)frame scopes:(NSArray<UBSDKScope *> *)scopes loginType:(UBSDKLoginType)loginType;
 
 @end
 

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKLoginButtonView.h
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKLoginButtonView.h
@@ -24,8 +24,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import <UberCore/UberCore-Swift.h>
-#import <UberRides/UberRides-Swift.h>
+@import UberCore;
+@import UberRides;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKLoginButtonView.h
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKLoginButtonView.h
@@ -24,6 +24,7 @@
 
 #import <UIKit/UIKit.h>
 
+#import <UberCore/UberCore-Swift.h>
 #import <UberRides/UberRides-Swift.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -35,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nonnull) UBSDKLoginButton *loginButton;
 
-- (instancetype)initWithFrame:(CGRect)frame scopes:(NSArray<UBSDKRidesScope *> *)scopes loginType:(UBSDKLoginType)loginType;
+- (instancetype)initWithFrame:(CGRect)frame scopes:(NSArray<UBSDKUberScope *> *)scopes loginType:(UBSDKLoginType)loginType;
 
 @end
 

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKLoginButtonView.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKLoginButtonView.m
@@ -29,7 +29,7 @@
 @interface UBSDKLoginButtonView()
 
 @property (nonatomic, nonnull) UBSDKLoginManager *loginManager;
-@property (nonatomic, readonly, nonnull) NSArray<UBSDKUberScope *> *scopes;
+@property (nonatomic, readonly, nonnull) NSArray<UBSDKScope *> *scopes;
 
 @end
 
@@ -37,7 +37,7 @@
 
 #pragma mark - UBSDKLoginButtonView
 
-- (instancetype)initWithFrame:(CGRect)frame scopes:(NSArray<UBSDKUberScope *> *)scopes loginType:(UBSDKLoginType)loginType {
+- (instancetype)initWithFrame:(CGRect)frame scopes:(NSArray<UBSDKScope *> *)scopes loginType:(UBSDKLoginType)loginType {
     self = [super initWithFrame:frame];
     if (self) {
         _scopes = scopes;

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKLoginButtonView.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKLoginButtonView.m
@@ -29,7 +29,7 @@
 @interface UBSDKLoginButtonView()
 
 @property (nonatomic, nonnull) UBSDKLoginManager *loginManager;
-@property (nonatomic, readonly, nonnull) NSArray<UBSDKRidesScope *> *scopes;
+@property (nonatomic, readonly, nonnull) NSArray<UBSDKUberScope *> *scopes;
 
 @end
 
@@ -37,7 +37,7 @@
 
 #pragma mark - UBSDKLoginButtonView
 
-- (instancetype)initWithFrame:(CGRect)frame scopes:(NSArray<UBSDKRidesScope *> *)scopes loginType:(UBSDKLoginType)loginType {
+- (instancetype)initWithFrame:(CGRect)frame scopes:(NSArray<UBSDKUberScope *> *)scopes loginType:(UBSDKLoginType)loginType {
     self = [super initWithFrame:frame];
     if (self) {
         _scopes = scopes;

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKNativeLoginExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKNativeLoginExampleViewController.m
@@ -26,6 +26,7 @@
 
 #import "UBSDKLocalization.h"
 
+#import <UberCore/UberCore-Swift.h>
 #import <UberRides/UberRides-Swift.h>
 
 @interface UBSDKNativeLoginExampleViewController() <UBSDKLoginButtonDelegate>
@@ -67,7 +68,7 @@
 - (void)_initialSetup {
     _loginManager = [[UBSDKLoginManager alloc] initWithLoginType:UBSDKLoginTypeNative];
     
-    NSArray<UBSDKRidesScope *> *scopes = @[UBSDKRidesScope.profile, UBSDKRidesScope.places, UBSDKRidesScope.request];
+    NSArray<UBSDKUberScope *> *scopes = @[UBSDKUberScope.profile, UBSDKUberScope.places, UBSDKUberScope.request];
     
     _blackLoginButton = ({
         UBSDKLoginButton *loginButton = [[UBSDKLoginButton alloc] initWithFrame:CGRectZero scopes:scopes loginManager:_loginManager];
@@ -79,7 +80,7 @@
     
     _whiteLoginButton = ({
         UBSDKLoginButton *loginButton = [[UBSDKLoginButton alloc] initWithFrame:CGRectZero scopes:scopes loginManager:_loginManager];
-        loginButton.colorStyle = RequestButtonColorStyleWhite;
+        loginButton.colorStyle = UberButtonColorStyleWhite;
         loginButton.presentingViewController = self;
         [loginButton sizeToFit];
         loginButton.delegate = self;
@@ -153,7 +154,7 @@
 #pragma mark - Actions
 
 - (void)_loginButtonAction:(UIButton *)button {
-    NSArray<UBSDKRidesScope *> *requestedScopes = @[ UBSDKRidesScope.rideWidgets, UBSDKRidesScope.profile, UBSDKRidesScope.places ];
+    NSArray<UBSDKUberScope *> *requestedScopes = @[ UBSDKUberScope.rideWidgets, UBSDKUberScope.profile, UBSDKUberScope.places ];
     
     [self.loginManager loginWithRequestedScopes:requestedScopes presentingViewController:self completion:^(UBSDKAccessToken * _Nullable accessToken, NSError * _Nullable error) {
         if (accessToken) {

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKNativeLoginExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKNativeLoginExampleViewController.m
@@ -68,7 +68,7 @@
 - (void)_initialSetup {
     _loginManager = [[UBSDKLoginManager alloc] initWithLoginType:UBSDKLoginTypeNative];
     
-    NSArray<UBSDKUberScope *> *scopes = @[UBSDKUberScope.profile, UBSDKUberScope.places, UBSDKUberScope.request];
+    NSArray<UBSDKScope *> *scopes = @[UBSDKScope.profile, UBSDKScope.places, UBSDKScope.request];
     
     _blackLoginButton = ({
         UBSDKLoginButton *loginButton = [[UBSDKLoginButton alloc] initWithFrame:CGRectZero scopes:scopes loginManager:_loginManager];
@@ -154,7 +154,7 @@
 #pragma mark - Actions
 
 - (void)_loginButtonAction:(UIButton *)button {
-    NSArray<UBSDKUberScope *> *requestedScopes = @[ UBSDKUberScope.rideWidgets, UBSDKUberScope.profile, UBSDKUberScope.places ];
+    NSArray<UBSDKScope *> *requestedScopes = @[ UBSDKScope.rideWidgets, UBSDKScope.profile, UBSDKScope.places ];
     
     [self.loginManager loginWithRequestedScopes:requestedScopes presentingViewController:self completion:^(UBSDKAccessToken * _Nullable accessToken, NSError * _Nullable error) {
         if (accessToken) {

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKNativeLoginExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKNativeLoginExampleViewController.m
@@ -26,8 +26,8 @@
 
 #import "UBSDKLocalization.h"
 
-#import <UberCore/UberCore-Swift.h>
-#import <UberRides/UberRides-Swift.h>
+@import UberCore;
+@import UberRides;
 
 @interface UBSDKNativeLoginExampleViewController() <UBSDKLoginButtonDelegate>
 

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKRideRequestWidgetExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKRideRequestWidgetExampleViewController.m
@@ -25,6 +25,7 @@
 #import "UBSDKRideRequestWidgetExampleViewController.h"
 #import "UBSDKLocalization.h"
 
+#import <UberCore/UberCore-Swift.h>
 #import <UberRides/UberRides-Swift.h>
 
 #import <CoreLocation/CoreLocation.h>
@@ -66,7 +67,6 @@
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    [self.locationManager requestWhenInUseAuthorization];
 }
 
 #pragma mark - Private
@@ -75,7 +75,7 @@
     _blackRideRequestButton = [self _buildRideRequestWidgetButtonWithLoginType:UBSDKLoginTypeNative];
     
     _whiteRideRequestButton = [self _buildRideRequestWidgetButtonWithLoginType:UBSDKLoginTypeImplicit];
-    [_whiteRideRequestButton setColorStyle:RequestButtonColorStyleWhite];
+    [_whiteRideRequestButton setColorStyle:UberButtonColorStyleWhite];
     
     _locationManager = [[CLLocationManager alloc] init];
 }

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKRideRequestWidgetExampleViewController.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKRideRequestWidgetExampleViewController.m
@@ -25,8 +25,8 @@
 #import "UBSDKRideRequestWidgetExampleViewController.h"
 #import "UBSDKLocalization.h"
 
-#import <UberCore/UberCore-Swift.h>
-#import <UberRides/UberRides-Swift.h>
+@import UberCore;
+@import UberRides;
 
 #import <CoreLocation/CoreLocation.h>
 

--- a/examples/Obj-C SDK/Obj-C SDK/UBSDKUtility.m
+++ b/examples/Obj-C SDK/Obj-C SDK/UBSDKUtility.m
@@ -24,7 +24,7 @@
 
 #import "UBSDKUtility.h"
 
-#import <UberRides/UberRides-Swift.h>
+@import UberRides;
 
 #import <UIKit/UIKit.h>
 

--- a/examples/Obj-C SDK/Podfile
+++ b/examples/Obj-C SDK/Podfile
@@ -1,0 +1,13 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'Obj-C SDK' do
+  # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for Obj-C SDK
+
+  pod 'UberRides', :path => '../../'
+  pod 'UberCore', :path => '../../'
+
+end

--- a/examples/Obj-C SDK/Podfile.lock
+++ b/examples/Obj-C SDK/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - UberCore (0.7.0)
+  - UberRides (0.7.0):
+    - UberCore
+
+DEPENDENCIES:
+  - UberCore (from `../../`)
+  - UberRides (from `../../`)
+
+EXTERNAL SOURCES:
+  UberCore:
+    :path: ../../
+  UberRides:
+    :path: ../../
+
+SPEC CHECKSUMS:
+  UberCore: a7bcaed389686209ce562a1132021c580da27baa
+  UberRides: 61e0aff1c996cff16b6371e5d17adc1d50dc3d16
+
+PODFILE CHECKSUM: 245f1d465fbbc4baa291260b541d36e5a0949a0a
+
+COCOAPODS: 1.3.1

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,37 +1,16 @@
 # Example Apps
 
-Example apps can be found in the `examples` folder. To build them, you can use Carthage or Cocoapods. 
+Requires Xcode 9
 
-## Carthage
-From inside the `examples/Swift SDK` or `examples/Obj-C SDK` folder, run:
+There are two sample apps, one written in Objective-C, and another written in Swift.
 
-```
-carthage update --platform iOS
-```
-This will build the required dependencies. Once you do that, open `Swift SDK.xcodeproj` or `Obj-C SDK.xcodeproj` in Xcode and run it.
-
-## CocoaPods
-First, you will have to remove Carthage dependencies. Navigate to the project folder and remove `Cartfile` and `Cartfile.resolved`. If you see a `Carthage` folder, remove that as well. Open .xcworkspace and navigate to  **General** tab, scroll to **Embedded Binaries** select `ObjectMapper.framework` and click the `-` button, do the same for `UberRides.framework`. Now go to  **Build Settings** tab and scroll to **Search Paths**, click on **Framework Search Paths** and remove the line $(PROJECT_DIR)/Carthage/Build/iOS.
-Now go to **Build Phases** find the **Copy Carthage Frameworks** and remove it.
-
-Now, still inside either `examples/Swift SDK` or `examples/Obj-C SDK`, create a new **Podfile** by running `pod init`, then add `pod 'UberRides'` to your main target. If you are using the Swift SDK, make sure to add the line `use_frameworks!`. Your **Podfile** should contain the following information:
-
-
-```ruby
-target 'Obj-C SDK' do
-  use_frameworks!
-  pod 'UberRides'
-end
-```
-
-Then, run the following command to install the dependency:
+The sample apps use [Cocoapods](https://cocoapods.org) for package management. To set up and open the sample apps, navigate to either the `Obj-C SDK` or `Swift SDK` folder and run the following command:
 
 ```bash
 $ pod install
 ```
 
-Now you can build the project.
+After Cocoapods installs the Uber dependencies, open `xcworkspace`, and run!
 
-<p align="center">
-  <img src="https://github.com/uber/rides-ios-sdk/blob/master/img/example_app.png?raw=true" alt="Example App Screenshot"/>
-</p>
+For the Objective-C project, you may run into a compilation error. If so, click on your Pods project and select the `UberRides` target. Search for the `Swift Language Version` property, and change it to "Swift 4.0". Do the same thing for `UberCore`. [See Cocoapods issue](https://github.com/CocoaPods/CocoaPods/issues/6791).
+

--- a/examples/Swift SDK/Cartfile
+++ b/examples/Swift SDK/Cartfile
@@ -1,1 +1,0 @@
-github "uber/rides-ios-sdk" ~> 0.7

--- a/examples/Swift SDK/Podfile
+++ b/examples/Swift SDK/Podfile
@@ -1,0 +1,13 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'Swift SDK' do
+  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for Swift SDK
+
+  pod 'UberRides', :path => '../../'
+  pod 'UberCore', :path => '../../'
+
+end

--- a/examples/Swift SDK/Podfile.lock
+++ b/examples/Swift SDK/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - UberCore (0.7.0)
+  - UberRides (0.7.0):
+    - UberCore
+
+DEPENDENCIES:
+  - UberCore (from `../../`)
+  - UberRides (from `../../`)
+
+EXTERNAL SOURCES:
+  UberCore:
+    :path: ../../
+  UberRides:
+    :path: ../../
+
+SPEC CHECKSUMS:
+  UberCore: a7bcaed389686209ce562a1132021c580da27baa
+  UberRides: 61e0aff1c996cff16b6371e5d17adc1d50dc3d16
+
+PODFILE CHECKSUM: 1d713d30b94c4238ccc4571330ddf2a95fe4daf5
+
+COCOAPODS: 1.3.1

--- a/examples/Swift SDK/Swift SDK.xcodeproj/project.pbxproj
+++ b/examples/Swift SDK/Swift SDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8D94BEF86EA555A4586CE452 /* Pods_Swift_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96A429C0BEA8F99C8FA10B67 /* Pods_Swift_SDK.framework */; };
 		AC0404A81BFAD0C800AC1501 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0404A71BFAD0C800AC1501 /* AppDelegate.swift */; };
 		AC0404AA1BFAD0C800AC1501 /* DeeplinkExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0404A91BFAD0C800AC1501 /* DeeplinkExampleViewController.swift */; };
 		AC0404AD1BFAD0C800AC1501 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AC0404AB1BFAD0C800AC1501 /* Main.storyboard */; };
@@ -21,8 +22,6 @@
 		DC78EC7C1CB35AAB00850814 /* ImplicitGrantExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC78EC7B1CB35AAB00850814 /* ImplicitGrantExampleViewController.swift */; };
 		DCD806161CFE7F4300EF6EB1 /* ButtonExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD806151CFE7F4300EF6EB1 /* ButtonExampleViewController.swift */; };
 		DCD806181CFE983B00EF6EB1 /* NativeLoginExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD806171CFE983B00EF6EB1 /* NativeLoginExampleViewController.swift */; };
-		DCEB808A1D078BCA00899810 /* UberRides.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCEB80891D078BCA00899810 /* UberRides.framework */; };
-		DCEB808B1D078BCA00899810 /* UberRides.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DCEB80891D078BCA00899810 /* UberRides.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,7 +48,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				DCEB808B1D078BCA00899810 /* UberRides.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -58,6 +56,7 @@
 
 /* Begin PBXFileReference section */
 		936D353832B2D6A2F78B5456 /* Pods-Swift SDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Swift SDK.release.xcconfig"; path = "Pods/Target Support Files/Pods-Swift SDK/Pods-Swift SDK.release.xcconfig"; sourceTree = "<group>"; };
+		96A429C0BEA8F99C8FA10B67 /* Pods_Swift_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Swift_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC0404A41BFAD0C800AC1501 /* Swift SDK.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Swift SDK.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC0404A71BFAD0C800AC1501 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AC0404A91BFAD0C800AC1501 /* DeeplinkExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkExampleViewController.swift; sourceTree = "<group>"; };
@@ -85,7 +84,6 @@
 		DC8FC36C1CBDF5D200D58839 /* hi-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hi-IN"; path = "hi-IN.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		DCD806151CFE7F4300EF6EB1 /* ButtonExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonExampleViewController.swift; sourceTree = "<group>"; };
 		DCD806171CFE983B00EF6EB1 /* NativeLoginExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeLoginExampleViewController.swift; sourceTree = "<group>"; };
-		DCEB80891D078BCA00899810 /* UberRides.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UberRides.framework; path = Carthage/Build/iOS/UberRides.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,7 +91,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DCEB808A1D078BCA00899810 /* UberRides.framework in Frameworks */,
+				8D94BEF86EA555A4586CE452 /* Pods_Swift_SDK.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -126,7 +124,7 @@
 		823B0AE4697BBA3B456C5C93 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				DCEB80891D078BCA00899810 /* UberRides.framework */,
+				96A429C0BEA8F99C8FA10B67 /* Pods_Swift_SDK.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -198,11 +196,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = AC0404CC1BFAD0C800AC1501 /* Build configuration list for PBXNativeTarget "Swift SDK" */;
 			buildPhases = (
+				B93972D24501F42E9C68E979 /* [CP] Check Pods Manifest.lock */,
 				AC0404A01BFAD0C800AC1501 /* Sources */,
 				AC0404A11BFAD0C800AC1501 /* Frameworks */,
 				AC0404A21BFAD0C800AC1501 /* Resources */,
-				DCEB807E1D078ACC00899810 /* Copy Carthage Frameworks */,
 				DCEB80851D078BB500899810 /* Embed Frameworks */,
+				E6835DE2B81B6684590AD161 /* [CP] Embed Pods Frameworks */,
+				8B1F36539338433F86C28295 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -326,20 +326,58 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		DCEB807E1D078ACC00899810 /* Copy Carthage Frameworks */ = {
+		8B1F36539338433F86C28295 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/UberRides.framework",
 			);
-			name = "Copy Carthage Frameworks";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Swift SDK/Pods-Swift SDK-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B93972D24501F42E9C68E979 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Swift SDK-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E6835DE2B81B6684590AD161 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-Swift SDK/Pods-Swift SDK-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/UberCore/UberCore.framework",
+				"${BUILT_PRODUCTS_DIR}/UberRides/UberRides.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/UberCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/UberRides.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Swift SDK/Pods-Swift SDK-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -507,14 +545,12 @@
 		};
 		AC0404CD1BFAD0C800AC1501 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C5ADDC8A8EE48350FDC38319 /* Pods-Swift SDK.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_TEAM = 5F83KRY2FH;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "Swift SDK/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -527,14 +563,12 @@
 		};
 		AC0404CE1BFAD0C800AC1501 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 936D353832B2D6A2F78B5456 /* Pods-Swift SDK.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_TEAM = 5F83KRY2FH;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "Swift SDK/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/examples/Swift SDK/Swift SDK.xcworkspace/contents.xcworkspacedata
+++ b/examples/Swift SDK/Swift SDK.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Swift SDK.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/Swift SDK/Swift SDK/AppDelegate.swift
+++ b/examples/Swift SDK/Swift SDK/AppDelegate.swift
@@ -23,6 +23,7 @@
 //  THE SOFTWARE.
 
 import UIKit
+import UberCore
 import UberRides
 
 @UIApplicationMain
@@ -40,7 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Configuration.shared.isSandbox = true
         
         // Handle incoming SSO Requests
-        _ = RidesAppDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
+        _ = UberAppDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
         return true
     }
 
@@ -68,13 +69,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     @available(iOS 9, *)
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool {
-        let handledUberURL = RidesAppDelegate.shared.application(app, open: url, sourceApplication: options[UIApplicationOpenURLOptionsKey.sourceApplication] as? String, annotation: options[UIApplicationOpenURLOptionsKey.annotation] as Any)
+        let handledUberURL = UberAppDelegate.shared.application(app, open: url, sourceApplication: options[UIApplicationOpenURLOptionsKey.sourceApplication] as? String, annotation: options[UIApplicationOpenURLOptionsKey.annotation] as Any)
         
         return handledUberURL
     }
     
     func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
-        let handledUberURL = RidesAppDelegate.shared.application(application, open: url, sourceApplication: sourceApplication, annotation: annotation)
+        let handledUberURL = UberAppDelegate.shared.application(application, open: url, sourceApplication: sourceApplication, annotation: annotation)
         
         return handledUberURL
     }

--- a/examples/Swift SDK/Swift SDK/AuthorizationBaseViewController.swift
+++ b/examples/Swift SDK/Swift SDK/AuthorizationBaseViewController.swift
@@ -22,6 +22,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+import UberCore
 import UberRides
 
 class AuthorizationBaseViewController: UIViewController {

--- a/examples/Swift SDK/Swift SDK/AuthorizationCodeGrantExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/AuthorizationCodeGrantExampleViewController.swift
@@ -22,6 +22,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+import UberCore
 import UberRides
 import CoreLocation
 
@@ -72,13 +73,10 @@ class AuthorizationCodeGrantExampleViewController: AuthorizationBaseViewControll
     }
     
     @IBAction func login(_ sender: AnyObject) {
-        // Can define a state variable to prevent tampering
-        loginManager.state = UUID().uuidString
-        
         // Define which scopes we're requesting
         // Need to be authorized on your developer dashboard at developer.uber.com
         // Privileged scopes can be used by anyone in sandbox for your own account but must be approved for production
-        let requestedScopes = [RidesScope.request, RidesScope.allTrips]
+        let requestedScopes = [UberScope.request, UberScope.allTrips]
         // Use your loginManager to login with the requested scopes, viewcontroller to present over, and completion block
         loginManager.login(requestedScopes: requestedScopes, presentingViewController: self) { (accessToken, error) -> () in
             // Error

--- a/examples/Swift SDK/Swift SDK/ExampleTableViewController.swift
+++ b/examples/Swift SDK/Swift SDK/ExampleTableViewController.swift
@@ -23,6 +23,7 @@
 //  THE SOFTWARE.
 
 import UIKit
+import UberCore
 import UberRides
 
 class ExampleTableViewController: UITableViewController {

--- a/examples/Swift SDK/Swift SDK/ImplicitGrantExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/ImplicitGrantExampleViewController.swift
@@ -24,6 +24,7 @@
 
 import UIKit
 import UberRides
+import UberCore
 import CoreLocation
 
 /// This class demonstrates how do use the LoginManager to complete Implicit Grant Authorization
@@ -84,7 +85,7 @@ class ImplicitGrantExampleViewController: AuthorizationBaseViewController {
     @IBAction func login(_ sender: AnyObject) {
         // Define which scopes we're requesting
         // Need to be authorized on your developer dashboard at developer.uber.com
-        let requestedScopes = [RidesScope.rideWidgets, RidesScope.profile, RidesScope.places, RidesScope.history, RidesScope.places]
+        let requestedScopes = [UberScope.rideWidgets, UberScope.profile, UberScope.places, UberScope.history, UberScope.places]
         // Use your loginManager to login with the requested scopes, viewcontroller to present over, and completion block
         loginManager.login(requestedScopes: requestedScopes, presentingViewController: self) { (accessToken, error) -> () in
             if accessToken != nil {

--- a/examples/Swift SDK/Swift SDK/NativeLoginExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/NativeLoginExampleViewController.swift
@@ -23,13 +23,14 @@
 //  THE SOFTWARE.
 
 import UIKit
+import UberCore
 import UberRides
 import CoreLocation
 
 /// This class provides an example for using the LoginButton to do Native Login (SSO with the Uber App)
 open class NativeLoginExampleViewController: ButtonExampleViewController, LoginButtonDelegate {
     
-    let scopes: [RidesScope]
+    let scopes: [UberScope]
     let loginManager: LoginManager
     let blackLoginButton: LoginButton
     let whiteLoginButton: LoginButton

--- a/examples/Swift SDK/Swift SDK/RideRequestWidgetExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/RideRequestWidgetExampleViewController.swift
@@ -23,6 +23,7 @@
 //  THE SOFTWARE.
 
 import UIKit
+import UberCore
 import UberRides
 import CoreLocation
 
@@ -54,10 +55,6 @@ class RideRequestWidgetExampleViewController: ButtonExampleViewController {
         addWhiteRequestButtonConstraints()
         
         locationManger.delegate = self
-        
-        if !checkLocationServices() {
-            locationManger.requestWhenInUseAuthorization()
-        }
     }
     
     // Mark: Private Interface
@@ -69,15 +66,6 @@ class RideRequestWidgetExampleViewController: ButtonExampleViewController {
         
         let rideParameters = RideParametersBuilder().build()
 
-        let accessTokenString = "access_token_string"
-        let token = AccessToken(tokenString: accessTokenString)
-        if TokenManager.save(accessToken: token){
-            // Success
-        } else {
-            // Unable to save
-        }
-
-        TokenManager.fetchToken()
         TokenManager.deleteToken()
         
         return RideRequestButton(rideParameters: rideParameters, requestingBehavior: requestBehavior)
@@ -99,14 +87,6 @@ class RideRequestWidgetExampleViewController: ButtonExampleViewController {
         let centerXConstraint = NSLayoutConstraint(item: whiteRideRequestButton, attribute: .centerX, relatedBy: .equal, toItem: bottomView, attribute: .centerX, multiplier: 1.0, constant: 0.0)
         
         bottomView.addConstraints([centerYConstraint, centerXConstraint])
-    }
-    
-    fileprivate func checkLocationServices() -> Bool {
-        let locationEnabled = CLLocationManager.locationServicesEnabled()
-        let locationAuthorization = CLLocationManager.authorizationStatus()
-        let locationAuthorized = locationAuthorization == .authorizedWhenInUse || locationAuthorization == .authorizedAlways
-        
-        return locationEnabled && locationAuthorized
     }
     
     fileprivate func showMessage(_ message: String) {

--- a/source/UberCore/Authentication/Tokens/TokenManager.swift
+++ b/source/UberCore/Authentication/Tokens/TokenManager.swift
@@ -88,7 +88,7 @@ import Foundation
 
      - returns: true if the accessToken was saved successfully, false otherwise
      */
-    @objc public static func save(accessToken: AccessToken, tokenIdentifier: String, accessGroup: String) -> Bool {
+    @discardableResult @objc public static func save(accessToken: AccessToken, tokenIdentifier: String, accessGroup: String) -> Bool {
         keychainWrapper.setAccessGroup(accessGroup)
         let success = keychainWrapper.setObject(accessToken, key: tokenIdentifier)
         if success {
@@ -108,7 +108,7 @@ import Foundation
      
      - returns: true if the accessToken was saved successfully, false otherwise
      */
-    @objc public static func save(accessToken: AccessToken, tokenIdentifier: String) -> Bool {
+    @discardableResult @objc public static func save(accessToken: AccessToken, tokenIdentifier: String) -> Bool {
         return self.save(accessToken: accessToken, tokenIdentifier: tokenIdentifier, accessGroup: Configuration.shared.defaultKeychainAccessGroup)
     }
     
@@ -123,7 +123,7 @@ import Foundation
      
      - returns: true if the accessToken was saved successfully, false otherwise
      */
-    @objc public static func save(accessToken: AccessToken) -> Bool {
+    @discardableResult @objc public static func save(accessToken: AccessToken) -> Bool {
         return self.save(accessToken: accessToken,  tokenIdentifier: Configuration.shared.defaultAccessTokenIdentifier, accessGroup: Configuration.shared.defaultKeychainAccessGroup)
     }
     
@@ -138,7 +138,7 @@ import Foundation
 
      - returns: true if the token was deleted, false otherwise
      */
-    @objc public static func deleteToken(identifier: String, accessGroup: String) -> Bool {
+    @discardableResult @objc public static func deleteToken(identifier: String, accessGroup: String) -> Bool {
         keychainWrapper.setAccessGroup(accessGroup)
         deleteCookies()
         let success = keychainWrapper.deleteObjectForKey(identifier)
@@ -156,7 +156,7 @@ import Foundation
      
      - returns: true if the token was deleted, false otherwise
      */
-    @objc public static func deleteToken(identifier: String) -> Bool {
+    @discardableResult @objc public static func deleteToken(identifier: String) -> Bool {
         return self.deleteToken(identifier: identifier, accessGroup: Configuration.shared.defaultKeychainAccessGroup)
     }
     
@@ -167,7 +167,7 @@ import Foundation
      
      - returns: true if the token was deleted, false otherwise
      */
-    @objc public static func deleteToken() -> Bool {
+    @discardableResult @objc public static func deleteToken() -> Bool {
         return self.deleteToken(identifier: Configuration.shared.defaultAccessTokenIdentifier, accessGroup: Configuration.shared.defaultKeychainAccessGroup)
     }
     

--- a/source/UberCore/Authentication/UberScope.swift
+++ b/source/UberCore/Authentication/UberScope.swift
@@ -97,7 +97,7 @@ import UIKit
 /**
  *  Object representing an access scope to the Uber API
  */
-@objc(UBSDKUberScope) public class UberScope : NSObject {
+@objc(UBSDKScope) public class UberScope : NSObject {
     /// The UberScopeType of this UberScope
     @objc public let uberScopeType: UberScopeType
     /// The ScopeType of this UberScope (General / Privileged)

--- a/source/UberCore/Configuration.swift
+++ b/source/UberCore/Configuration.swift
@@ -283,7 +283,9 @@ private let callbackURIStringKey = "URIString"
     }
 
     public func resetProcessPool() {
-        processPool = WKProcessPool()
+        DispatchQueue.main.async {
+            self.processPool = WKProcessPool()
+        }
     }
     
     // MARK: Private

--- a/source/UberCore/Deeplinks/DeeplinkManager.swift
+++ b/source/UberCore/Deeplinks/DeeplinkManager.swift
@@ -31,7 +31,6 @@ class DeeplinkManager {
     private var waitingOnSystemPromptResponse = false
     private var checkingSystemPromptResponse = false
     private var promptTimer: Timer?
-    private var completionWrapper: ((NSError?) -> ()) = { _ in }
 
     func open(_ deeplink: Deeplinking, completion: DeeplinkCompletionHandler? = nil) {
         open(deeplink.url, completion: completion)
@@ -91,7 +90,7 @@ class DeeplinkManager {
             error = DeeplinkErrorFactory.errorForType(.unableToOpen)
         }
 
-        completionWrapper(error)
+        callbackWrapper?(error)
     }
 
     //Mark: App Lifecycle Notifications
@@ -100,7 +99,7 @@ class DeeplinkManager {
         if !waitingOnSystemPromptResponse {
             waitingOnSystemPromptResponse = true
         } else if checkingSystemPromptResponse {
-            completionWrapper(nil)
+            callbackWrapper?(nil)
         }
     }
 
@@ -112,11 +111,11 @@ class DeeplinkManager {
     }
 
     @objc private func appDidEnterBackgroundHandler(_ notification: Notification) {
-        completionWrapper(nil)
+        callbackWrapper?(nil)
     }
 
     @objc private func deeplinkHelper() {
         let error = DeeplinkErrorFactory.errorForType(.deeplinkNotFollowed)
-        completionWrapper(error)
+        callbackWrapper?(error)
     }
 }

--- a/source/UberRides/RideRequestView.swift
+++ b/source/UberRides/RideRequestView.swift
@@ -146,6 +146,7 @@ import UberCore
      Requires that the access token has been retrieved.
      */
     @objc public func load() {
+        guard !webView.isLoading else { return }
         guard let accessToken = accessToken else {
             self.delegate?.rideRequestView(self, didReceiveError: RideRequestViewErrorFactory.errorForType(.accessTokenMissing))
             return

--- a/source/UberRides/RideRequestViewController.swift
+++ b/source/UberRides/RideRequestViewController.swift
@@ -104,8 +104,8 @@ import UberCore
         setupRideRequestView()
     }
 
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         load()
     }
     


### PR DESCRIPTION
These changes update, fix bugs in, and improve the sample apps. 

* Migrated example pods to Cocoapods for easier testing and debugging. (Ignore all .xcworkspace/xcodeproj files)
* Migrate renames.
* Fix / improve sample apps / SDK code:
  * Obj-C sample was missing deeplink handler for iOS 8
  * Add `@discardableResult` annotation to token manager methods, removing warnings for unused result values. 
  * Fix crash from performing WebKit operation off main thread
  * Fix Ride Request Widget load errors. 