### PR TITLE
Fix manual access token creation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ When migrating to 0.8, you may need to add `import UberCore` to files previously
 * `LoginManager` now uses `SFAuthenticationSession`, `SFSafariViewController`, or external Safari for web-based OAuth flows.
 * `Deeplinking` protocol simplified. Public properties from the previous protocol is now available under the `.url` property. 
 * `UberAuthenticating` protocol simplified. 
+* `AccessToken` adds two new initializers intended to make custom OAuth flows easier. Fixes [Issue #187](https://github.com/uber/rides-ios-sdk/issues/187)
 
 ### Moved to UberCore
 

--- a/source/UberCoreTests/RefreshEndpointTests.swift
+++ b/source/UberCoreTests/RefreshEndpointTests.swift
@@ -88,8 +88,6 @@ class RefreshEndpointTests: XCTestCase {
 
         XCTAssertTrue(queryItems.contains(expectedClientID))
         XCTAssertTrue(queryItems.contains(expectedRefreshToken))
-
-
         
         waitForExpectations(timeout: timeout, handler: { error in
             if let error = error {

--- a/source/UberRides/RidesClient.swift
+++ b/source/UberRides/RidesClient.swift
@@ -540,7 +540,7 @@ import UberCore
             var accessToken: AccessToken?
             if let data = response.data,
                 response.error == nil {
-                accessToken = try? JSONDecoder.uberDecoder.decode(AccessToken.self, from: data)
+                accessToken = try? AccessTokenFactory.createAccessToken(fromJSONData: data)
             }
             completion(accessToken, response)
         }


### PR DESCRIPTION
Fixes #187 

PR will be changed to be based against `develop` once we merge #206 / #210 

* Adds two new initializers for AccessToken: `init(tokenString:refreshToken:expirationDate:grantedScopes:)` and `init?(oauthDictionary:)`
* Makes `AccessTokenFactory` public
* Adds additional test coverage to assert more parameters from JSON deserialization, and test new getters.
* Adds comments to document `AccessToken`'s `NSCoding` behavior
* Removes the `Codable` protocol from `AccessToken` since it won't be used for JSON serialization / deserialization