### PR TITLE
Fixed zero size login button

### DIFF
--- a/source/UberCore/Authentication/LoginButton.swift
+++ b/source/UberCore/Authentication/LoginButton.swift
@@ -126,6 +126,7 @@ import UIKit
             self.delegate?.loginButton(self, didCompleteLoginWithToken: token, error: error)
             self.refreshContent()
         }
+        sizeToFit()
     }
     
     /**


### PR DESCRIPTION
By default, adding a LoginButton without sizing constraints to your view would make a 0x0 login button. 

I noticed this while testing the README last week, but also publicly reported [here](https://stackoverflow.com/questions/47502509/uber-login-not-working-correctly#comment81960895_47502509).

This is because we were missing a `sizeToFit()` call. See the `RideRequestButton`, for instance.

https://github.com/uber/rides-ios-sdk/blob/master/source/UberRides/RideRequestButton.swift#L168

This will also be rebased against `develop`