### PR TITLE
Add fallback to m.uber for Ride Request Deeplinks

### DIFF
--- a/source/UberCore/Deeplinks/BaseDeeplink.swift
+++ b/source/UberCore/Deeplinks/BaseDeeplink.swift
@@ -30,6 +30,23 @@ import Foundation
 @objc(UBSDKBaseDeeplink) open class BaseDeeplink: NSObject, Deeplinking {
     @objc public var url: URL
 
+    @objc open var fallbackURLs: [URL] {
+        var urls: [URL] = []
+        if url.scheme == "uber",
+            var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+            urlComponents.scheme = "uber-enterprise"
+            if let betaURL = urlComponents.url {
+                urls.append(betaURL)
+            }
+
+            urlComponents.scheme = "uber-nightly"
+            if let nightlyURL = urlComponents.url {
+                urls.append(nightlyURL)
+            }
+        }
+        return urls
+    }
+
     @objc public init?(scheme: String, host: String, path: String, queryItems: [URLQueryItem]?) {
         var components = URLComponents()
         components.scheme = scheme
@@ -54,4 +71,14 @@ import Foundation
     @objc public func execute(completion: DeeplinkCompletionHandler? = nil) {
         DeeplinkManager.shared.open(self, completion: completion)
     }
+}
+
+/// Fallback types for Deeplinks
+@objc(UBSDKDeeplinkFallbackType) public enum DeeplinkFallbackType: Int {
+    /// Mobile web fallback (m.uber.com)
+    case mobileWeb
+    /// App Store download fallback
+    case appStore
+    /// No fallback
+    case none
 }

--- a/source/UberCore/Deeplinks/DeeplinkErrorType.swift
+++ b/source/UberCore/Deeplinks/DeeplinkErrorType.swift
@@ -27,7 +27,7 @@
  
  - DeeplinkNotFollowed: The user declined a prompt to follow the deeplink (iOS 9+ only)
  - UnableToFollow:      The deeplink attempted to open the url, but failed
- - UnableToOpen:        The application either is unable to open the URL or was unable to query for the provided deeplink scheme (iOS 9+ only). The latter requires you to add it to your application's plist file under LSQpplicationQueriesSchemes
+ - UnableToOpen:        The application is unable to open the URL.
  */
 @objc(UBSDKDeeplinkErrorType) public enum DeeplinkErrorType: Int {
     case deeplinkNotFollowed

--- a/source/UberCore/Deeplinks/DeeplinkManager.swift
+++ b/source/UberCore/Deeplinks/DeeplinkManager.swift
@@ -53,7 +53,6 @@ class DeeplinkManager {
     //Mark: Internal Interface
 
     private func open(_ url: URL) {
-        print("opening \(url)")
         if #available(iOS 9.0, *) {
             executeOnIOS9(deeplink: url)
         } else {
@@ -118,7 +117,7 @@ class DeeplinkManager {
         deeplinkDidFinish(error: error)
     }
 
-    //Mark: App Lifecycle Notifications
+    // Mark: App Lifecycle Notifications
 
     @objc private func appWillResignActiveHandler(_ notification: Notification) {
         if !waitingOnSystemPromptResponse {

--- a/source/UberCore/Deeplinks/DeeplinkingProtocol.swift
+++ b/source/UberCore/Deeplinks/DeeplinkingProtocol.swift
@@ -30,13 +30,10 @@ public typealias DeeplinkCompletionHandler = (NSError?) -> Void
 @objc(UBSDKDeeplinking) public protocol Deeplinking {
     /// The deeplink URL that the deeplink will execute
     var url: URL { get }
-    
-    /**
-     Execute a deeplink to launch into an external app
-     
-     - returns: true if the deeplink was executed, false otherwise.
-     */
-    
+
+    /// Fallback URLs for the deeplink (eg, a website, alternate app, etc)
+    var fallbackURLs: [URL] { get }
+
     /**
      Execute a deeplink to launch into an external app
      

--- a/source/UberCoreTests/BaseDeeplinkTests.swift
+++ b/source/UberCoreTests/BaseDeeplinkTests.swift
@@ -60,6 +60,24 @@ class BaseDeeplinkTests: XCTestCase {
 
         XCTAssertEqual(baseDeeplink.url, expectedURL)
     }
+
+    func testUberSchemeResultsInFallbacks() {
+        guard let deeplink = BaseDeeplink(scheme: "uber", host: "", path: "", queryItems: nil) else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(deeplink.fallbackURLs.count, 2)
+        XCTAssertEqual(deeplink.fallbackURLs[0].scheme, "uber-enterprise")
+        XCTAssertEqual(deeplink.fallbackURLs[1].scheme, "uber-nightly")
+    }
+
+    func testNonUberSchemeResultsInNoFallbacks() {
+        guard let deeplink = BaseDeeplink(scheme: "uberauth", host: "", path: "", queryItems: nil) else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(deeplink.fallbackURLs.count, 0)
+    }
 }
 
 

--- a/source/UberCoreTests/DeeplinkManagerTests.swift
+++ b/source/UberCoreTests/DeeplinkManagerTests.swift
@@ -1,0 +1,146 @@
+//
+//  DeeplinkManagerTests.swift
+//  UberCoreTests
+//
+//  Created by Edward Jiang on 12/5/17.
+//  Copyright © 2017 Uber. All rights reserved.
+//
+
+import XCTest
+@testable import UberCore
+
+class DeeplinkManagerTests: XCTestCase {
+    private var deeplinkManager: DeeplinkManager!
+    private var urlOpener: URLOpeningMock!
+    private var testDeeplink: TestDeeplink!
+
+    override func setUp() {
+        super.setUp()
+
+        deeplinkManager = DeeplinkManager()
+        urlOpener = URLOpeningMock()
+        deeplinkManager.urlOpener = urlOpener
+        testDeeplink = TestDeeplink()
+    }
+
+    func testDeeplinkOpensFirstURL() {
+        let expectCallback = self.expectation(description: "Callback is run")
+        urlOpener.openURLHandler = { url in
+            return true // All URLS can open
+        }
+        openDeeplink(testDeeplink) { error in
+            XCTAssertNil(error)
+            expectCallback.fulfill()
+        }
+        XCTAssertEqual(urlOpener.openURLCallCount, 1)
+
+        self.waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func testDeeplinkOpensSecondURL() {
+        let expectCorrectURLScheme = self.expectation(description: "We need to open up the app2 URL scheme")
+        let expectCallback = self.expectation(description: "Callback is run")
+        urlOpener.openURLHandler = { url in
+            if url.scheme == "app2" {
+                expectCorrectURLScheme.fulfill()
+            }
+            return url.scheme == "app2"
+        }
+        openDeeplink(testDeeplink) { error in
+            XCTAssertNil(error)
+            expectCallback.fulfill()
+        }
+        XCTAssertEqual(urlOpener.openURLCallCount, 2)
+
+        self.waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func testDeeplinkErrorsWhenNoFallbacks() {
+        let expectCallback = self.expectation(description: "Callback is run")
+        urlOpener.openURLHandler = { url in
+            return false
+        }
+        openDeeplink(testDeeplink) { error in
+            let expectedError = DeeplinkErrorFactory.errorForType(DeeplinkErrorType.unableToOpen)
+            XCTAssertNotNil(error)
+            XCTAssertEqual(error, expectedError)
+            expectCallback.fulfill()
+        }
+        XCTAssertEqual(urlOpener.openURLCallCount, 4)
+
+        self.waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func testDeeplinkOpensURLWhenIOSPromptsPermission() {
+        let expectCallback = self.expectation(description: "Callback is run")
+        urlOpener.openURLHandler = { url in
+            return true // All URLS can open
+        }
+        openDeeplinkWithSuccessfulPrompt(testDeeplink) { error in
+            XCTAssertNil(error)
+            expectCallback.fulfill()
+        }
+        XCTAssertEqual(urlOpener.openURLCallCount, 1)
+
+        self.waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func testDeeplinkErrorsWhenUserDeniesPermission() {
+        let expectCallback = self.expectation(description: "Callback is run")
+        urlOpener.openURLHandler = { url in
+            return true // All URLS can open
+        }
+        openDeeplinkWithCancelledPrompt(testDeeplink) { error in
+            let expectedError = DeeplinkErrorFactory.errorForType(.deeplinkNotFollowed)
+            XCTAssertEqual(error, expectedError)
+            expectCallback.fulfill()
+        }
+        XCTAssertEqual(urlOpener.openURLCallCount, 1)
+
+        self.waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    private func openDeeplink(_ deeplink: Deeplinking, completion: @escaping DeeplinkCompletionHandler) {
+        deeplinkManager.open(deeplink, completion: completion)
+        NotificationCenter.default.post(Notification(name: Notification.Name.UIApplicationDidEnterBackground))
+    }
+
+    private func openDeeplinkWithSuccessfulPrompt(_ deeplink: Deeplinking, completion: @escaping DeeplinkCompletionHandler) {
+        deeplinkManager.open(deeplink, completion: completion)
+        NotificationCenter.default.post(Notification(name: Notification.Name.UIApplicationWillResignActive))
+        NotificationCenter.default.post(Notification(name: Notification.Name.UIApplicationDidBecomeActive))
+        NotificationCenter.default.post(Notification(name: Notification.Name.UIApplicationDidEnterBackground))
+    }
+
+    private func openDeeplinkWithCancelledPrompt(_ deeplink: Deeplinking, completion: @escaping DeeplinkCompletionHandler) {
+        deeplinkManager.open(deeplink, completion: completion)
+        NotificationCenter.default.post(Notification(name: Notification.Name.UIApplicationWillResignActive))
+        NotificationCenter.default.post(Notification(name: Notification.Name.UIApplicationDidBecomeActive))    }
+}
+
+private class TestDeeplink: Deeplinking {
+    func execute(completion: DeeplinkCompletionHandler?) {}
+
+    var url: URL = URL(string: "app1://test")!
+    var fallbackURLs: [URL] = [URL(string: "app2://test")!,
+                               URL(string: "app3://test")!,
+                               URL(string: "https://test")!]
+}
+
+private class URLOpeningMock: URLOpening {
+    var canOpenURLCallCount = 0
+    var canOpenURLHandler: ((URL) -> Bool)?
+    func canOpenURL(_ url: URL) -> Bool {
+        canOpenURLCallCount += 1
+
+        return canOpenURLHandler?(url) ?? false
+    }
+
+    var openURLCallCount = 0
+    var openURLHandler: ((URL) -> Bool)?
+    func openURL(_ url: URL) -> Bool {
+        openURLCallCount += 1
+
+        return openURLHandler?(url) ?? false
+    }
+}

--- a/source/UberRides.xcodeproj/project.pbxproj
+++ b/source/UberRides.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		DF021B481F996549004A7893 /* AuthenticationURLUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCAEA9931CEE91D000E6F239 /* AuthenticationURLUtility.swift */; };
 		DF021B4A1F996B0F004A7893 /* NativeAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6410831CED0B3A009C4C8A /* NativeAuthenticator.swift */; };
 		DF021B511F998A1D004A7893 /* OAuthEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF021B501F998A1D004A7893 /* OAuthEndpoint.swift */; };
+		DF0233971FD76F5F00351976 /* DeeplinkManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0233961FD76F5F00351976 /* DeeplinkManagerTests.swift */; };
 		DF0A44A91F998C7E002CFE5B /* ImplicitGrantAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81C85271CC74F4B00DC82EE /* ImplicitGrantAuthenticator.swift */; };
 		DF0A44AA1F998C7E002CFE5B /* AuthorizationCodeGrantAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D4A511CD01894000EE8A9 /* AuthorizationCodeGrantAuthenticator.swift */; };
 		DF137B731F981EAB00B954A7 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DF137B6E1F981E5400B954A7 /* Localizable.strings */; };
@@ -319,6 +320,7 @@
 		DCF87E7A1CF3995C0081894C /* BaseAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseAuthenticator.swift; sourceTree = "<group>"; };
 		DCF87E7C1CF3A9D40081894C /* BaseAuthenticatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseAuthenticatorTests.swift; sourceTree = "<group>"; };
 		DF021B501F998A1D004A7893 /* OAuthEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthEndpoint.swift; sourceTree = "<group>"; };
+		DF0233961FD76F5F00351976 /* DeeplinkManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkManagerTests.swift; sourceTree = "<group>"; };
 		DF137B6F1F981E5400B954A7 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DF137B701F981E5400B954A7 /* hi-In */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hi-In"; path = "hi-In.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		DF137B711F981E5400B954A7 /* pt-br */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-br"; path = "pt-br.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -646,6 +648,7 @@
 				DFA91C3B1FABEADD00149E8F /* UberMocks.swift */,
 				DC78ED121CB578D100850814 /* UberScopeFactoryTests.swift */,
 				DFFCA8BD1F96A4800032E6BA /* Info.plist */,
+				DF0233961FD76F5F00351976 /* DeeplinkManagerTests.swift */,
 			);
 			path = UberCoreTests;
 			sourceTree = "<group>";
@@ -1110,6 +1113,7 @@
 				DFC99A1A1FAB9AD200C12021 /* LoginButtonTests.swift in Sources */,
 				DFC99A241FAB9D8E00C12021 /* BaseAuthenticatorTests.swift in Sources */,
 				DFA91C3C1FABEADD00149E8F /* UberMocks.swift in Sources */,
+				DF0233971FD76F5F00351976 /* DeeplinkManagerTests.swift in Sources */,
 				DFC99A1B1FAB9CE000C12021 /* OAuthTests.swift in Sources */,
 				DFC99A1D1FAB9CFA00C12021 /* AccessTokenFactoryTests.swift in Sources */,
 				DFFCA8DA1F97D7250032E6BA /* BaseDeeplinkTests.swift in Sources */,

--- a/source/UberRides/DeeplinkRequestingBehavior.swift
+++ b/source/UberRides/DeeplinkRequestingBehavior.swift
@@ -25,6 +25,16 @@
 import UberCore
 
 @objc(UBSDKDeeplinkRequestingBehavior) public class DeeplinkRequestingBehavior : NSObject, RideRequesting {
+    private var fallbackType: DeeplinkFallbackType?
+
+    @objc public init(fallbackType: DeeplinkFallbackType) {
+        self.fallbackType = fallbackType
+        super.init()
+    }
+
+    @objc public override init() {
+        super.init()
+    }
         
     /**
      Requests a ride using a RequestDeeplink that is constructed using the provided
@@ -37,22 +47,15 @@ import UberCore
         guard let rideParameters = rideParameters else {
             return
         }
-        let deeplink = createDeeplink(rideParameters: rideParameters)
-        
-        let deeplinkCompletion: (NSError?) -> () = { error in
-            if let error = error, error.code != DeeplinkErrorType.deeplinkNotFollowed.rawValue {
-                self.createAppStoreDeeplink(rideParameters: rideParameters).execute(completion: nil)
-            }
-        }
-        
-        deeplink.execute(completion: deeplinkCompletion)
+
+        createDeeplink(rideParameters: rideParameters).execute()
     }
-    
+
     func createDeeplink(rideParameters: RideParameters) -> RequestDeeplink {
-        return RequestDeeplink(rideParameters: rideParameters)
-    }
-    
-    func createAppStoreDeeplink(rideParameters: RideParameters) -> Deeplinking {
-        return AppStoreDeeplink(userAgent: rideParameters.userAgent)
+        if let fallbackType = fallbackType {
+            return RequestDeeplink(rideParameters: rideParameters, fallbackType: fallbackType)
+        } else {
+            return RequestDeeplink(rideParameters: rideParameters)
+        }
     }
 }

--- a/source/UberRides/RequestDeeplink.swift
+++ b/source/UberRides/RequestDeeplink.swift
@@ -32,14 +32,48 @@ import UberCore
  */
 @objc(UBSDKRequestDeeplink) public class RequestDeeplink: BaseDeeplink {
     static let sourceString = "deeplink"
-    
-    @objc public init(rideParameters: RideParameters = RideParametersBuilder().build()) {
-        rideParameters.source = rideParameters.source ?? RequestDeeplink.sourceString
-        
+
+    private let rideParameters: RideParameters
+    private let fallbackType: DeeplinkFallbackType
+
+    @objc public convenience init(rideParameters: RideParameters = RideParametersBuilder().build()) {
+        self.init(rideParameters: rideParameters, fallbackType: DeeplinkFallbackType.mobileWeb)
+    }
+
+    @objc public init(rideParameters: RideParameters, fallbackType: DeeplinkFallbackType) {
+        self.rideParameters = rideParameters
+        self.fallbackType = fallbackType
+        self.rideParameters.source = rideParameters.source ?? RequestDeeplink.sourceString
+
         let queryItems = RequestURLUtil.buildRequestQueryParameters(rideParameters)
         let scheme = "uber"
         let domain = ""
-        
+
         super.init(scheme: scheme, host: domain, path: "", queryItems: queryItems)!
+    }
+
+    public override var fallbackURLs: [URL] {
+        var urls = super.fallbackURLs
+        if let fallbackURL = buildFallbackURL() {
+            urls.append(fallbackURL)
+        }
+        return urls
+    }
+
+    private func buildFallbackURL() -> URL? {
+        switch fallbackType {
+        case .mobileWeb:
+            if var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+                urlComponents.scheme = "https"
+                urlComponents.host = "m.uber.com"
+                return urlComponents.url
+            }
+        case .appStore:
+            let deeplink = AppStoreDeeplink(userAgent: rideParameters.userAgent)
+            return deeplink.url
+        default:
+            break
+        }
+        return nil
     }
 }

--- a/source/UberRides/RequestDeeplink.swift
+++ b/source/UberRides/RequestDeeplink.swift
@@ -36,10 +36,16 @@ import UberCore
     private let rideParameters: RideParameters
     private let fallbackType: DeeplinkFallbackType
 
+    /**
+     Initialize a ride request deeplink. If the Uber app is not installed, fallback to the App Store.
+     */
     @objc public convenience init(rideParameters: RideParameters = RideParametersBuilder().build()) {
-        self.init(rideParameters: rideParameters, fallbackType: DeeplinkFallbackType.mobileWeb)
+        self.init(rideParameters: rideParameters, fallbackType: DeeplinkFallbackType.appStore)
     }
 
+    /**
+     Initialize a ride request deeplink.
+     */
     @objc public init(rideParameters: RideParameters, fallbackType: DeeplinkFallbackType) {
         self.rideParameters = rideParameters
         self.fallbackType = fallbackType

--- a/source/UberRidesTests/DeeplinkRequestingBehaviorTests.swift
+++ b/source/UberRidesTests/DeeplinkRequestingBehaviorTests.swift
@@ -55,14 +55,14 @@ class DeeplinkRequestingBehaviorTests : XCTestCase {
 
         let rideParameters = RideParametersBuilder().build()
         rideParameters.source = RideRequestButton.sourceString
-        let requestingBehavior = DeeplinkRequestingBehavior()
+        let requestingBehavior = DeeplinkRequestingBehavior(fallbackType: .appStore)
         
-        let appStoreDeeplink = requestingBehavior.createAppStoreDeeplink(rideParameters: rideParameters)
+        let appStoreDeeplink = requestingBehavior.createDeeplink(rideParameters: rideParameters).fallbackURLs.last!
         
-        let components = URLComponents(url: appStoreDeeplink.url, resolvingAgainstBaseURL: false)
+        let components = URLComponents(url: appStoreDeeplink, resolvingAgainstBaseURL: false)
         XCTAssertNotNil(components)
         
-        XCTAssertEqual(expectedUrlString, appStoreDeeplink.url.absoluteString)
+        XCTAssertEqual(expectedUrlString, appStoreDeeplink.absoluteString)
         XCTAssertEqual(components!.queryItems!.count, 2)
         XCTAssertTrue(components!.query!.contains("&user-agent=\(expectedButtonUserAgent!)"))
     }
@@ -75,14 +75,14 @@ class DeeplinkRequestingBehaviorTests : XCTestCase {
 
         let rideParameters = RideParametersBuilder().build()
         rideParameters.source = RequestDeeplink.sourceString
-        let requestingBehavior = DeeplinkRequestingBehavior()
+        let requestingBehavior = DeeplinkRequestingBehavior(fallbackType: .appStore)
         
-        let appStoreDeeplink = requestingBehavior.createAppStoreDeeplink(rideParameters: rideParameters)
+        let appStoreDeeplink = requestingBehavior.createDeeplink(rideParameters: rideParameters).fallbackURLs.last!
         
-        let components = URLComponents(url: appStoreDeeplink.url, resolvingAgainstBaseURL: false)
+        let components = URLComponents(url: appStoreDeeplink, resolvingAgainstBaseURL: false)
         XCTAssertNotNil(components)
         
-        XCTAssertEqual(expectedUrlString, appStoreDeeplink.url.absoluteString)
+        XCTAssertEqual(expectedUrlString, appStoreDeeplink.absoluteString)
         XCTAssertEqual(components!.queryItems!.count, 2)
         XCTAssertTrue(components!.query!.contains("&user-agent=\(expectedDeeplinkUserAgent!)"))
     }

--- a/source/UberRidesTests/RequestDeeplinkTests.swift
+++ b/source/UberRidesTests/RequestDeeplinkTests.swift
@@ -234,4 +234,31 @@ class UberRidesDeeplinkTests: XCTestCase {
             XCTAssertNil(error)
         })
     }
+
+    func testRequestDeeplinkFallbackDefaultsMuber() {
+        let deeplink = RequestDeeplink()
+        XCTAssertEqual(deeplink.fallbackURLs.count, 3)
+        XCTAssertEqual(deeplink.fallbackURLs[0].scheme, "uber-enterprise")
+        XCTAssertEqual(deeplink.fallbackURLs[1].scheme, "uber-nightly")
+        XCTAssertEqual(deeplink.fallbackURLs[2].scheme, "https")
+        XCTAssertEqual(deeplink.fallbackURLs[2].host, "m.uber.com")
+        XCTAssertEqual(deeplink.fallbackURLs[2].path, "")
+    }
+
+    func testRequestDeeplinkFallbackAppStore() {
+        let deeplink = RequestDeeplink(rideParameters: RideParametersBuilder().build(), fallbackType: .appStore)
+        XCTAssertEqual(deeplink.fallbackURLs.count, 3)
+        XCTAssertEqual(deeplink.fallbackURLs[0].scheme, "uber-enterprise")
+        XCTAssertEqual(deeplink.fallbackURLs[1].scheme, "uber-nightly")
+        XCTAssertEqual(deeplink.fallbackURLs[2].scheme, "https")
+        XCTAssertEqual(deeplink.fallbackURLs[2].host, "m.uber.com")
+        XCTAssertEqual(deeplink.fallbackURLs[2].path, "/sign-up")
+    }
+
+    func testRequestDeeplinkFallbackNone() {
+        let deeplink = RequestDeeplink(rideParameters: RideParametersBuilder().build(), fallbackType: .none)
+        XCTAssertEqual(deeplink.fallbackURLs.count, 2)
+        XCTAssertEqual(deeplink.fallbackURLs[0].scheme, "uber-enterprise")
+        XCTAssertEqual(deeplink.fallbackURLs[1].scheme, "uber-nightly")
+    }
 }

--- a/source/UberRidesTests/RequestDeeplinkTests.swift
+++ b/source/UberRidesTests/RequestDeeplinkTests.swift
@@ -235,24 +235,24 @@ class UberRidesDeeplinkTests: XCTestCase {
         })
     }
 
-    func testRequestDeeplinkFallbackDefaultsMuber() {
+    func testRequestDeeplinkFallbackAppStore() {
         let deeplink = RequestDeeplink()
         XCTAssertEqual(deeplink.fallbackURLs.count, 3)
         XCTAssertEqual(deeplink.fallbackURLs[0].scheme, "uber-enterprise")
         XCTAssertEqual(deeplink.fallbackURLs[1].scheme, "uber-nightly")
         XCTAssertEqual(deeplink.fallbackURLs[2].scheme, "https")
         XCTAssertEqual(deeplink.fallbackURLs[2].host, "m.uber.com")
-        XCTAssertEqual(deeplink.fallbackURLs[2].path, "")
+        XCTAssertEqual(deeplink.fallbackURLs[2].path, "/sign-up")
     }
 
-    func testRequestDeeplinkFallbackAppStore() {
-        let deeplink = RequestDeeplink(rideParameters: RideParametersBuilder().build(), fallbackType: .appStore)
+    func testRequestDeeplinkFallbackDefaultsMuber() {
+        let deeplink = RequestDeeplink(rideParameters: RideParametersBuilder().build(), fallbackType: .mobileWeb)
         XCTAssertEqual(deeplink.fallbackURLs.count, 3)
         XCTAssertEqual(deeplink.fallbackURLs[0].scheme, "uber-enterprise")
         XCTAssertEqual(deeplink.fallbackURLs[1].scheme, "uber-nightly")
         XCTAssertEqual(deeplink.fallbackURLs[2].scheme, "https")
         XCTAssertEqual(deeplink.fallbackURLs[2].host, "m.uber.com")
-        XCTAssertEqual(deeplink.fallbackURLs[2].path, "/sign-up")
+        XCTAssertEqual(deeplink.fallbackURLs[2].path, "")
     }
 
     func testRequestDeeplinkFallbackNone() {

--- a/source/UberRidesTests/RidesMocks.swift
+++ b/source/UberRidesTests/RidesMocks.swift
@@ -121,7 +121,7 @@ class RequestDeeplinkMock : RequestDeeplink {
     var testClosure: ((URL?) -> (Bool))?
     init(rideParameters: RideParameters, testClosure: ((URL?) -> (Bool))?) {
         self.testClosure = testClosure
-        super.init(rideParameters: rideParameters)
+        super.init(rideParameters: rideParameters, fallbackType: .mobileWeb)
     }
     
     override func execute(completion: ((NSError?) -> ())? = nil) {
@@ -173,6 +173,8 @@ class DeeplinkRequestingBehaviorMock: DeeplinkRequestingBehavior {
             backingDeeplinkURL = newDeeplinkURL
         }
     }
+
+    var fallbackURLs: [URL] = []
 
     @objc func execute(completion: ((NSError?) -> ())?) {
         if let closure = executeClosure {


### PR DESCRIPTION
This change allows deeplinks to specify a fallback if the original deeplink doesn't open properly.

We add a `fallbackURLs: [URL]` property to the `Deeplinking` protocol. The `BaseDeeplink` implements it and automatically adds the `Uber-enterprise` and `Uber-nightly` schemes if the original scheme is `uber`, to make beta testing easier. 

The `DeeplinkManager` is modified so that it uses the fallbacks if opening a deeplink is not successful. 

The `RequestDeeplink` and `DeeplinkRequestingBehavior` take an additional `DeeplinkFallbackType` enum in the initializer which defaults to `.mobileWeb`. Otherwise, it can fall back to `.appStore` or `.none`. 