### PR TITLE
Update HTTP Requests with Uber SDK Version Info

### DIFF
--- a/source/UberCore/Authentication/OAuthEndpoint.swift
+++ b/source/UberCore/Authentication/OAuthEndpoint.swift
@@ -34,7 +34,7 @@ public enum OAuth: APIEndpoint {
     case authorizationCodeLogin(clientID: String, redirect: URL, scopes: [UberScope], state: String?)
     case refresh(clientID: String, refreshToken: String)
 
-    public var method: HTTPMethod {
+    public var method: UberHTTPMethod {
         switch self {
         case .implicitLogin:
             fallthrough

--- a/source/UberCore/Networking/APIEndpoint.swift
+++ b/source/UberCore/Networking/APIEndpoint.swift
@@ -80,14 +80,6 @@ public extension APIEndpoint {
 }
 
 /**
- Enum for HTTPHeaders.
- */
-public enum HTTPHeader: String {
-    case Authorization = "Authorization"
-    case ContentType = "Content-Type"
-}
-
-/**
  Enum for HTTPMethods
  */
 public enum HTTPMethod: String {

--- a/source/UberCore/Networking/APIEndpoint.swift
+++ b/source/UberCore/Networking/APIEndpoint.swift
@@ -29,7 +29,7 @@ public protocol APIEndpoint {
     var body: Data? { get }
     var headers: [String: String]? { get }
     var host: String { get}
-    var method: HTTPMethod { get }
+    var method: UberHTTPMethod { get }
     var path: String { get }
     var query: [URLQueryItem] { get }
 }
@@ -80,9 +80,9 @@ public extension APIEndpoint {
 }
 
 /**
- Enum for HTTPMethods
+ Enum for UberHTTPMethods
  */
-public enum HTTPMethod: String {
+public enum UberHTTPMethod: String {
     case get = "GET"
     case post = "POST"
     case put = "PUT"

--- a/source/UberCore/Networking/Request.swift
+++ b/source/UberCore/Networking/Request.swift
@@ -105,6 +105,10 @@ public class Request {
      */
     private func addHeaders() {
         urlRequest.setValue("gzip, deflate", forHTTPHeaderField: "Accept-Encoding")
+
+        if let versionNumber = Bundle(for: type(of: self)).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String {
+            urlRequest.setValue("iOS Rides SDK v\(versionNumber)", forHTTPHeaderField: "X-Uber-User-Agent")
+        }
         if let token = bearerToken {
             urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: HTTPHeader.Authorization.rawValue)
         } else if let token = serverToken {

--- a/source/UberCore/Networking/Request.swift
+++ b/source/UberCore/Networking/Request.swift
@@ -110,9 +110,9 @@ public class Request {
             urlRequest.setValue("iOS Rides SDK v\(versionNumber)", forHTTPHeaderField: "X-Uber-User-Agent")
         }
         if let token = bearerToken {
-            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: HTTPHeader.Authorization.rawValue)
+            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         } else if let token = serverToken {
-            urlRequest.setValue("Token \(token)", forHTTPHeaderField: HTTPHeader.Authorization.rawValue)
+            urlRequest.setValue("Token \(token)", forHTTPHeaderField: "Authorization")
         }
         if let headers = endpoint.headers {
             for (header,value) in headers {

--- a/source/UberRides/EndpointsManager.swift
+++ b/source/UberRides/EndpointsManager.swift
@@ -285,7 +285,7 @@ enum Requests: APIEndpoint {
     }
     
     var headers: [String : String]? {
-        return [HTTPHeader.ContentType.rawValue: "application/json"]
+        return ["Content-Type": "application/json"]
     }
     
     var method: HTTPMethod {
@@ -385,7 +385,7 @@ enum Places: APIEndpoint {
         case .getPlace:
             return nil
         case .putPlace:
-            return [HTTPHeader.ContentType.rawValue: "application/json"]
+            return ["Content-Type": "application/json"]
         }
     }
     

--- a/source/UberRides/EndpointsManager.swift
+++ b/source/UberRides/EndpointsManager.swift
@@ -59,7 +59,7 @@ private enum Resources: String {
 enum Components: APIEndpoint {
     case rideRequestWidget(rideParameters: RideParameters?)
     
-    var method: HTTPMethod {
+    var method: UberHTTPMethod {
         switch self {
         case .rideRequestWidget:
             return .get
@@ -102,7 +102,7 @@ enum Products: APIEndpoint {
     case getAll(location: CLLocation)
     case getProduct(productID: String)
     
-    var method: HTTPMethod {
+    var method: UberHTTPMethod {
         switch self {
         case .getAll:
             fallthrough
@@ -142,7 +142,7 @@ enum Estimates: APIEndpoint {
     case price(startLocation: CLLocation, endLocation: CLLocation)
     case time(location: CLLocation, productID: String?)
     
-    var method: HTTPMethod {
+    var method: UberHTTPMethod {
         switch self {
         case .price:
             fallthrough
@@ -185,7 +185,7 @@ enum Estimates: APIEndpoint {
 enum History: APIEndpoint {
     case get(offset: Int?, limit: Int?)
     
-    var method: HTTPMethod {
+    var method: UberHTTPMethod {
         switch self {
         case .get:
             return .get
@@ -217,7 +217,7 @@ enum History: APIEndpoint {
 enum Me: APIEndpoint {
     case userProfile
     
-    var method: HTTPMethod {
+    var method: UberHTTPMethod {
         switch self {
         case .userProfile:
             return .get
@@ -288,7 +288,7 @@ enum Requests: APIEndpoint {
         return ["Content-Type": "application/json"]
     }
     
-    var method: HTTPMethod {
+    var method: UberHTTPMethod {
         switch self {
         case .deleteCurrent:
             fallthrough
@@ -350,7 +350,7 @@ enum Payment: APIEndpoint {
         return nil
     }
     
-    var method: HTTPMethod {
+    var method: UberHTTPMethod {
         return .get
     }
     
@@ -389,7 +389,7 @@ enum Places: APIEndpoint {
         }
     }
     
-    var method: HTTPMethod {
+    var method: UberHTTPMethod {
         switch self {
         case .getPlace:
             return .get

--- a/source/UberRidesTests/APIManagerTests.swift
+++ b/source/UberRidesTests/APIManagerTests.swift
@@ -277,7 +277,7 @@ class APIManagerTests: XCTestCase {
             XCTAssert(false)
         }
         XCTAssertNotNil(request.httpBody)
-        XCTAssertEqual(request.allHTTPHeaderFields![HTTPHeader.ContentType.rawValue], "application/json")
+        XCTAssertEqual(request.allHTTPHeaderFields!["Content-Type"], "application/json")
     }
     
     /**
@@ -363,7 +363,7 @@ class APIManagerTests: XCTestCase {
             XCTAssert(false)
         }
         if let headers = request.allHTTPHeaderFields {
-            XCTAssertEqual(headers[HTTPHeader.ContentType.rawValue], "application/json")
+            XCTAssertEqual(headers["Content-Type"], "application/json")
         } else {
             XCTAssert(false)
         }
@@ -400,7 +400,7 @@ class APIManagerTests: XCTestCase {
         }
         
         if let headers = request.allHTTPHeaderFields {
-            XCTAssertEqual(headers[HTTPHeader.ContentType.rawValue], "application/json")
+            XCTAssertEqual(headers["Content-Type"], "application/json")
         } else {
             XCTAssert(false)
         }
@@ -441,7 +441,7 @@ class APIManagerTests: XCTestCase {
         }
         
         if let headers = request.allHTTPHeaderFields {
-            XCTAssertEqual(headers[HTTPHeader.ContentType.rawValue], "application/json")
+            XCTAssertEqual(headers["Content-Type"], "application/json")
         } else {
             XCTAssert(false)
         }
@@ -507,7 +507,7 @@ class APIManagerTests: XCTestCase {
         }
         XCTAssertNil(request.httpBody)
         if let headers = request.allHTTPHeaderFields {
-            XCTAssertEqual(headers[HTTPHeader.ContentType.rawValue], "application/json")
+            XCTAssertEqual(headers["Content-Type"], "application/json")
         } else {
             XCTAssert(false)
         }
@@ -526,7 +526,7 @@ class APIManagerTests: XCTestCase {
         }
         XCTAssertNil(request.httpBody)
         if let headers = request.allHTTPHeaderFields {
-            XCTAssertEqual(headers[HTTPHeader.ContentType.rawValue], "application/json")
+            XCTAssertEqual(headers["Content-Type"], "application/json")
         } else {
             XCTAssert(false)
         }

--- a/source/UberRidesTests/APIManagerTests.swift
+++ b/source/UberRidesTests/APIManagerTests.swift
@@ -75,7 +75,7 @@ class APIManagerTests: XCTestCase {
      
      - parameter endpoint: Endpoint that conforms to UberAPI.
      
-     - returns: URLRequest with URL and HTTPMethod set.
+     - returns: URLRequest with URL and UberHTTPMethod set.
      */
     func buildRequestForEndpoint(_ endpoint: APIEndpoint) -> URLRequest {
         let request = Request(session: nil, endpoint: endpoint)
@@ -89,7 +89,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetAllProducts() {
         let request = buildRequestForEndpoint(Products.getAll(location: CLLocation(latitude: pickupLat, longitude: pickupLong)))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetProducts)
         } else {
@@ -102,7 +102,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetProduct() {
         let request = buildRequestForEndpoint(Products.getProduct(productID: productID))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetProduct)
         } else {
@@ -115,7 +115,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetPriceEstimates() {
         let request = buildRequestForEndpoint(Estimates.price(startLocation: CLLocation(latitude: pickupLat, longitude: pickupLong), endLocation: CLLocation(latitude: dropoffLat, longitude: dropoffLong)))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetPriceEstimates)
         } else {
@@ -128,7 +128,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetTimeEstimates() {
         let request = buildRequestForEndpoint(Estimates.time(location: CLLocation(latitude: pickupLat, longitude: pickupLong), productID: nil))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetTimeEstimates)
         } else {
@@ -141,7 +141,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetTimeEstimatesWithOptionalParameters() {
         let request = buildRequestForEndpoint(Estimates.time(location: CLLocation(latitude: pickupLat, longitude: pickupLong), productID: productID))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetTimeEstimatesAllParams)
         } else {
@@ -154,7 +154,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetHistory() {
         let request = buildRequestForEndpoint(History.get(offset: nil, limit: nil))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetHistory)
         } else {
@@ -167,7 +167,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetHistoryWithAllParameters() {
         let request = buildRequestForEndpoint(History.get(offset: offset, limit: limit))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetHistoryWithAllParameters)
         } else {
@@ -180,7 +180,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetHistoryWithOffsetParameter() {
         let request = buildRequestForEndpoint(History.get(offset: offset, limit: nil))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetHistoryWithOffset)
         } else {
@@ -193,7 +193,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetHistoryWithLimitParameter() {
         let request = buildRequestForEndpoint(History.get(offset: nil, limit: limit))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetHistoryWithLimit)
         } else {
@@ -206,7 +206,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetUserProfile() {
         let request = buildRequestForEndpoint(Me.userProfile)
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetUserProfile)
         } else {
@@ -270,7 +270,7 @@ class APIManagerTests: XCTestCase {
         builder.productID = productID
         let rideParameters = builder.build()
         let request = buildRequestForEndpoint(Requests.make(rideParameters: rideParameters))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.post.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.post.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.PostRequest)
         } else {
@@ -285,7 +285,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetCurrentRequest() {
         let request = buildRequestForEndpoint(Requests.getCurrent)
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetCurrentRequest)
         } else {
@@ -298,7 +298,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetRequestByID() {
         let request = buildRequestForEndpoint(Requests.getRequest(requestID: requestID))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetRequestByID)
         } else {
@@ -340,7 +340,7 @@ class APIManagerTests: XCTestCase {
     func testGetPlace() {
         let placeID = Place.home
         let request = buildRequestForEndpoint(Places.getPlace(placeID: placeID))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetPlace)
         } else {
@@ -356,7 +356,7 @@ class APIManagerTests: XCTestCase {
         let testAddress = "testAddress"
         let placeID = Place.home
         let request = buildRequestForEndpoint(Places.putPlace(placeID: placeID, address: testAddress))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.put.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.put.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.PutPlace)
         } else {
@@ -499,7 +499,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetRideReceipt() {
         let request = buildRequestForEndpoint(Requests.rideReceipt(requestID: requestID))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetRideReceipt)
         } else {
@@ -518,7 +518,7 @@ class APIManagerTests: XCTestCase {
      */
     func testGetRideMap() {
         let request = buildRequestForEndpoint(Requests.rideMap(requestID: requestID))
-        XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
+        XCTAssertEqual(request.httpMethod, UberHTTPMethod.get.rawValue)
         if let url = request.url {
             XCTAssertEqual(url.absoluteString, ExpectedEndpoint.GetRideMap)
         } else {


### PR DESCRIPTION
This adds a `X-Uber-User-Agent` header to HTTP requests made by the SDK, just like the Android SDK.

In addition, I clean up the `HTTPHeader` and `HTTPMethod` enums. The Header enum seemed fairly useless, so I deleted it. `HTTPMethod` was conflicting with `Alamofire`, a popular Swift library, and is meant mostly for internal (Uber modules) use. Thus I renamed it to `UberHTTPMethod` to make developers lives easier. See #216. 