### PR TITLE
Fixed a bug where the system dialog box:

### DIFF
--- a/examples/Swift SDK/Swift SDK/AuthorizationCodeGrantExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/AuthorizationCodeGrantExampleViewController.swift
@@ -202,7 +202,7 @@ class AuthorizationCodeGrantExampleViewController: AuthorizationBaseViewControll
         let updateStatusEndpoint = URL(string: "https://sandbox-api.uber.com/v1/sandbox/requests/\(requestID)")!
         var request = URLRequest(url: updateStatusEndpoint)
         request.httpMethod = "PUT"
-        request.setValue("Bearer \(token.tokenString!)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(token.tokenString)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         do {
             let data = try JSONSerialization.data(withJSONObject: ["status":status], options: .prettyPrinted)

--- a/source/UberCore/Authentication/LoginManagingProtocol.swift
+++ b/source/UberCore/Authentication/LoginManagingProtocol.swift
@@ -74,6 +74,12 @@
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool
     
     /**
+     Called via the RidesAppDelegate when the application is about to enter the foreground. Used to determine
+     if a user abandons Native login without getting an access token.
+     */
+    func applicationWillEnterForeground()
+    
+    /**
      Called via the RidesAppDelegate when the application becomes active. Used to determine
      if a user abandons Native login without getting an access token.
      */

--- a/source/UberCore/Authentication/UberAppDelegate.swift
+++ b/source/UberCore/Authentication/UberAppDelegate.swift
@@ -43,6 +43,7 @@
         super.init()
         
         NotificationCenter.default.addObserver(self, selector: #selector(didBecomeActive), name: Notification.Name.UIApplicationDidBecomeActive, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: Notification.Name.UIApplicationWillEnterForeground, object: nil)
     }
     
     deinit {
@@ -94,10 +95,16 @@
     
     //MARK: Private Methods
     
+    @objc private func willEnterForeground(_ notification: Notification) {
+        if let manager = loginManager {
+            manager.applicationWillEnterForeground()
+        }
+    }
+    
     @objc private func didBecomeActive(_ notification: Notification) {
         if let manager = loginManager {
             manager.applicationDidBecomeActive()
-            loginManager = nil
         }
     }
+
 }

--- a/source/UberCoreTests/LoginManagerTests.swift
+++ b/source/UberCoreTests/LoginManagerTests.swift
@@ -139,10 +139,21 @@ class LoginManagerTests: XCTestCase {
         XCTAssertNil(loginManager.authenticator)
     }
 
+    func testCancelLoginNotCalled_whenNotEnteringForeground() {
+        let loginManager = LoginManager(loginType: .native)
+        loginManager.loggingIn = true
+
+        loginManager.applicationDidBecomeActive()
+
+        XCTAssertNil(loginManager.authenticator)
+        XCTAssertTrue(loginManager.loggingIn)
+    }
+
     func testCancelLoginCalled_whenDidBecomeActive() {
         let loginManager = LoginManager(loginType: .native)
         loginManager.loggingIn = true
 
+        loginManager.applicationWillEnterForeground()
         loginManager.applicationDidBecomeActive()
 
         XCTAssertNil(loginManager.authenticator)

--- a/source/UberCoreTests/UberAppDelegateTests.swift
+++ b/source/UberCoreTests/UberAppDelegateTests.swift
@@ -136,7 +136,8 @@ class UberAppDelegateTests : XCTestCase {
         
         loginManagerMock.didBecomeActiveClosure = didBecomeActiveClosure
         appDelegate.loginManager = loginManagerMock
-        
+
+        NotificationCenter.default.post(name: NSNotification.Name.UIApplicationWillEnterForeground, object: nil)
         NotificationCenter.default.post(name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
         
         waitForExpectations(timeout: 0.2) { _ in

--- a/source/UberCoreTests/UberAppDelegateTests.swift
+++ b/source/UberCoreTests/UberAppDelegateTests.swift
@@ -140,9 +140,7 @@ class UberAppDelegateTests : XCTestCase {
         NotificationCenter.default.post(name: NSNotification.Name.UIApplicationWillEnterForeground, object: nil)
         NotificationCenter.default.post(name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
         
-        waitForExpectations(timeout: 0.2) { _ in
-            XCTAssertNil(appDelegate.loginManager)
-        }
+        waitForExpectations(timeout: 0.2)
     }
     
 }

--- a/source/UberCoreTests/UberMocks.swift
+++ b/source/UberCoreTests/UberMocks.swift
@@ -36,6 +36,7 @@ class LoginManagerPartialMock: LoginManager {
     var loginClosure: (([UberScope], UIViewController?, ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?) -> Void)?
     var openURLClosure: ((UIApplication, URL, String?, Any?) -> Bool)?
     var didBecomeActiveClosure: (() -> ())?
+    var willEnterForegroundClosure: (() -> ())?
 
     var backingManager: LoginManaging?
 
@@ -75,6 +76,14 @@ class LoginManagerPartialMock: LoginManager {
             closure()
         } else if let manager = backingManager {
             manager.applicationDidBecomeActive()
+        }
+    }
+
+    func applicationWillEnterForeground() {
+        if let closure = willEnterForegroundClosure {
+            closure()
+        } else {
+            backingManager?.applicationWillEnterForeground()
         }
     }
 }


### PR DESCRIPTION
Fixed a bug where the system dialog box:

"<App Name>" wants to open "Uber"
Cancel / Open

would cause SSO to fail because the system dialog triggers the UIApplicationDidBecomeActive notification.
The fix is to make sure that the notification is preceded by a UIApplicationWillEnterForeground notification,
which happens only when the there's been a context switch to the Uber app.

Fixed a related bug where, if the user were to select Cancel in the system dialog box (above), the library
would attempt to use fallback to a web view, when the correct handling would be to stop attempting to log
in and return an error to the caller.