### PR TITLE
Making UI update of LoginButton happening on the Main Thread

### DIFF
--- a/source/UberCore/Authentication/LoginButton.swift
+++ b/source/UberCore/Authentication/LoginButton.swift
@@ -213,7 +213,11 @@ import UIKit
     //Mark: Private Interface
     
     @objc private func refreshContent() {
-        uberTitleLabel.text = titleForButtonState(buttonState)
+        DispatchQueue.main.async { [weak self] in
+            guard let strongSelf = self else { return }
+
+            strongSelf.uberTitleLabel.text = strongSelf.titleForButtonState(strongSelf.buttonState)
+        }
     }
     
     private func titleForButtonState(_ buttonState: LoginButtonState) -> String {


### PR DESCRIPTION
Currently, the text of the UILabel  `uberTitleLabel` is not being updated on the main thread, resulting in the text displayed not properly on screen in some cases.

I switched the operation to the main thread. `Self` is captured `weak` for better memory management.



Xcode warning:
![screen shot 2018-03-08 at 1 01 06 pm](https://user-images.githubusercontent.com/16561699/37169172-29907404-22d5-11e8-84c3-deb40f2be2c9.png)
