### PR TITLE
Feature/code authenticator

### DIFF
--- a/examples/Swift SDK/Swift SDK/AuthorizationCodeGrantExampleViewController.swift
+++ b/examples/Swift SDK/Swift SDK/AuthorizationCodeGrantExampleViewController.swift
@@ -87,6 +87,7 @@ class AuthorizationCodeGrantExampleViewController: AuthorizationBaseViewControll
             
             // Poll backend for access token
             // Replace "YOUR_URL" with the path for your backend service
+            // Use accessToken.authorizationCode to receive authorizationCode
             if let url = URL(string: "YOUR_URL") {
                 let request = URLRequest(url: url)
                 URLSession.shared.dataTask(with: request) { (data, response, error) in

--- a/source/UberCore/Authentication/Authenticators/AuthorizationCodeGrantAuthenticator.swift
+++ b/source/UberCore/Authentication/Authenticators/AuthorizationCodeGrantAuthenticator.swift
@@ -30,4 +30,20 @@ import UIKit
     @objc override var authorizationURL: URL {
         return OAuth.authorizationCodeLogin(clientID: Configuration.shared.clientID, redirect: Configuration.shared.getCallbackURI(for: .authorizationCode), scopes: scopes, state: state).url
     }
+    
+    /**
+     Overrided method to create AccessToken with Authorization Code
+     */
+    @objc public override func consumeResponse(url: URL, completion: AuthenticationCompletionHandler?) {
+        if AuthenticationURLUtility.shouldHandleRedirectURL(url) {
+            do {
+                let accessToken = try AccessTokenFactory.createAuthorizationCode(fromRedirectURL: url)
+                completion?(accessToken, nil)
+            } catch let ridesError as NSError {
+                completion?(nil, ridesError)
+            } catch {
+                completion?(nil, UberAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidResponse))
+            }
+        }
+    }
 }

--- a/source/UberCore/Authentication/Tokens/AccessToken.swift
+++ b/source/UberCore/Authentication/Tokens/AccessToken.swift
@@ -36,6 +36,9 @@
     /// String containing the refresh token.
     @objc public private(set) var refreshToken: String?
     
+    /// String containing the authorization code for LoginType.authorizationCode authentication type.
+    @objc public private(set) var authorizationCode: String?
+    
     /// The expiration date for this access token
     @objc public private(set) var expirationDate: Date?
     
@@ -49,6 +52,17 @@
      */
     @objc public init(tokenString: String) {
         self.tokenString = tokenString
+        super.init()
+    }
+    
+    /**
+     Initializes an AccessToken with the provided authorizationCode
+     
+     - parameter authorizationCode: The authorization code
+     */
+    @objc public init(tokenString: String, authorizationCode: String?) {
+        self.tokenString = tokenString
+        self.authorizationCode = authorizationCode
         super.init()
     }
     

--- a/source/UberCore/Authentication/Tokens/AccessTokenFactory.swift
+++ b/source/UberCore/Authentication/Tokens/AccessTokenFactory.swift
@@ -65,6 +65,42 @@ Factory class to build access tokens
     }
     
     /**
+     Builds an AccessToken with authorizationCode from the provided redirect URL
+     
+     - throws: UberAuthenticationError
+     - parameter url: The URL to parse the authorization code from
+     - returns: An initialized AccessToken, or nil if one couldn't be created
+     */
+    public static func createAuthorizationCode(fromRedirectURL redirectURL: URL) throws -> AccessToken {
+        guard var components = URLComponents(url: redirectURL, resolvingAgainstBaseURL: false) else {
+            throw UberAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidResponse)
+        }
+        
+        var finalQueryArray = [String]()
+        if let existingQuery = components.query {
+            finalQueryArray.append(existingQuery)
+        }
+        if let existingFragment = components.fragment {
+            finalQueryArray.append(existingFragment)
+        }
+        components.fragment = nil
+        components.query = finalQueryArray.joined(separator: "&")
+        
+        guard let queryItems = components.queryItems else {
+            throw UberAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .invalidRequest)
+        }
+        var queryDictionary = [String: Any]()
+        for queryItem in queryItems {
+            guard let value = queryItem.value else {
+                continue
+            }
+            queryDictionary[queryItem.name] = value
+        }
+        
+        return AccessToken(tokenString: "", authorizationCode: queryDictionary["code"] as? String)
+    }
+    
+    /**
      Builds an AccessToken from the provided JSON data
      
      - throws: UberAuthenticationError


### PR DESCRIPTION
I've discovered that in rides-ios-sdk loginManager.login() with LoginType.authorizationCode is not implemented properly, because even your example returns error if you try to use it. (error code 14, I will describe reasons below)

The problem is in class AccessTokenFactory. It is not setup to receive authorization code, it is setup to make AccessToken no matter what login type you use. Which is wrong, because .authorizationCode login flow doesn't need AccessToken, but it needs authorization code to proceed authorization.

I've changed AccessToken model so it contain authorizationCode variable to store authorizationCode for this type of login.

Also i've added method:
`public static func createAuthorizationCode(fromRedirectURL redirectURL: URL) throws -> AccessToken`

to create empty instance of accessToken with filled authorizationCode variable.

Then AuthorizationCodeGrantAuthenticator returns AuthenticationCompletionHandler with AccessToken that contains only authorizationCode variable so developer could finish his authentication process via backend service. 

My changes doesn't impact on all other login types and functionality of SDK, they just fix .authorizationCode login flow.

I've tested it in my app and it works fine, authentication is successful. Also I've tested it on rides-ios-sdk examples and it works fine too.

