### PR TITLE
Allows for using auth code fallback without priviledged scope

### DIFF
--- a/source/UberCore/Authentication/LoginManager.swift
+++ b/source/UberCore/Authentication/LoginManager.swift
@@ -339,9 +339,12 @@ import SafariServices
             }
 
             // If we can't open the deeplink, fallback.
-            // Privileged scopes require auth code flow.
+            // First check if the user requests auth code fallback regardless of scope.
+            // Next, check for privileged scopes, which require auth code flow.
             // Since that requires server support, fallback to app store if not available.
-            if authenticationProvider.scopes.contains(where: { $0.scopeType == .privileged }) {
+            if Configuration.shared.alwaysUseAuthCodeFallback {
+                self.loginType = .authorizationCode
+            } else if authenticationProvider.scopes.contains(where: { $0.scopeType == .privileged }) {
                 if (Configuration.shared.useFallback) {
                     self.loginType = .authorizationCode
                 } else {

--- a/source/UberCore/Configuration.swift
+++ b/source/UberCore/Configuration.swift
@@ -154,6 +154,15 @@ private let callbackURIStringKey = "URIString"
      */
     @objc public var useFallback: Bool = false
 
+    /**
+     Returns if the fallback to use Authorization Code Grant is enabled. If true,
+     a failed SSO attempt will follow up with an attempt to do Authorization Code Grant,
+     regardless of scopes requested.
+
+     - returns: true if fallback enabled, false otherwise
+     */
+    @objc public var alwaysUseAuthCodeFallback: Bool = false
+
     public override init() {
         self.clientID = ""
         self.appDisplayName = ""

--- a/source/UberCoreTests/LoginManagerTests.swift
+++ b/source/UberCoreTests/LoginManagerTests.swift
@@ -181,6 +181,24 @@ class LoginManagerTests: XCTestCase {
         XCTAssertFalse(loginManager.loggingIn)
     }
 
+    func testNativeLoginCompletionDoesFallback_whenUnavailableError_withConfiguration_alwaysUseAuthCodeFallback() {
+        Configuration.shared.alwaysUseAuthCodeFallback = true
+        let scopes = [UberScope.historyLite]
+
+        let loginManager = LoginManager(loginType: .native)
+
+        let nativeAuthenticatorStub = RidesNativeAuthenticatorPartialStub(scopes: [])
+        nativeAuthenticatorStub.consumeResponseCompletionValue = (nil, UberAuthenticationErrorFactory.errorForType(ridesAuthenticationErrorType: .unavailable))
+
+        loginManager.authenticator = nativeAuthenticatorStub
+
+        let viewController = UIViewController()
+
+        loginManager.login(requestedScopes: scopes, presentingViewController: viewController, completion: nil)
+
+        XCTAssertEqual(loginManager.loginType, LoginType.authorizationCode)
+    }
+
     func testNativeLoginCompletionDoesFallback_whenUnavailableError_withPrivelegedScopes_rides() {
         Configuration.shared.useFallback = true
         let scopes = [UberScope.request]


### PR DESCRIPTION
Adds a configuration option to use authorization code fallback rather than implicit, without requiring privileged scope.

This is the iOS implementation of this merged Android pull request: https://github.com/uber/rides-android-sdk/pull/128