### PR TITLE
Added token_type property support to AccessToken model

### DIFF
--- a/source/UberCore/Authentication/Tokens/AccessToken.swift
+++ b/source/UberCore/Authentication/Tokens/AccessToken.swift
@@ -36,6 +36,9 @@
     /// String containing the refresh token.
     @objc public private(set) var refreshToken: String?
     
+    /// String containing the token type.
+    @objc public private(set) var tokenType: String?
+    
     /// The expiration date for this access token
     @objc public private(set) var expirationDate: Date?
     
@@ -57,15 +60,18 @@
      
      - parameter tokenString: The access token string
      - parameter refreshToken: String containing the refresh token.
+     - parameter tokenType: String containing the token type.
      - parameter expirationDate: The expiration date for this access token
      - parameter grantedScopes: The scopes this token is valid for
      */
     @objc public init(tokenString: String,
                       refreshToken: String?,
+                      tokenType: String?,
                       expirationDate: Date?,
                       grantedScopes: [UberScope]) {
         self.tokenString = tokenString
         self.refreshToken = refreshToken
+        self.tokenType = tokenType
         self.expirationDate = expirationDate
         self.grantedScopes = grantedScopes
         super.init()
@@ -76,7 +82,7 @@
      the OAuth access token response.
      
      See https://tools.ietf.org/html/rfc6749#section-5.1 for more details.
-     The `token_type` parameter is not required for this initializer.
+     The `token_type` parameter is not required for this initializer, however is supported.
      
      - parameter oauthDictionary: A dictionary with key/values matching
      the OAuth access token response.
@@ -85,6 +91,7 @@
         guard let tokenString = oauthDictionary["access_token"] as? String else { return nil }
         self.tokenString = tokenString
         self.refreshToken = oauthDictionary["refresh_token"] as? String
+        self.tokenType = oauthDictionary["token_type"] as? String
         if let expiresIn = oauthDictionary["expires_in"] as? Double {
             self.expirationDate = Date(timeIntervalSinceNow: expiresIn)
         } else if let expiresIn = oauthDictionary["expires_in"] as? String,
@@ -116,6 +123,7 @@
         }
         tokenString = token
         refreshToken = decoder.decodeObject(forKey: "refreshToken") as? String
+        tokenType = decoder.decodeObject(forKey: "tokenType") as? String
         expirationDate = decoder.decodeObject(forKey: "expirationDate") as? Date
         if let scopesString = decoder.decodeObject(forKey: "grantedScopes") as? String {
             grantedScopes = scopesString.toUberScopesArray()
@@ -131,6 +139,7 @@
     @objc public func encode(with coder: NSCoder) {
         coder.encode(self.tokenString, forKey: "tokenString")
         coder.encode(self.refreshToken, forKey:  "refreshToken")
+        coder.encode(self.tokenType, forKey:  "tokenType")
         coder.encode(self.expirationDate, forKey: "expirationDate")
         coder.encode(self.grantedScopes.toUberScopeString(), forKey: "grantedScopes")
     }

--- a/source/UberCoreTests/AccessTokenFactoryTests.swift
+++ b/source/UberCoreTests/AccessTokenFactoryTests.swift
@@ -28,6 +28,7 @@ import XCTest
 class AccessTokenFactoryTests: XCTestCase {
     private let redirectURI = "http://localhost:1234/"
     private let tokenString = "token"
+    private let tokenTypeString = "type"
     private let refreshTokenString = "refreshToken"
     private let expirationTime = 10030.23
     private let allowedScopesString = "profile history"
@@ -45,7 +46,7 @@ class AccessTokenFactoryTests: XCTestCase {
 
     func testParseTokenFromURL_withSuccess() {
         var components = URLComponents()
-        components.fragment = "access_token=\(tokenString)&refresh_token=\(refreshTokenString)&expires_in=\(expirationTime)&scope=\(allowedScopesString)"
+        components.fragment = "access_token=\(tokenString)&refresh_token=\(refreshTokenString)&token_type=\(tokenTypeString)&expires_in=\(expirationTime)&scope=\(allowedScopesString)"
         components.host = redirectURI
         guard let url = components.url else {
             XCTAssert(false)
@@ -56,6 +57,7 @@ class AccessTokenFactoryTests: XCTestCase {
             XCTAssertNotNil(token)
             XCTAssertEqual(token.tokenString, tokenString)
             XCTAssertEqual(token.refreshToken, refreshTokenString)
+            XCTAssertEqual(token.tokenType, tokenTypeString)
             XCTAssertEqual(token.grantedScopes.toUberScopeString(), allowedScopesString)
             UBSDKAssert(date: token.expirationDate!, approximatelyIn: expirationTime)
             
@@ -68,7 +70,7 @@ class AccessTokenFactoryTests: XCTestCase {
     
     func testParseTokenFromURL_withError() {
         var components = URLComponents()
-        components.fragment = "access_token=\(tokenString)&refresh_token=\(refreshTokenString)&expires_in=\(expirationTime)&scope=\(allowedScopesString)&error=\(errorString)"
+        components.fragment = "access_token=\(tokenString)&refresh_token=\(refreshTokenString)&token_type=\(tokenTypeString)&expires_in=\(expirationTime)&scope=\(allowedScopesString)&error=\(errorString)"
         components.host = redirectURI
         guard let url = components.url else {
             XCTAssert(false)
@@ -117,6 +119,7 @@ class AccessTokenFactoryTests: XCTestCase {
             XCTAssertNotNil(token)
             XCTAssertEqual(token.tokenString, tokenString)
             XCTAssertNil(token.refreshToken)
+            XCTAssertNil(token.tokenType)
             XCTAssertNil(token.expirationDate)
             XCTAssertEqual(token.grantedScopes, [UberScope]())
         } catch _ as NSError {
@@ -148,7 +151,7 @@ class AccessTokenFactoryTests: XCTestCase {
     
     func testParseTokenFromURL_withFragmentAndQuery_withSuccess() {
         var components = URLComponents(string: redirectURI)!
-        components.fragment = "access_token=\(tokenString)&refresh_token=\(refreshTokenString)"
+        components.fragment = "access_token=\(tokenString)&refresh_token=\(refreshTokenString)&token_type=\(tokenTypeString)"
         components.query = "expires_in=\(expirationTime)&scope=\(allowedScopesString)"
         guard let url = components.url else {
             XCTAssert(false)
@@ -158,6 +161,7 @@ class AccessTokenFactoryTests: XCTestCase {
             let token : AccessToken = try AccessTokenFactory.createAccessToken(fromRedirectURL: url)
             XCTAssertNotNil(token)
             XCTAssertEqual(token.tokenString, tokenString)
+            XCTAssertEqual(token.tokenType, tokenTypeString)
             XCTAssertEqual(token.refreshToken, refreshTokenString)
             XCTAssertEqual(token.grantedScopes.toUberScopeString(), allowedScopesString)
             UBSDKAssert(date: token.expirationDate!, approximatelyIn: expirationTime)
@@ -179,6 +183,7 @@ class AccessTokenFactoryTests: XCTestCase {
             let token : AccessToken = try AccessTokenFactory.createAccessToken(fromRedirectURL: url)
             XCTAssertNotNil(token)
             XCTAssertEqual(token.tokenString, tokenString)
+            XCTAssertNil(token.tokenType)
             XCTAssertNil(token.refreshToken)
             XCTAssertNil(token.expirationDate)
             XCTAssertEqual(token.grantedScopes, [UberScope]())
@@ -190,7 +195,7 @@ class AccessTokenFactoryTests: XCTestCase {
     }
 
     func testParseValidJsonStringToAccessToken() {
-        let jsonString = "{\"access_token\": \"\(tokenString)\", \"refresh_token\": \"\(refreshTokenString)\", \"expires_in\": \"\(expirationTime)\", \"scope\": \"\(allowedScopesString)\"}"
+        let jsonString = "{\"access_token\": \"\(tokenString)\", \"refresh_token\": \"\(refreshTokenString)\", \"token_type\": \"\(tokenTypeString)\", \"expires_in\": \"\(expirationTime)\", \"scope\": \"\(allowedScopesString)\"}"
 
         guard let accessToken = try? AccessTokenFactory.createAccessToken(fromJSONData: jsonString.data(using: .utf8)!) else {
             XCTFail()
@@ -198,6 +203,7 @@ class AccessTokenFactoryTests: XCTestCase {
         }
         XCTAssertEqual(accessToken.tokenString, tokenString)
         XCTAssertEqual(accessToken.refreshToken, refreshTokenString)
+        XCTAssertEqual(accessToken.tokenType, tokenTypeString)
         UBSDKAssert(date: accessToken.expirationDate!, approximatelyIn: expirationTime)
         XCTAssert(accessToken.grantedScopes.contains(UberScope.profile))
         XCTAssert(accessToken.grantedScopes.contains(UberScope.history))

--- a/source/UberCoreTests/OAuthTests.swift
+++ b/source/UberCoreTests/OAuthTests.swift
@@ -32,6 +32,7 @@ class OAuthTests: XCTestCase {
     let timeout: TimeInterval = 2
     let tokenString = "accessToken1234"
     let refreshTokenString = "refresh"
+    let tokenTypeString = "type"
     let expiresIn = 10030.23
     let scope = "profile history"
     
@@ -67,6 +68,7 @@ class OAuthTests: XCTestCase {
         let result = keychain.getObjectForKey(key) as! AccessToken
         XCTAssertEqual(result.tokenString, token.tokenString)
         XCTAssertEqual(result.refreshToken, token.refreshToken)
+        XCTAssertEqual(result.tokenType, token.tokenType)
         XCTAssertEqual(result.grantedScopes, token.grantedScopes)
         
         XCTAssertTrue(keychain.deleteObjectForKey(key))
@@ -93,6 +95,7 @@ class OAuthTests: XCTestCase {
         let result = keychain.getObjectForKey(key) as! AccessToken
         XCTAssertEqual(result.tokenString, newToken.tokenString)
         XCTAssertEqual(result.refreshToken, newToken.refreshToken)
+        XCTAssertEqual(result.tokenType, newToken.tokenType)
         XCTAssertEqual(result.grantedScopes, newToken.grantedScopes)
         
         XCTAssertTrue(keychain.deleteObjectForKey(key))
@@ -133,6 +136,7 @@ class OAuthTests: XCTestCase {
         }
         XCTAssertEqual(token.tokenString, tokenString)
         XCTAssertEqual(token.refreshToken, refreshTokenString)
+        XCTAssertEqual(token.tokenType, tokenTypeString)
         UBSDKAssert(date: token.expirationDate!, approximatelyIn: expiresIn)
         XCTAssert(token.grantedScopes.contains(UberScope.profile))
         XCTAssert(token.grantedScopes.contains(UberScope.history))
@@ -153,6 +157,7 @@ class OAuthTests: XCTestCase {
         var jsonDictionary = [String: Any]()
         jsonDictionary["access_token"] = accessToken
         jsonDictionary["refresh_token"] = refreshTokenString
+        jsonDictionary["token_type"] = tokenTypeString
         jsonDictionary["expires_in"] = expiresIn
         jsonDictionary["scope"] = scope
         return AccessToken(oauthDictionary: jsonDictionary)

--- a/source/UberRidesTests/RidesClientTests.swift
+++ b/source/UberRidesTests/RidesClientTests.swift
@@ -898,6 +898,12 @@ class RidesClientTests: XCTestCase {
         })
     }
     
+    func testTokenType() {
+        stub(condition: isHost("login.uber.com")) { _ in
+            return OHHTTPStubsResponse(fileAtPath: OHPathForFile("refresh.json", type(of: self))!, statusCode: 200, headers: nil)
+        }
+    }
+    
     /**
      Test to check getting the access token when using the default settings
      and the token exists


### PR DESCRIPTION
`AccessToken` on the iOS version of the SDK doesn't include the `token_type` property, while this is available in the Android version of the SDK, and provided by the backend. 

To ensure consistency between versions of the SDK, the `token_type` property has been added to the `AccessToken` model. This has been verified as available and functioning correctly via unit tests, and a live integration of the SDK in a test application.

Screenshots are attached below of this change in action: 
<img width="987" alt="Screen Shot 2019-04-10 at 2 16 27 PM" src="https://user-images.githubusercontent.com/51029/55904192-4bba3b80-5b9d-11e9-9fe7-8717a525eda7.png">
