### PR TITLE
Implementing PAC

### DIFF
--- a/source/UberCore/Authentication/AuthenticationURLUtility.swift
+++ b/source/UberCore/Authentication/AuthenticationURLUtility.swift
@@ -32,10 +32,11 @@ class AuthenticationURLUtility {
     static let scopesKey = "scope"
     static let sdkKey = "sdk"
     static let sdkVersionKey = "sdk_version"
+    static let requestUriKey = "request_uri"
     
     static let sdkValue = "ios"
     
-    static func buildQueryParameters(_ scopes: [UberScope]) -> [URLQueryItem] {
+    static func buildQueryParameters(scopes: [UberScope], requestUri: String?) -> [URLQueryItem] {
         var queryItems = [URLQueryItem]()
         
         queryItems.append(URLQueryItem(name: appNameKey, value: Configuration.shared.appDisplayName))
@@ -44,6 +45,9 @@ class AuthenticationURLUtility {
         queryItems.append(URLQueryItem(name: scopesKey, value: scopes.toUberScopeString()))
         queryItems.append(URLQueryItem(name: sdkKey, value: sdkValue))
         queryItems.append(URLQueryItem(name: sdkVersionKey, value: Configuration.shared.sdkVersion))
+        if let requestUri {
+            queryItems.append(URLQueryItem(name: requestUriKey, value: requestUri))
+        }
         
         return queryItems
     }

--- a/source/UberCore/Authentication/Authenticators/AuthenticationProvider.swift
+++ b/source/UberCore/Authentication/Authenticators/AuthenticationProvider.swift
@@ -30,6 +30,7 @@ class AuthenticationProvider {
 
     let productFlowPriority: [UberAuthenticationProductFlow]
     let scopes: [UberScope]
+    let requestUri: String?
 
     /// Returns an AuthenticationProvider.
     ///
@@ -38,8 +39,9 @@ class AuthenticationProvider {
     ///   - productFlowPriority: The product flows against which to authenticate, in the order of which Uber products you'd like to use to authenticate the user.
     ///
     ///     For example, you may want to SSO with the UberEats app, but if the app does not exist on the user's device, then try to authenticate with the Uber Rides app instead. In this example you'd call this parameter with [ eats, rides ].
-    init(scopes: [UberScope], productFlowPriority: [UberAuthenticationProductFlow]) {
+    init(scopes: [UberScope], productFlowPriority: [UberAuthenticationProductFlow], requestUri: String?) {
         self.scopes = scopes
+        self.requestUri = requestUri
         self.productFlowPriority = productFlowPriority
     }
 
@@ -54,16 +56,16 @@ class AuthenticationProvider {
         switch loginType {
         case .authorizationCode:
             // Rides and Eats temporarily share the same authorization code flow
-            return AuthorizationCodeGrantAuthenticator(scopes: scopes)
+            return AuthorizationCodeGrantAuthenticator(scopes: scopes, requestUri: requestUri)
         case .implicit:
             // Rides and Eats temporarily share the same implicit grant code flow
-            return ImplicitGrantAuthenticator(scopes: scopes)
+            return ImplicitGrantAuthenticator(scopes: scopes, requestUri: requestUri)
         case .native:
             switch authProduct.uberProductType {
             case .rides:
-                return RidesNativeAuthenticator(scopes: scopes)
+                return RidesNativeAuthenticator(scopes: scopes, requestUri: requestUri)
             case .eats:
-                return EatsNativeAuthenticator(scopes: scopes)
+                return EatsNativeAuthenticator(scopes: scopes, requestUri: requestUri)
             }
         }
     }

--- a/source/UberCore/Authentication/Authenticators/AuthorizationCodeGrantAuthenticator.swift
+++ b/source/UberCore/Authentication/Authenticators/AuthorizationCodeGrantAuthenticator.swift
@@ -28,6 +28,12 @@ import UIKit
     @objc public var state: String?
     
     @objc override var authorizationURL: URL {
-        return OAuth.authorizationCodeLogin(clientID: Configuration.shared.clientID, redirect: Configuration.shared.getCallbackURI(for: .authorizationCode), scopes: scopes, state: state).url
+        return OAuth.authorizationCodeLogin(
+            clientID: Configuration.shared.clientID,
+            redirect: Configuration.shared.getCallbackURI(for: .authorizationCode),
+            scopes: scopes,
+            state: state,
+            requestUri: requestUri
+        ).url
     }
 }

--- a/source/UberCore/Authentication/Authenticators/BaseAuthenticator.swift
+++ b/source/UberCore/Authentication/Authenticators/BaseAuthenticator.swift
@@ -29,8 +29,12 @@ import UIKit
     /// Scopes to request during login
     @objc public var scopes: [UberScope]
     
-    @objc public init(scopes: [UberScope]) {
+    @objc public var requestUri: String?
+    
+    @objc public init(scopes: [UberScope],
+                      requestUri: String? = nil) {
         self.scopes = scopes
+        self.requestUri = requestUri
         super.init()
     }
 

--- a/source/UberCore/Authentication/Authenticators/EatsAuthenticationDeeplink.swift
+++ b/source/UberCore/Authentication/Authenticators/EatsAuthenticationDeeplink.swift
@@ -36,8 +36,8 @@ import Foundation
 
      - returns: An initialized AuthenticationDeeplink
      */
-    @objc public init(scopes: [UberScope]) {
-        let queryItems = AuthenticationURLUtility.buildQueryParameters(scopes)
+    @objc public init(scopes: [UberScope], requestUri: String?) {
+        let queryItems = AuthenticationURLUtility.buildQueryParameters(scopes: scopes, requestUri: requestUri)
         let scheme = "eatsauth"
         let domain = "connect"
 

--- a/source/UberCore/Authentication/Authenticators/EatsNativeAuthenticator.swift
+++ b/source/UberCore/Authentication/Authenticators/EatsNativeAuthenticator.swift
@@ -41,8 +41,8 @@ import Foundation
 
      - returns: true if a redirect was handled, false otherwise.
      */
-    @objc public override init(scopes: [UberScope]) {
-        deeplink = EatsAuthenticationDeeplink(scopes: scopes)
-        super.init(scopes: scopes)
+    @objc public override init(scopes: [UberScope], requestUri: String?) {
+        deeplink = EatsAuthenticationDeeplink(scopes: scopes, requestUri: requestUri)
+        super.init(scopes: scopes, requestUri: requestUri)
     }
 }

--- a/source/UberCore/Authentication/Authenticators/ImplicitGrantAuthenticator.swift
+++ b/source/UberCore/Authentication/Authenticators/ImplicitGrantAuthenticator.swift
@@ -27,6 +27,11 @@
  */
 @objc(UBSDKImplicitGrantAuthenticator) public class ImplicitGrantAuthenticator: BaseAuthenticator {
     @objc override var authorizationURL: URL {
-        return OAuth.implicitLogin(clientID: Configuration.shared.clientID, scopes: self.scopes, redirect: Configuration.shared.getCallbackURI(for: .implicit)).url
+        return OAuth.implicitLogin(
+            clientID: Configuration.shared.clientID,
+            scopes: scopes,
+            redirect: Configuration.shared.getCallbackURI(for: .implicit),
+            requestUri: requestUri
+        ).url
     }
 }

--- a/source/UberCore/Authentication/Authenticators/RidesNativeAuthenticator.swift
+++ b/source/UberCore/Authentication/Authenticators/RidesNativeAuthenticator.swift
@@ -41,8 +41,8 @@ import Foundation
 
      - returns: true if a redirect was handled, false otherwise.
      */
-    @objc public override init(scopes: [UberScope]) {
-        deeplink = RidesAuthenticationDeeplink(scopes: scopes)
-        super.init(scopes: scopes)
+    @objc public override init(scopes: [UberScope], requestUri: String?) {
+        deeplink = RidesAuthenticationDeeplink(scopes: scopes, requestUri: requestUri)
+        super.init(scopes: scopes, requestUri: requestUri)
     }
 }

--- a/source/UberCore/Authentication/LoginButton.swift
+++ b/source/UberCore/Authentication/LoginButton.swift
@@ -43,13 +43,21 @@ import UIKit
     @objc func loginButton(_ button: LoginButton, didLogoutWithSuccess success: Bool)
     
     /**
-     THe Login Button completed a login
+     The Login Button completed a login
      
      - parameter button:  The LoginButton involved
      - parameter accessToken: The access token that
      - parameter error:       The error that occured
      */
     @objc func loginButton(_ button: LoginButton, didCompleteLoginWithToken accessToken: AccessToken?, error: NSError?)
+}
+
+/**
+ *  Protocol to provide content for login
+ */
+@objc(UBSDKLoginButtonDataSource) public protocol LoginButtonDataSource {
+    
+    @objc func prefillValues(_ button: LoginButton) -> Prefill?
 }
 
 /// Button to handle logging in to Uber
@@ -61,6 +69,8 @@ import UIKit
 
     /// The LoginButtonDelegate for this button
     @objc public weak var delegate: LoginButtonDelegate?
+    
+    @objc public weak var dataSource: LoginButtonDataSource?
     
     /// The LoginManager to use for log in
     @objc public var loginManager: LoginManager {
@@ -206,7 +216,12 @@ import UIKit
             delegate?.loginButton(self, didLogoutWithSuccess: success)
             refreshContent()
         case .signedOut:
-            loginManager.login(requestedScopes: scopes, presentingViewController: presentingViewController, completion: loginCompletion)
+            loginManager.login(
+                requestedScopes: scopes,
+                presentingViewController: presentingViewController,
+                prefillValues: dataSource?.prefillValues(self),
+                completion: loginCompletion
+            )
         }
     }
     

--- a/source/UberCore/Authentication/LoginManagingProtocol.swift
+++ b/source/UberCore/Authentication/LoginManagingProtocol.swift
@@ -41,9 +41,10 @@
      
      - parameter scopes:                   scopes being requested.
      - parameter presentingViewController: The presenting view controller present the login view controller over.
+     - parameter prefillValues:            Optional values to pre-populate the signin form with.
      - parameter completion:               The LoginManagerRequestTokenHandler completion handler for login success/failure.
      */
-    @objc func login(requestedScopes scopes: [UberScope], presentingViewController: UIViewController?, completion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?)
+    @objc func login(requestedScopes scopes: [UberScope], presentingViewController: UIViewController?, prefillValues: Prefill?, completion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?)
     
     /**
      Called via the RidesAppDelegate when the application is opened via a URL. Responsible

--- a/source/UberCore/Authentication/Par.swift
+++ b/source/UberCore/Authentication/Par.swift
@@ -1,8 +1,8 @@
 //
-//  RidesAuthenticationDeeplink.swift
+//  Ride.swift
 //  UberRides
 //
-//  Copyright © 2018 Uber Technologies, Inc. All rights reserved.
+//  Copyright © 2016 Uber Technologies, Inc. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -22,25 +22,31 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import Foundation
+// MARK: Par
 
 /**
- *  A Deeplinking object for authenticating a user via the native Uber rides app
+ *  Contains the status of an ongoing/completed trip created using the Ride Request endpoint
  */
-@objc(UBSDKRidesAuthenticationDeeplink) public class RidesAuthenticationDeeplink: BaseDeeplink {
+@objc(UBSDKPar) public class Par: NSObject, Decodable {
+    
+    /// An identifier used for profile sharing
+    @objc public private(set) var requestUri: String?
+    
+    /// Lifetime of the request_uri
+    @objc public private(set) var expiresIn: NSNumber?
 
-    /**
-     Initializes an Authentication Deeplink to request the provided scopes
-
-     - parameter scopes: An array of UberScopes you would like to request
-
-     - returns: An initialized AuthenticationDeeplink
-     */
-    @objc public init(scopes: [UberScope], requestUri: String? = nil) {
-        let queryItems = AuthenticationURLUtility.buildQueryParameters(scopes: scopes, requestUri: requestUri)
-        let scheme = "uberauth"
-        let domain = "connect"
-
-        super.init(scheme: scheme, host: domain, path: "", queryItems: queryItems)!
+    enum CodingKeys: String, CodingKey {
+        case requestUri = "request_uri"
+        case expiresIn  = "expires_in"
+    }
+    
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        requestUri = try container.decodeIfPresent(String.self, forKey: .requestUri)
+        if let expiration = try container.decodeIfPresent(Int64.self, forKey: .expiresIn) {
+            expiresIn = NSNumber(value: expiration)
+        } else {
+            expiresIn = nil
+        }
     }
 }

--- a/source/UberCore/Authentication/PrefillValue.swift
+++ b/source/UberCore/Authentication/PrefillValue.swift
@@ -1,0 +1,33 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+import Foundation
+
+@objc public class Prefill: NSObject {
+    public let email: String?
+    public let phoneNumber: String?
+    public let firstName: String?
+    public let lastName: String?
+    
+    public init(email: String? = nil,
+                phoneNumber: String? = nil,
+                firstName: String? = nil,
+                lastName: String? = nil) {
+        self.email = email
+        self.phoneNumber = phoneNumber
+        self.firstName = firstName
+        self.lastName = lastName
+    }
+    
+    var dictValue: [String: String] {
+        [
+            "email": email,
+            "phone": phoneNumber,
+            "first_name": firstName,
+            "last_name": lastName
+        ]
+        .compactMapValues { $0 }
+    }
+}

--- a/source/UberCore/Networking/APIEndpoint.swift
+++ b/source/UberCore/Networking/APIEndpoint.swift
@@ -32,6 +32,7 @@ public protocol APIEndpoint {
     var method: UberHTTPMethod { get }
     var path: String { get }
     var query: [URLQueryItem] { get }
+    var contentType: String? { get }
 }
 
 public extension APIEndpoint {
@@ -76,6 +77,10 @@ public extension APIEndpoint {
             queryItems.append(URLQueryItem(name: query.name, value: query.value))
         }
         return queryItems
+    }
+    
+    var contentType: String? {
+        return nil
     }
 }
 

--- a/source/UberCore/Networking/Request.swift
+++ b/source/UberCore/Networking/Request.swift
@@ -114,10 +114,12 @@ public class Request {
         } else if let token = serverToken {
             urlRequest.setValue("Token \(token)", forHTTPHeaderField: "Authorization")
         }
-        if let headers = endpoint.headers {
-            for (header,value) in headers {
-                urlRequest.setValue(value, forHTTPHeaderField: header)
-            }
+        var headers = endpoint.headers ?? [:]
+        if let contentType = endpoint.contentType {
+            headers["Content-Type"] = contentType
+        }
+        for (header,value) in headers {
+            urlRequest.setValue(value, forHTTPHeaderField: header)
         }
     }
     

--- a/source/UberCoreTests/AuthenticationURLUtilityTests.swift
+++ b/source/UberCoreTests/AuthenticationURLUtilityTests.swift
@@ -61,7 +61,7 @@ class AuthenticationURLUtilityTests: XCTestCase {
         let expectedQueryItems = [scopeQueryItem, clientIDQueryItem, appNameQueryItem, callbackURIQueryItem, sdkQueryItem, sdkVersionQueryItem]
         let comparisonSet = NSSet(array: expectedQueryItems)
         
-        let testQueryItems = AuthenticationURLUtility.buildQueryParameters(scopes)
+        let testQueryItems = AuthenticationURLUtility.buildQueryParameters(scopes: scopes, requestUri: nil)
         let testComparisonSet = NSSet(array:testQueryItems)
         
         XCTAssertEqual(comparisonSet, testComparisonSet)
@@ -88,7 +88,7 @@ class AuthenticationURLUtilityTests: XCTestCase {
         let expectedQueryItems = [scopeQueryItem, clientIDQueryItem, appNameQueryItem, callbackURIQueryItem, sdkQueryItem, sdkVersionQueryItem]
         let comparisonSet = NSSet(array: expectedQueryItems)
         
-        let testQueryItems = AuthenticationURLUtility.buildQueryParameters(scopes)
+        let testQueryItems = AuthenticationURLUtility.buildQueryParameters(scopes: scopes, requestUri: nil)
         let testComparisonSet = NSSet(array:testQueryItems)
         
         XCTAssertEqual(comparisonSet, testComparisonSet)

--- a/source/UberCoreTests/OauthEndpointTests.swift
+++ b/source/UberCoreTests/OauthEndpointTests.swift
@@ -45,7 +45,7 @@ class OauthEndpointTests: XCTestCase {
         Configuration.shared.isSandbox = true
         
         let scopes = [ UberScope.profile, UberScope.history ]
-        let expectedHost = "https://login.uber.com"
+        let expectedHost = "https://auth.uber.com"
         let expectedPath = "/oauth/v2/authorize"
         let expectedScopes = scopes.toUberScopeString()
         let expectedClientID = Configuration.shared.clientID
@@ -70,7 +70,7 @@ class OauthEndpointTests: XCTestCase {
         Configuration.shared.isSandbox = false
         
         let scopes = [ UberScope.profile, UberScope.history ]
-        let expectedHost = "https://login.uber.com"
+        let expectedHost = "https://auth.uber.com"
         let expectedPath = "/oauth/v2/authorize"
         let expectedScopes = scopes.toUberScopeString()
         let expectedClientID = Configuration.shared.clientID
@@ -93,7 +93,7 @@ class OauthEndpointTests: XCTestCase {
 
     func testLogin_forAuthorizationCodeGrant_defaultSettings() {
         let scopes = [ UberScope.allTrips, UberScope.history ]
-        let expectedHost = "https://login.uber.com"
+        let expectedHost = "https://auth.uber.com"
         let expectedPath = "/oauth/v2/authorize"
         let expectedScopes = scopes.toUberScopeString()
         let expectedClientID = Configuration.shared.clientID
@@ -115,5 +115,65 @@ class OauthEndpointTests: XCTestCase {
         XCTAssertEqual(login.host, expectedHost)
         XCTAssertEqual(login.path, expectedPath)
         XCTAssertEqual(login.query, expectedQueryItems)
+    }
+    
+    func testPar_forResponseTypeCode_defaultSettings() {
+        let expectedHost = "https://auth.uber.com"
+        let expectedPath = "/oauth/v2/par"
+        let expectedClientID = Configuration.shared.clientID
+        let expectedResponseType = OAuth.ResponseType.code
+        let expectedLoginHint: [String: String] = [
+            "email": "test@test.com",
+            "phone": "5555555555",
+            "first_name": "First",
+            "last_name": "Last"
+        ]
+        let expectedLoginHintString = try! JSONSerialization.data(withJSONObject: expectedLoginHint).base64EncodedString()
+
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: expectedClientID),
+            URLQueryItem(name: "response_type", value: expectedResponseType.rawValue),
+            URLQueryItem(name: "login_hint", value: expectedLoginHintString),
+        ]
+        let expectedQueryItems = components.query!
+        
+        let login = OAuth.par(clientID: expectedClientID, loginHint: expectedLoginHint, responseType: expectedResponseType)
+        
+        let queryString = String(data: login.body!, encoding: .utf8)
+        
+        XCTAssertEqual(login.host, expectedHost)
+        XCTAssertEqual(login.path, expectedPath)
+        XCTAssertEqual(queryString, expectedQueryItems)
+    }
+    
+    func testPar_forResponseTypeToken_defaultSettings() {
+        let expectedHost = "https://auth.uber.com"
+        let expectedPath = "/oauth/v2/par"
+        let expectedClientID = Configuration.shared.clientID
+        let expectedResponseType = OAuth.ResponseType.token
+        let expectedLoginHint: [String: String] = [
+            "email": "test@test.com",
+            "phone": "5555555555",
+            "first_name": "First",
+            "last_name": "Last"
+        ]
+        let expectedLoginHintString = try! JSONSerialization.data(withJSONObject: expectedLoginHint).base64EncodedString()
+
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: expectedClientID),
+            URLQueryItem(name: "response_type", value: expectedResponseType.rawValue),
+            URLQueryItem(name: "login_hint", value: expectedLoginHintString),
+        ]
+        let expectedQueryItems = components.query!
+        
+        let login = OAuth.par(clientID: expectedClientID, loginHint: expectedLoginHint, responseType: expectedResponseType)
+        
+        let queryString = String(data: login.body!, encoding: .utf8)
+        
+        XCTAssertEqual(login.host, expectedHost)
+        XCTAssertEqual(login.path, expectedPath)
+        XCTAssertEqual(queryString, expectedQueryItems)
     }
 }

--- a/source/UberCoreTests/RefreshEndpointTests.swift
+++ b/source/UberCoreTests/RefreshEndpointTests.swift
@@ -52,7 +52,7 @@ class RefreshEndpointTests: XCTestCase {
      Test 200 success response
      */
     func test200Response() {
-        stub(condition: isHost("login.uber.com")) { _ in
+        stub(condition: isHost("auth.uber.com")) { _ in
             return HTTPStubsResponse(fileAtPath:OHPathForFile("refresh.json", type(of: self))!, statusCode:200, headers:self.headers)
         }
         let refreshToken = "ThisIsRefresh"
@@ -104,7 +104,7 @@ class RefreshEndpointTests: XCTestCase {
     func test400Error() {
         let error = "invalid_refresh_token"
         
-        stub(condition: isHost("login.uber.com")) { _ in
+        stub(condition: isHost("auth.uber.com")) { _ in
             let json = ["error": error]
             return HTTPStubsResponse(jsonObject: json, statusCode: 400, headers: self.headers)
         }

--- a/source/UberCoreTests/UberMocks.swift
+++ b/source/UberCoreTests/UberMocks.swift
@@ -26,7 +26,10 @@
 class LoginManagerPartialMock: LoginManager {
     var executeLoginClosure: ((AuthenticationCompletionHandler?) -> ())?
 
-    @objc public override func login(requestedScopes scopes: [UberScope], presentingViewController: UIViewController? = nil, completion: AuthenticationCompletionHandler? = nil) {
+    @objc public override func login(requestedScopes scopes: [UberScope],
+                                     presentingViewController: UIViewController?,
+                                     prefillValues: Prefill?,
+                                     completion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?) {
         executeLoginClosure?(completion)
     }
 }
@@ -45,11 +48,19 @@ class LoginManagerPartialMock: LoginManager {
         super.init()
     }
 
-    func login(requestedScopes scopes: [UberScope], presentingViewController: UIViewController?, completion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?) {
+    func login(requestedScopes scopes: [UberScope],
+               presentingViewController: UIViewController?,
+               prefillValues: Prefill?,
+               completion: ((_ accessToken: AccessToken?, _ error: NSError?) -> Void)?) {
         if let closure = loginClosure {
             closure(scopes, presentingViewController, completion)
         } else if let manager = backingManager {
-            manager.login(requestedScopes: scopes, presentingViewController: presentingViewController, completion: completion)
+            manager.login(
+                requestedScopes: scopes,
+                presentingViewController: presentingViewController,
+                prefillValues: nil,
+                completion: completion
+            )
         }
     }
 

--- a/source/UberRides.xcodeproj/project.pbxproj
+++ b/source/UberRides.xcodeproj/project.pbxproj
@@ -27,6 +27,11 @@
 		B261EBAA29E4A9A3007CDCC3 /* OHHTTPStubsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = B261EBA929E4A9A3007CDCC3 /* OHHTTPStubsSwift */; };
 		B261EBAC29E4A9A9007CDCC3 /* OHHTTPStubs in Frameworks */ = {isa = PBXBuildFile; productRef = B261EBAB29E4A9A9007CDCC3 /* OHHTTPStubs */; };
 		B261EBAE29E4A9A9007CDCC3 /* OHHTTPStubsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = B261EBAD29E4A9A9007CDCC3 /* OHHTTPStubsSwift */; };
+		B289FC9F29D5FB560071FFF4 /* UberCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFFCA8AC1F96A4800032E6BA /* UberCore.framework */; };
+		B289FCA029D5FB7C0071FFF4 /* UberRides.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC0404751BFACD1D00AC1501 /* UberRides.framework */; };
+		B289FCA229D6123B0071FFF4 /* PrefillValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B289FCA129D6123B0071FFF4 /* PrefillValue.swift */; };
+		B291DED929EF09D1005DD810 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B291DED729EF09D1005DD810 /* Main.storyboard */; };
+		B2D31CA429E88C4B001A9891 /* Par.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D31CA329E88C4B001A9891 /* Par.swift */; };
 		D81A8B161C658A2800339C13 /* TimeEstimate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81A8B151C658A2800339C13 /* TimeEstimate.swift */; };
 		D81A8B181C658A4F00339C13 /* getTimeEstimates.json in Resources */ = {isa = PBXBuildFile; fileRef = D81A8B171C658A4F00339C13 /* getTimeEstimates.json */; };
 		D81A8B1A1C69186B00339C13 /* RequestLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81A8B191C69186B00339C13 /* RequestLayerTests.swift */; };
@@ -99,7 +104,6 @@
 		DCD8060C1CFE50F300EF6EB1 /* requestEstimateNoCars.json in Resources */ = {isa = PBXBuildFile; fileRef = DCD8060B1CFE50F300EF6EB1 /* requestEstimateNoCars.json */; };
 		DCDD153E1D99A7F20053BC8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDD153D1D99A7F20053BC8F /* AppDelegate.swift */; };
 		DCDD15401D99A7F20053BC8F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDD153F1D99A7F20053BC8F /* ViewController.swift */; };
-		DCDD15431D99A7F20053BC8F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DCDD15411D99A7F20053BC8F /* Main.storyboard */; };
 		DCDD15451D99A7F20053BC8F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DCDD15441D99A7F20053BC8F /* Assets.xcassets */; };
 		DCDD15481D99A7F20053BC8F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DCDD15461D99A7F20053BC8F /* LaunchScreen.storyboard */; };
 		DF021B3E1F996158004A7893 /* KeychainWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CC80FA1C7D3AA300385AD5 /* KeychainWrapper.swift */; };
@@ -215,6 +219,9 @@
 		AC0404931BFACDAF00AC1501 /* RequestDeeplink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestDeeplink.swift; sourceTree = "<group>"; };
 		AC0404951BFACDC900AC1501 /* RidesClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RidesClient.swift; sourceTree = "<group>"; };
 		AC0404991BFACE5400AC1501 /* RequestDeeplinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestDeeplinkTests.swift; sourceTree = "<group>"; };
+		B289FCA129D6123B0071FFF4 /* PrefillValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefillValue.swift; sourceTree = "<group>"; };
+		B291DED829EF09D1005DD810 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		B2D31CA329E88C4B001A9891 /* Par.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Par.swift; sourceTree = "<group>"; };
 		C1C60712D3DA8E230F9B36D2 /* Pods-UberRidesTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UberRidesTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-UberRidesTests/Pods-UberRidesTests.release.xcconfig"; sourceTree = "<group>"; };
 		D80D4A511CD01894000EE8A9 /* AuthorizationCodeGrantAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthorizationCodeGrantAuthenticator.swift; sourceTree = "<group>"; };
 		D81A8B151C658A2800339C13 /* TimeEstimate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TimeEstimate.swift; path = Model/TimeEstimate.swift; sourceTree = "<group>"; };
@@ -324,7 +331,6 @@
 		DCDD153B1D99A7F20053BC8F /* TestAppShim.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestAppShim.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCDD153D1D99A7F20053BC8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DCDD153F1D99A7F20053BC8F /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		DCDD15421D99A7F20053BC8F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		DCDD15441D99A7F20053BC8F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		DCDD15471D99A7F20053BC8F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		DCDD15491D99A7F20053BC8F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -388,6 +394,8 @@
 			files = (
 				B261EBA429E4A973007CDCC3 /* OHHTTPStubs in Frameworks */,
 				B261EBA629E4A973007CDCC3 /* OHHTTPStubsSwift in Frameworks */,
+				B289FC9F29D5FB560071FFF4 /* UberCore.framework in Frameworks */,
+				B289FCA029D5FB7C0071FFF4 /* UberRides.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -577,10 +585,10 @@
 		DCDD153C1D99A7F20053BC8F /* TestAppShim */ = {
 			isa = PBXGroup;
 			children = (
+				B291DED729EF09D1005DD810 /* Main.storyboard */,
 				DCDD154D1D99A82D0053BC8F /* TestAppShim.entitlements */,
 				DCDD153D1D99A7F20053BC8F /* AppDelegate.swift */,
 				DCDD153F1D99A7F20053BC8F /* ViewController.swift */,
-				DCDD15411D99A7F20053BC8F /* Main.storyboard */,
 				DCDD15441D99A7F20053BC8F /* Assets.xcassets */,
 				DCDD15461D99A7F20053BC8F /* LaunchScreen.storyboard */,
 				DCDD15491D99A7F20053BC8F /* Info.plist */,
@@ -637,7 +645,9 @@
 				DCAEA9931CEE91D000E6F239 /* AuthenticationURLUtility.swift */,
 				DF021B501F998A1D004A7893 /* OAuthEndpoint.swift */,
 				DC8D42A81CF4C95000C16D16 /* UberAppDelegate.swift */,
+				B2D31CA329E88C4B001A9891 /* Par.swift */,
 				DC1AE1B81CF6BF3900B8CFCB /* LoginButton.swift */,
+				B289FCA129D6123B0071FFF4 /* PrefillValue.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -976,7 +986,7 @@
 				DFFCA8DC1F97F6860032E6BA /* testInfo.plist in Resources */,
 				DCDD15481D99A7F20053BC8F /* LaunchScreen.storyboard in Resources */,
 				DCDD15451D99A7F20053BC8F /* Assets.xcassets in Resources */,
-				DCDD15431D99A7F20053BC8F /* Main.storyboard in Resources */,
+				B291DED929EF09D1005DD810 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1100,7 +1110,9 @@
 				77370828212B366800BB1C01 /* EatsNativeAuthenticator.swift in Sources */,
 				DFFCA8CA1F96AADE0032E6BA /* BaseDeeplink.swift in Sources */,
 				DFFCA8D51F96C1160032E6BA /* UberError.swift in Sources */,
+				B289FCA229D6123B0071FFF4 /* PrefillValue.swift in Sources */,
 				DF0A44A91F998C7E002CFE5B /* ImplicitGrantAuthenticator.swift in Sources */,
+				B2D31CA429E88C4B001A9891 /* Par.swift in Sources */,
 				DF0A44AA1F998C7E002CFE5B /* AuthorizationCodeGrantAuthenticator.swift in Sources */,
 				772E1168212DF15800056C63 /* EatsAppStoreDeeplink.swift in Sources */,
 				77370822212B000200BB1C01 /* RidesAuthenticationDeeplink.swift in Sources */,
@@ -1170,6 +1182,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		B291DED729EF09D1005DD810 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				B291DED829EF09D1005DD810 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
 		DC8FC3611CBDF4D000D58839 /* Localizable.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -1179,14 +1199,6 @@
 				DFD7096F1F159865007550C8 /* pt-BR */,
 			);
 			name = Localizable.strings;
-			sourceTree = "<group>";
-		};
-		DCDD15411D99A7F20053BC8F /* Main.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				DCDD15421D99A7F20053BC8F /* Base */,
-			);
-			name = Main.storyboard;
 			sourceTree = "<group>";
 		};
 		DCDD15461D99A7F20053BC8F /* LaunchScreen.storyboard */ = {


### PR DESCRIPTION
This PR adds the functionality to submit profile values to Uber backend and pre-populate the results during auth. For example, supplying phone number would have the phone number field filled when launching the signup flow. Note, this only works for implicit and auth code login types, not native.

The changes include:
- A new Prefill type to specify email, phone number, and name
- A new DataSource for LoginButton to allow implementers to pass prefill values to the login method
- Changes to LoginManager.login to accept prefill values
- A new endpoint `par` used to submit values to BE and get a request_uri in response
- Changes to pass request_uri into the login requests
- Changing login.uber.com -> auth.uber.com
- Unit tests