### PR TITLE
Adds support for Auth Code Grant Flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.build/
 build/
 *.pbxuser
 !default.pbxuser

--- a/Sources/UberAuth/AuthProviding.swift
+++ b/Sources/UberAuth/AuthProviding.swift
@@ -15,3 +15,16 @@ public protocol AuthProviding {
     
     func handle(response url: URL) -> Bool
 }
+
+extension AuthProviding where Self == AuthorizationCodeAuthProvider {
+    
+    public static func authorizationCode(presentationAnchor: ASPresentationAnchor = .init(),
+                                         scopes: [String] = AuthorizationCodeAuthProvider.defaultScopes,
+                                         shouldExchangeAuthCode: Bool = true) -> Self {
+        AuthorizationCodeAuthProvider(
+            presentationAnchor: presentationAnchor,
+            scopes: scopes,
+            shouldExchangeAuthCode: shouldExchangeAuthCode
+        )
+    }
+}

--- a/Sources/UberAuth/Authorize/AuthenticationSession.swift
+++ b/Sources/UberAuth/Authorize/AuthenticationSession.swift
@@ -1,0 +1,84 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+import AuthenticationServices
+import Foundation
+
+/// @mockable
+protocol AuthenticationSessioning {
+    init(anchor: ASPresentationAnchor,
+         callbackURLScheme: String,
+         url: URL,
+         completion: @escaping AuthCompletion)
+    
+    func start()
+}
+
+final class AuthenticationSession: AuthenticationSessioning {
+    
+    private let authSession: ASWebAuthenticationSession
+    
+    private let presentationContextProvider: ASWebAuthenticationPresentationContextProviding?
+    
+    init(anchor: ASPresentationAnchor = ASPresentationAnchor(),
+         callbackURLScheme: String, 
+         url: URL,
+         completion: @escaping AuthCompletion) {
+        self.presentationContextProvider = AuthPresentationContextProvider(anchor: anchor)
+        self.authSession = ASWebAuthenticationSession(
+            url: url,
+            callbackURLScheme: callbackURLScheme,
+            completionHandler: { url, error in
+                switch (url, error) {
+                case (_, .some(let error)):
+                    completion(.failure(UberAuthError(error: error)))
+                case (.none, _):
+                    completion(.failure(UberAuthError.invalidAuthCode))
+                case (.some(let url), _):
+                    guard let code = Self.parse(url: url) else {
+                        completion(.failure(UberAuthError.invalidAuthCode))
+                        return
+                    }
+                    completion(.success(.init(authorizationCode: code)))
+                }
+            }
+        )
+        self.authSession.presentationContextProvider = presentationContextProvider
+    }
+    
+    func start() {
+        if #available(iOS 13.4, *) {
+            guard authSession.canStart else {
+                return
+            }
+        }
+        authSession.start()
+    }
+    
+    
+    /// Attempts to get the authorization code `code` from the query parameters of the provided url
+    /// - Parameter url: The URL containing the response code
+    /// - Returns: An optional string containing the autorization code's value
+    private static func parse(url: URL) -> String? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let codeParameter = components.queryItems?.first(where: { $0.name == "code" }) else {
+            return nil
+        }
+        return codeParameter.value
+    }
+}
+
+final class AuthPresentationContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+    
+    private weak var anchor: ASPresentationAnchor?
+    
+    init(anchor: ASPresentationAnchor) {
+        self.anchor = anchor
+    }
+    
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        anchor ?? UIWindow()
+    }
+}

--- a/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
+++ b/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
@@ -8,20 +8,143 @@ import UberCore
 
 public final class AuthorizationCodeAuthProvider: AuthProviding {
     
+    // MARK: Public Properties
+    
+    public let clientID: String
+    
+    public let redirectURI: String
+    
+    public typealias Completion = (Result<Client, UberAuthError>) -> Void
+    
+    public static let defaultScopes = ["profile"]
+
+    // MARK: Private Properties
+
+    private let shouldExchangeAuthCode: Bool
+    
+    var currentSession: AuthenticationSessioning?
+    
+    private let presentationAnchor: ASPresentationAnchor
+    
+    private let pkce = PKCE()
+    
+    private var completion: Completion?
+    
     // MARK: Initializers
     
-    public init() {}
+    public init(presentationAnchor: ASPresentationAnchor = .init(),
+                scopes: [String] = AuthorizationCodeAuthProvider.defaultScopes,
+                shouldExchangeAuthCode: Bool = true,
+                configurationProvider: ConfigurationProviding = PlistParser(plistName: "Info")) {
+                
+        guard let clientID: String = configurationProvider.clientID else {
+            preconditionFailure("No clientID specified in Info.plist")
+        }
+        
+        guard let redirectURI: String = configurationProvider.redirectURI else {
+            preconditionFailure("No redirectURI specified in Info.plist")
+        }
+        
+        self.redirectURI = redirectURI
+        self.clientID = clientID
+        self.presentationAnchor = presentationAnchor
+        self.shouldExchangeAuthCode = shouldExchangeAuthCode
+    }
     
-    // MARK: AutoProviding
+    // MARK: AuthProviding
     
     public func execute(authDestination: AuthDestination,
                         prefill: Prefill?,
-                        completion: @escaping AuthCompletion) {
-        // TODO: Implement
+                        completion: @escaping Completion) {
+        self.completion = completion
+        
+        // TODO: Implement PAR
+        
+        executeLogin(
+            authDestination: authDestination,
+            requestURI: nil,
+            completion: completion
+        )
     }
     
     public func handle(response url: URL) -> Bool {
         // TODO: Implement
         true
+    }
+    
+    // MARK: - Private
+    
+    private func executeLogin(authDestination: AuthDestination,
+                              requestURI: String?,
+                              completion: @escaping Completion) {
+        switch authDestination {
+        case .inApp:
+            executeInAppLogin(
+                requestURI: requestURI,
+                completion: completion
+            )
+        case .native:
+            // TODO: Implement
+            break
+        }
+    }
+    
+    /// Performs login using an embedded browser within the third party client.
+    /// - Parameters:
+    ///   - completion: A closure to handle the login result
+    private func executeInAppLogin(requestURI: String?,
+                                   completion: @escaping Completion) {
+        
+        // Only execute one authentication session at a time
+        guard currentSession == nil else {
+            completion(.failure(.existingAuthSession))
+            return
+        }
+        
+        let request = AuthorizeRequest(
+            type: .url,
+            clientID: clientID,
+            codeChallenge: pkce.codeChallenge,
+            redirectURI: redirectURI,
+            requestURI: requestURI
+        )
+        
+        guard let url = request.url(baseUrl: Constants.baseUrl) else {
+            completion(.failure(.invalidRequest("Invalid base URL")))
+            return
+        }
+        
+        guard let callbackURL = URL(string: redirectURI),
+              let callbackURLScheme = callbackURL.scheme else {
+            completion(.failure(.invalidRequest("Invalid redirect URI")))
+            return
+        }
+        
+        currentSession = AuthenticationSession(
+            anchor: presentationAnchor,
+            callbackURLScheme: callbackURLScheme,
+            url: url,
+            completion: { result in
+                if self.shouldExchangeAuthCode,
+                   case .success(let client) = result,
+                   let code = client.authorizationCode {
+                    // TODO: Exchange auth code here
+                    self.currentSession = nil
+                    return
+                }
+                completion(result)
+                self.currentSession = nil
+            }
+        )
+        
+        currentSession?.start()
+    }
+        
+    // MARK: Constants
+    
+    private enum Constants {
+        static let clientIDKey = "ClientID"
+        static let redirectURI = "RedirectURI"
+        static let baseUrl = "https://auth.uber.com/v2"
     }
 }

--- a/Sources/UberAuth/Authorize/AuthorizeRequest.swift
+++ b/Sources/UberAuth/Authorize/AuthorizeRequest.swift
@@ -1,0 +1,77 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+import Foundation
+
+struct AuthorizeRequest: Request {
+    
+    // MARK: Properties
+    
+    let host: String?
+    let path: String
+    
+    // MARK: Private Properties
+    
+    private let codeChallenge: String
+    private let clientID: String
+    private let redirectURI: String
+    private let requestURI: String?
+    
+    // MARK: Initializers
+    
+    init(type: LinkType,
+         clientID: String,
+         codeChallenge: String,
+         redirectURI: String,
+         requestURI: String?) {
+        self.host = type.host
+        self.path = type.path
+        self.clientID = clientID
+        self.codeChallenge = codeChallenge
+        self.redirectURI = redirectURI
+        self.requestURI = requestURI
+    }
+    
+    // MARK: Request
+    
+    struct Response: Codable {}
+    
+    var parameters: [String : String]? {
+        [
+            "response_type": "code",
+            "client_id": clientID,
+            "code_challenge": codeChallenge,
+            "code_challenge_method": "S256",
+            "redirect_uri": redirectURI,
+            "request_uri": requestURI
+        ]
+        .compactMapValues { $0 }
+    }
+    
+    // MARK: LinkType
+    
+    enum LinkType {
+        case url
+        case deeplink
+        
+        var host: String? {
+            switch self {
+            case .url:
+                return nil
+            case .deeplink:
+                return "authorize"
+            }
+        }
+        
+        var path: String {
+            switch self {
+            case .url:
+                return "/oauth/v2/authorize"
+            case .deeplink:
+                return ""
+            }
+        }
+    }
+}

--- a/Sources/UberAuth/Authorize/PKCE.swift
+++ b/Sources/UberAuth/Authorize/PKCE.swift
@@ -1,0 +1,53 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+import CommonCrypto
+import Foundation
+
+public struct PKCE {
+
+    public let codeVerifier: String
+    public let codeChallenge: String
+
+    public init() {
+        let pkce = PKCE.generatePKCE()
+        self.codeVerifier = pkce.codeVerifier
+        self.codeChallenge = pkce.codeChallenge
+    }
+
+    static func generatePKCE() -> (codeChallenge: String, codeVerifier: String) {
+        let charDictCodeVerifer: [Character: Character] = ["+": "-", "/": "-", "=": "-"]
+        let charDictCodeChallenge: [Character: Character] = ["+": "-", "/": "_", "=": " "]
+
+        var buffer1 = [UInt8](repeating: 0, count: 64)
+        _ = SecRandomCopyBytes(kSecRandomDefault, buffer1.count, &buffer1)
+        let codeVerifierData = Data(buffer1)
+        let codeVerifier = codeVerifierData.convertToStringByReplacingCharacters(dict: charDictCodeVerifer)
+
+        guard let codeVerifierBytes = codeVerifier.data(using: .ascii) else { return ("", "") }
+        var buffer2 = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        codeVerifierBytes.withUnsafeBytes {
+            _ = CC_SHA256($0.baseAddress, CC_LONG(codeVerifierBytes.count), &buffer2)
+        }
+
+        let codeChallengeData = Data(buffer2)
+        let codeChallenge = codeChallengeData.convertToStringByReplacingCharacters(dict: charDictCodeChallenge)
+        return (codeChallenge, codeVerifier)
+
+    }
+}
+
+fileprivate extension Data {
+    func convertToStringByReplacingCharacters(dict: [Character: Character]) -> String {
+        let string = self.base64EncodedString()
+        let stringArray: [Character] = string.map {
+            guard let val = dict[$0] else {
+                return $0
+            }
+            return val
+        }
+        return String(stringArray).trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/Sources/UberAuth/Client.swift
+++ b/Sources/UberAuth/Client.swift
@@ -37,3 +37,17 @@ public struct Client: Equatable {
         self.scope = scope
     }
 }
+
+extension Client: CustomStringConvertible {
+    
+    public var description: String {
+        return """
+        Authorization Code: \(authorizationCode ?? "nil")
+        Access Token: \(accessToken ?? "nil")
+        Refresh Token: \(refreshToken ?? "nil")
+        Token Type: \(tokenType ?? "nil")
+        Expires In: \(expiresIn ?? -1)
+        Scopes: \(scope?.joined(separator: ", ") ?? "nil")
+        """
+    }
+}

--- a/Sources/UberAuth/Errors/UberAuthError.swift
+++ b/Sources/UberAuth/Errors/UberAuthError.swift
@@ -13,11 +13,14 @@ public enum UberAuthError: Error {
     // The application failed to open the Uber client app
     case couldNotOpenApp(UberApp)
     
+    // An existing authentication session is in progress
+    case existingAuthSession
+    
     // The auth code was not found or is malformed
     case invalidAuthCode
     
     // Failed to build the auth request
-    case invalidRequest
+    case invalidRequest(String)
     
     // An OAuth standard error occurred
     case oAuth(OAuthError)
@@ -39,12 +42,14 @@ extension UberAuthError: LocalizedError {
             return "The user cancelled the auth flow"
         case .couldNotOpenApp(let uberApp):
             return "The application failed to open the Uber client app: \(uberApp)"
+        case .existingAuthSession:
+            return "An existing authentication session is in progress"
         case .invalidAuthCode:
             return "The auth code was not found or is malformed"
-        case .invalidRequest:
-            return "Failed to build the auth request"
         case .oAuth(let error):
             return error.errorDescription
+        case .invalidRequest(let details):
+            return "Failed to build the auth request: \(details)"
         case .other(let error):
             return "An unknown error occurred: \(error)"
         case .serviceError:

--- a/Sources/UberAuth/Networking/Request.swift
+++ b/Sources/UberAuth/Networking/Request.swift
@@ -1,0 +1,91 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+import Foundation
+
+protocol Request {
+    
+    associatedtype Response: Codable
+    
+    var body: [String: String]? { get }
+    var contentType: String? { get }
+    var headers: [String: String]? { get }
+    var host: String? { get }
+    var method: HTTPMethod { get }
+    var parameters: [String: String]? { get }
+    var path: String { get }
+    var scheme: String? { get }
+}
+
+extension Request {
+    
+    var contentType: String? { nil }
+    var body: [String: String]? { nil }
+    var headers: [String: String]? { nil }
+    var host: String? { nil }
+    var method: HTTPMethod { .get }
+    var parameters: [String: String]? { nil }
+    var scheme: String? { nil }
+}
+
+extension Request {
+    
+    func url(baseUrl: String) -> URL? {
+        urlRequest(baseUrl: baseUrl)?.url
+    }
+    
+    func urlRequest(baseUrl: String) -> URLRequest? {
+        guard var components = URLComponents(string: baseUrl) else {
+            return nil
+        }
+        
+        if let host {
+            components.host = host
+        }
+        if let scheme {
+            components.scheme = scheme
+        }
+        components.path = path
+        components.queryItems = parameters?.map { (name, value) in
+            URLQueryItem(name: name, value: value)
+        }
+        
+        guard let url = components.url else {
+            return nil
+        }
+        
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = method.rawValue
+        
+        // Headers
+        urlRequest.allHTTPHeaderFields = {
+            let defaultHeaders = [
+                "Accept-Encoding": "gzip, deflate",
+                "Content-Type": contentType
+            ]
+            .compactMapValues { $0 }
+            
+            return defaultHeaders
+                .merging(
+                    headers ?? [:],
+                    uniquingKeysWith: { h1, h2 in h1 }
+                )
+        }()
+        
+        // Body
+        urlRequest.httpBody = {
+            var components = URLComponents()
+            components.queryItems = body?.map { URLQueryItem(name: $0.key, value: $0.value) }
+            return components.query?.data(using: .utf8)
+        }()
+        
+        return urlRequest
+    }
+}
+
+enum HTTPMethod: String {
+    case get = "GET"
+    case post = "POST"
+}

--- a/Sources/UberAuth/Utilities/PlistParser.swift
+++ b/Sources/UberAuth/Utilities/PlistParser.swift
@@ -1,0 +1,83 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+import Foundation
+
+/// @mockable
+public protocol ConfigurationProviding {
+    var clientID: String? { get }
+    var redirectURI: String? { get }
+}
+
+public struct PlistParser {
+    
+    private let dict: [String: Any]
+    
+    /// A non-throwing initializer. Any invalid parameters will result in 
+    /// empty storage and all keys will return nil.
+    /// All keys are checked against the `UberAuth` object contained in the plist.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the plist to access
+    ///   - bundle: The bundle the plist is contained in
+    public init(plistName: String,
+         bundle: Bundle = .main) {
+        guard let plistUrl = bundle.url(forResource: plistName, withExtension: "plist") else {
+            self.dict = [:]
+            return
+        }
+        
+        guard let contents = try? NSDictionary(contentsOf: plistUrl, error: ()),
+              let dict = contents["UberAuth"] as? Dictionary<String, Any> else {
+            self.dict = [:]
+            return
+        }
+        
+        self.dict = dict
+    }
+    
+    /// A throwing initializer. Any invalid parameters will result in
+    /// a thrown ParserError indicating the failure.
+    /// All keys are checked against the `UberAuth` object contained in the plist.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the plist to access
+    ///   - bundle: The bundle the plist is contained in
+    public init(name: String,
+         bundle: Bundle = .main) throws {
+        guard let plistUrl = bundle.url(forResource: name, withExtension: "plist") else {
+            throw ParserError.noResourceFound
+        }
+        let contents = try NSDictionary(contentsOf: plistUrl, error: ())
+        guard let dict = contents["UberAuth"] as? Dictionary<String, Any> else {
+            throw ParserError.missingContents
+        }
+        self.dict = dict
+    }
+    
+    public subscript<T>(key: String) -> T? {
+        dict[key] as? T
+    }
+    
+    public enum ParserError: Error {
+        
+        // A plist with the supplied name was not found
+        case noResourceFound
+        
+        // An `UberAuth` object was not found in the plist
+        case missingContents
+    }
+}
+
+extension PlistParser: ConfigurationProviding {
+    
+    public var clientID: String? {
+        self["ClientID"]
+    }
+    
+    public var redirectURI: String? {
+        self["RedirectURI"]
+    }
+}

--- a/examples/UberSDK/UberSDK.xcodeproj/project.pbxproj
+++ b/examples/UberSDK/UberSDK.xcodeproj/project.pbxproj
@@ -8,8 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		B28217C82B97A2E400EE786D /* AuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28217C72B97A2E400EE786D /* AuthManagerTests.swift */; };
+		B28CDD322BA403A900EB1BBD /* AuthorizationCodeAuthProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28CDD312BA403A900EB1BBD /* AuthorizationCodeAuthProviderTests.swift */; };
+		B28CDD342BA4BE2100EB1BBD /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28CDD332BA4BE2100EB1BBD /* RequestTests.swift */; };
+		B28CDD362BA4C6CA00EB1BBD /* AuthorizeRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28CDD352BA4C6CA00EB1BBD /* AuthorizeRequestTests.swift */; };
 		B2D096932B97B8E70093B510 /* UberAuthMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D096922B97B8E70093B510 /* UberAuthMocks.swift */; };
 		B2D096952B97C4A00093B510 /* UberAuthErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D096942B97C4A00093B510 /* UberAuthErrorTests.swift */; };
+		B2D0969A2B98012A0093B510 /* SelectionOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D096992B98012A0093B510 /* SelectionOptions.swift */; };
 		B2D7AE1C2B979EDA007F03FB /* UberSDKApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D7AE1B2B979EDA007F03FB /* UberSDKApp.swift */; };
 		B2D7AE1E2B979EDA007F03FB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D7AE1D2B979EDA007F03FB /* ContentView.swift */; };
 		B2D7AE202B979EDB007F03FB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B2D7AE1F2B979EDB007F03FB /* Assets.xcassets */; };
@@ -42,10 +46,15 @@
 
 /* Begin PBXFileReference section */
 		B28217C72B97A2E400EE786D /* AuthManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManagerTests.swift; sourceTree = "<group>"; };
+		B28CDD312BA403A900EB1BBD /* AuthorizationCodeAuthProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationCodeAuthProviderTests.swift; sourceTree = "<group>"; };
+		B28CDD332BA4BE2100EB1BBD /* RequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
+		B28CDD352BA4C6CA00EB1BBD /* AuthorizeRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizeRequestTests.swift; sourceTree = "<group>"; };
 		B29303D62B891D3E00D28BAA /* SelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionView.swift; sourceTree = "<group>"; };
 		B29303D82B89408D00D28BAA /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		B2D096922B97B8E70093B510 /* UberAuthMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UberAuthMocks.swift; sourceTree = "<group>"; };
 		B2D096942B97C4A00093B510 /* UberAuthErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UberAuthErrorTests.swift; sourceTree = "<group>"; };
+		B2D096982B9800020093B510 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		B2D096992B98012A0093B510 /* SelectionOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectionOptions.swift; sourceTree = "<group>"; };
 		B2D7AE192B979EDA007F03FB /* UberSDK.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UberSDK.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2D7AE1B2B979EDA007F03FB /* UberSDKApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UberSDKApp.swift; sourceTree = "<group>"; };
 		B2D7AE1D2B979EDA007F03FB /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -89,6 +98,9 @@
 			isa = PBXGroup;
 			children = (
 				B28217C72B97A2E400EE786D /* AuthManagerTests.swift */,
+				B28CDD312BA403A900EB1BBD /* AuthorizationCodeAuthProviderTests.swift */,
+				B28CDD352BA4C6CA00EB1BBD /* AuthorizeRequestTests.swift */,
+				B28CDD332BA4BE2100EB1BBD /* RequestTests.swift */,
 				B2D096942B97C4A00093B510 /* UberAuthErrorTests.swift */,
 			);
 			path = UberAuth;
@@ -125,10 +137,12 @@
 		B2D7AE1A2B979EDA007F03FB /* UberSDK */ = {
 			isa = PBXGroup;
 			children = (
+				B2D096982B9800020093B510 /* Info.plist */,
 				B2D7AE1B2B979EDA007F03FB /* UberSDKApp.swift */,
 				B29303D62B891D3E00D28BAA /* SelectionView.swift */,
 				B29303D82B89408D00D28BAA /* Helpers.swift */,
 				B2D7AE1D2B979EDA007F03FB /* ContentView.swift */,
+				B2D096992B98012A0093B510 /* SelectionOptions.swift */,
 				B2D7AE1F2B979EDB007F03FB /* Assets.xcassets */,
 				B2D7AE212B979EDB007F03FB /* Preview Content */,
 			);
@@ -302,6 +316,7 @@
 				B2D7AE1E2B979EDA007F03FB /* ContentView.swift in Sources */,
 				B2D7AE1C2B979EDA007F03FB /* UberSDKApp.swift in Sources */,
 				B2D7AE492B979F58007F03FB /* SelectionView.swift in Sources */,
+				B2D0969A2B98012A0093B510 /* SelectionOptions.swift in Sources */,
 				B2D7AE4A2B979F5D007F03FB /* Helpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -310,9 +325,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B28CDD342BA4BE2100EB1BBD /* RequestTests.swift in Sources */,
 				B2D096952B97C4A00093B510 /* UberAuthErrorTests.swift in Sources */,
 				B28217C82B97A2E400EE786D /* AuthManagerTests.swift in Sources */,
+				B28CDD362BA4C6CA00EB1BBD /* AuthorizeRequestTests.swift in Sources */,
 				B2D096932B97B8E70093B510 /* UberAuthMocks.swift in Sources */,
+				B28CDD322BA403A900EB1BBD /* AuthorizationCodeAuthProviderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -471,6 +489,7 @@
 				DEVELOPMENT_TEAM = 5F83KRY2FH;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = UberSDK/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -501,6 +520,7 @@
 				DEVELOPMENT_TEAM = 5F83KRY2FH;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = UberSDK/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/examples/UberSDK/UberSDK/Info.plist
+++ b/examples/UberSDK/UberSDK/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UberAuth</key>
+	<dict>
+		<key>ClientID</key>
+		<string>&lt;Client ID&gt;</string>
+		<key>RedirectURI</key>
+		<string>&lt;Redirect URI&gt;</string>
+	</dict>
+</dict>
+</plist>

--- a/examples/UberSDK/UberSDK/SelectionOptions.swift
+++ b/examples/UberSDK/UberSDK/SelectionOptions.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+import Foundation
+import UberAuth
+
+enum LoginType: String, CaseIterable, SelectionOption {
+    case authorizationCode = "Authorization Code"
+
+    var description: String { rawValue }
+    var id: String { rawValue }
+}
+
+enum LoginDestination: String, CaseIterable, SelectionOption {
+    case inApp = "In App"
+    case native = "Native"    
+    
+    var description: String { rawValue }
+    var id: String { rawValue }
+}

--- a/examples/UberSDK/UberSDK/SelectionView.swift
+++ b/examples/UberSDK/UberSDK/SelectionView.swift
@@ -6,7 +6,9 @@
 import Foundation
 import SwiftUI
 
-struct SelectionView<Value: Hashable & Identifiable & CustomStringConvertible>: View {
+typealias SelectionOption = Hashable & Identifiable & CustomStringConvertible
+
+struct SelectionView<Value: SelectionOption>: View {
     
     @Environment(\.dismiss) var dismiss: DismissAction
     

--- a/examples/UberSDK/UberSDKTests/Mocks/UberAuthMocks.swift
+++ b/examples/UberSDK/UberSDKTests/Mocks/UberAuthMocks.swift
@@ -6,10 +6,49 @@
 
 import AuthenticationServices
 import Foundation
-import UIKit
-import UberCore
 @testable import UberAuth
+import UberCore
 
+
+public class ConfigurationProvidingMock: ConfigurationProviding {
+    public init() { }
+    public init(clientID: String? = nil, redirectURI: String? = nil) {
+        self.clientID = clientID
+        self.redirectURI = redirectURI
+    }
+
+
+    public private(set) var clientIDSetCallCount = 0
+    public var clientID: String? = nil { didSet { clientIDSetCallCount += 1 } }
+
+    public private(set) var redirectURISetCallCount = 0
+    public var redirectURI: String? = nil { didSet { redirectURISetCallCount += 1 } }
+}
+
+class AuthenticationSessioningMock: AuthenticationSessioning {
+        private var _anchor: ASPresentationAnchor!
+    private var _callbackURLScheme: String!
+    private var _completion: AuthCompletion!
+    private var _url: URL!
+    init() { }
+    required init(anchor: ASPresentationAnchor, callbackURLScheme: String = "", url: URL = URL(fileURLWithPath: ""), completion: @escaping AuthCompletion) {
+        self._anchor = anchor
+        self._callbackURLScheme = callbackURLScheme
+        self._url = url
+        self._completion = completion
+    }
+
+
+    private(set) var startCallCount = 0
+    var startHandler: (() -> ())?
+    func start()  {
+        startCallCount += 1
+        if let startHandler = startHandler {
+            startHandler()
+        }
+        
+    }
+}
 
 public class AuthProvidingMock: AuthProviding {
     public init() { }

--- a/examples/UberSDK/UberSDKTests/UberAuth/AuthorizationCodeAuthProviderTests.swift
+++ b/examples/UberSDK/UberSDKTests/UberAuth/AuthorizationCodeAuthProviderTests.swift
@@ -1,0 +1,99 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+@testable import UberAuth
+import XCTest
+
+final class AuthorizationCodeAuthProviderTests: XCTestCase {
+
+    func test_executeInAppLogin_createsAuthenticationSession() {
+        
+        let provider = AuthorizationCodeAuthProvider()
+                
+        XCTAssertNil(provider.currentSession)
+        
+        provider.execute(
+            authDestination: .inApp,
+            prefill: nil,
+            completion: { _ in }
+        )
+        
+        XCTAssertNotNil(provider.currentSession)
+    }
+    
+    func test_executeInAppLogin_existingSessionBlocksRequest() {
+        
+        let provider = AuthorizationCodeAuthProvider()
+        
+        let authSession = AuthenticationSessioningMock()
+        provider.currentSession = authSession
+        
+        XCTAssertEqual(authSession.startCallCount, 0)
+        
+        provider.execute(
+            authDestination: .inApp,
+            prefill: nil,
+            completion: { _ in }
+        )
+        
+        XCTAssertEqual(authSession.startCallCount, 0)
+    }
+
+    func test_execute_existingSession_returnsExistingAuthSessionError() {
+        let provider = AuthorizationCodeAuthProvider()
+        
+        provider.execute(
+            authDestination: .inApp,
+            prefill: nil,
+            completion: { _ in }
+        )
+        
+        let expectation = XCTestExpectation()
+        
+        provider.execute(
+            authDestination: .inApp,
+            prefill: nil,
+            completion: { result in
+                switch result {
+                case .failure(.existingAuthSession):
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+        )
+        
+        wait(for: [expectation], timeout: 0.1)
+    }
+    
+    func test_invalidRedirectURI_returnsInvalidRequestError() {
+        
+        let configurationProvider = ConfigurationProvidingMock(
+            clientID: "",
+            redirectURI: "uber"
+        )
+        
+        let provider = AuthorizationCodeAuthProvider(
+            configurationProvider: configurationProvider
+        )
+        
+        let expectation = XCTestExpectation()
+        
+        provider.execute(
+            authDestination: .inApp,
+            prefill: nil,
+            completion: { result in
+                switch result {
+                case .failure(.invalidRequest):
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+        )
+        
+        wait(for: [expectation], timeout: 0.1)
+    }
+}

--- a/examples/UberSDK/UberSDKTests/UberAuth/AuthorizeRequestTests.swift
+++ b/examples/UberSDK/UberSDKTests/UberAuth/AuthorizeRequestTests.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+@testable import UberAuth
+import XCTest
+
+final class AuthorizeRequestTests: XCTestCase {
+
+    func test_generatedUrl() {
+        
+        let request = AuthorizeRequest(
+            type: .url,
+            clientID: "test_client_id",
+            codeChallenge: "code_challenge",
+            redirectURI: "redirect_uri",
+            requestURI: "request_url"
+        )
+        
+        let urlRequest = request.urlRequest(baseUrl: "https://auth.uber.com")!
+        let url = urlRequest.url!
+        
+        XCTAssertEqual(url.host(), "auth.uber.com")
+        XCTAssertEqual(url.scheme, "https")
+        XCTAssertTrue(url.query()!.contains("response_type=code"))
+        XCTAssertTrue(url.query()!.contains("client_id=test_client_id"))
+        XCTAssertTrue(url.query()!.contains("code_challenge=code_challenge"))
+        XCTAssertTrue(url.query()!.contains("request_uri=request_url"))
+        XCTAssertTrue(url.query()!.contains("code_challenge_method=S256"))
+        XCTAssertTrue(url.query()!.contains("redirect_uri=redirect_uri"))
+    }
+    
+    func test_generatedUrl_deeplink() {
+        
+        let request = AuthorizeRequest(
+            type: .deeplink,
+            clientID: "test_client_id",
+            codeChallenge: "code_challenge",
+            redirectURI: "redirect_uri",
+            requestURI: "request_url"
+        )
+        
+        let urlRequest = request.urlRequest(baseUrl: "uber://")!
+        let url = urlRequest.url!
+        
+        XCTAssertEqual(url.host(), "authorize")
+        XCTAssertEqual(url.scheme, "uber")
+        XCTAssertTrue(url.query()!.contains("response_type=code"))
+        XCTAssertTrue(url.query()!.contains("client_id=test_client_id"))
+        XCTAssertTrue(url.query()!.contains("code_challenge=code_challenge"))
+        XCTAssertTrue(url.query()!.contains("request_uri=request_url"))
+        XCTAssertTrue(url.query()!.contains("code_challenge_method=S256"))
+        XCTAssertTrue(url.query()!.contains("redirect_uri=redirect_uri"))
+    }
+
+}

--- a/examples/UberSDK/UberSDKTests/UberAuth/RequestTests.swift
+++ b/examples/UberSDK/UberSDKTests/UberAuth/RequestTests.swift
@@ -1,0 +1,102 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+@testable import UberAuth
+import XCTest
+
+final class RequestTests: XCTestCase {
+
+    func test_invalidBaseUrl_returnsNil() {
+        XCTAssertNil(
+            TestRequest().url(baseUrl: "http://auth.uber.com:-80/")
+        )
+    }
+    
+    func test_validUrlWithHost() {
+        let request = TestRequest(
+            contentType: "content-type",
+            host: "auth.uber.com",
+            method: .get,
+            parameters: [
+                "key": "value"
+            ], 
+            path: "/test-path",
+            scheme: "https"
+        )
+        
+        XCTAssertEqual(
+            request.url(baseUrl: "auth.uber.com")!.absoluteString,
+            "https://auth.uber.com/test-path?key=value"
+        )
+    }
+    
+    func test_validUrlWithoutHost() {
+        let request = TestRequest(
+            contentType: "content-type",
+            method: .get,
+            parameters: [
+                "key": "value"
+            ],
+            path: "/test-path"
+        )
+        
+        XCTAssertEqual(
+            request.url(baseUrl: "https://auth.uber.com")!.absoluteString,
+            "https://auth.uber.com/test-path?key=value"
+        )
+    }
+    
+    func test_urlRequest_containsCustomAndDefaultHeaders() {
+        let request = TestRequest(
+            contentType: "test_content_type",
+            headers: [
+                "header_key": "header_value"
+            ]
+        )
+        
+        let urlRequest = request.urlRequest(baseUrl: "auth.uber.com")
+        let headers = urlRequest!.allHTTPHeaderFields!
+        
+        XCTAssertEqual(
+            headers["header_key"]!,
+            "header_value"
+        )
+        
+        XCTAssertEqual(
+            headers["Accept-Encoding"]!,
+            "gzip, deflate"
+        )
+        
+        XCTAssertEqual(
+            headers["Content-Type"]!,
+            "test_content_type"
+        )
+    }
+    
+    func test_urlRequest_containsBody() {
+        
+        let body = [
+            "body_key": "body_value"
+        ]
+        
+        let request = TestRequest(body: body)
+        let urlRequest = request.urlRequest(baseUrl: "auth.uber.com")
+
+        XCTAssertNotNil(urlRequest?.httpBody)
+    }
+    
+    fileprivate struct TestRequest: Request {
+        var body: [String: String]? = nil
+        var contentType: String? = nil
+        var headers: [String: String]? = nil
+        var host: String? = nil
+        var method: HTTPMethod = .get
+        var parameters: [String: String]? = nil
+        var path: String = ""
+        var scheme: String? = nil
+        
+        struct Response: Codable {}
+    }
+}


### PR DESCRIPTION
## Description
This PR adds support for the auth code grant flow via In App login.
This will allow integrators to request an authorization code via Uber through ASWebAuthenticationSession only (native coming in the next PR).

### AuthorizeRequest / Request
Added a request class that is specific to auth related requests. This will also be used for PAR and any other auth types in the future.
There is an existing Request class in UberCore, however it is primarily used for Rides requests which may be stripped in the future.

### AuthenticationSession
A wrapper around ASWebAuthenticationSession to make launching and handling the result easier.

### AuthorizationCodeAuthProvider
The main logic for the auth code grant flow. This class will be responsible for fetching request dependencies and making the network request to Uber auth.
Eventually it will also manage initiating native login and exchanging auth code for tokens.

### PlistParser
A helper class to fetch values from the Info.plist

## Testing
### Sample App
The sample app has been updated to allow testing the new flow. To do so you will need to set a test ClientID and Redirect URL in the Info.plist of the sample app. You can use the following values:

| ClientID | RedirectURI |
|--|--|
| 9QZcD_Ki6NbhGCrVXSUHCxfevm-C9Khj | com.uber.UberSDK://oauth/consumer |

### Unit tests
Unit tests were added for all logic heavy classes minus AuthenticationSession. ASWebAuthenticationSession is not easily testable. I will add partial testing to this class later on.

### Video
https://github.com/uber/rides-ios-sdk/assets/5241321/51da7b6f-066f-45ec-a8d9-2972967d5cbd
