### PR TITLE
Add scope support, Fix TokenRequest

### DIFF
--- a/Sources/UberAuth/Authorize/AuthorizeRequest.swift
+++ b/Sources/UberAuth/Authorize/AuthorizeRequest.swift
@@ -19,6 +19,7 @@ struct AuthorizeRequest: NetworkRequest {
     private let clientID: String
     private let redirectURI: String
     private let requestURI: String?
+    private let scopes: [String]
     
     // MARK: Initializers
     
@@ -26,12 +27,14 @@ struct AuthorizeRequest: NetworkRequest {
          clientID: String,
          codeChallenge: String,
          redirectURI: String,
-         requestURI: String?) {
+         requestURI: String?,
+         scopes: [String] = []) {
         self.app = app
         self.clientID = clientID
         self.codeChallenge = codeChallenge
         self.redirectURI = redirectURI
         self.requestURI = requestURI
+        self.scopes = scopes
     }
     
     // MARK: Request
@@ -45,7 +48,8 @@ struct AuthorizeRequest: NetworkRequest {
             "code_challenge": codeChallenge,
             "code_challenge_method": "S256",
             "redirect_uri": redirectURI,
-            "request_uri": requestURI
+            "request_uri": requestURI,
+            "scope": scopes.joined(separator: " ")
         ]
         .compactMapValues { $0 }
     }

--- a/Sources/UberAuth/Token/TokenRequest.swift
+++ b/Sources/UberAuth/Token/TokenRequest.swift
@@ -42,7 +42,7 @@ struct TokenRequest: NetworkRequest {
     
     typealias Response = AccessToken
     
-    var parameters: [String : String]? {
+    var body: [String : String]? {
         [
             "code": authorizationCode,
             "client_id": clientID,


### PR DESCRIPTION
## Description
Combining a few minor fixes for bugs found in UberAuth. Details below.

## Changes
### Scopes
Scopes were not being sent in the Authorize request, only the default scope was being used in all cases. This PR adds logic to inject the scopes passed in the AuthContext into the authorize request and on to the backend.

### Application Launcher
There were certain scenarios where the ApplicationLauncher, a protocol representing UIApplication's openURL, could be called from a background thread. This wraps the only openURL call to ensure it is made from the main thread.
To support this change in testing, a closure can now be passed in to AuthorizationCodeAuthProvider allowing us to specify the AuthorizationSession to be used when launching in app auth.

### TokenRequest body
We were incorrectly setting the form url encoded body for the TokenRequest as the url parameters, and it was somehow still working. This PR fixes this by setting the values in the httpBody instead.