### PR TITLE
Adds Bundle utility

### DIFF
--- a/Sources/UberAuth/Button/LoginButton.swift
+++ b/Sources/UberAuth/Button/LoginButton.swift
@@ -94,7 +94,7 @@ public final class LoginButton: UberButton {
     override public var image: UIImage? {
         UIImage(
             named: "uber_logo_white",
-            in: .module,
+            in: .resource(for: LoginButton.self),
             compatibleWith: nil
         )?.withRenderingMode(.alwaysTemplate)
     }
@@ -145,14 +145,14 @@ public final class LoginButton: UberButton {
             case .loggedIn:
                 return NSLocalizedString(
                     "Sign Out",
-                    bundle: .module,
+                    bundle: .resource(for: LoginButton.self),
                     comment: "Login Button Sign Out Description"
                 )
                 .uppercased()
             case .loggedOut:
                 return NSLocalizedString(
                     "Sign In",
-                    bundle: .module,
+                    bundle: .resource(for: LoginButton.self),
                     comment: "Login Button Sign In Description"
                 )
                 .uppercased()

--- a/Sources/UberAuth/Utilities/Bundle.swift
+++ b/Sources/UberAuth/Utilities/Bundle.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+import Foundation
+
+extension Bundle {
+    
+    static func resource(for targetClass: AnyClass?) -> Bundle {
+#if SWIFT_PACKAGE
+        return .module
+#endif
+        if let targetClass {
+            return Bundle(for: targetClass)
+        }
+        return .main
+    }
+}

--- a/Sources/UberCore/Colors.swift
+++ b/Sources/UberCore/Colors.swift
@@ -9,19 +9,19 @@ extension UIColor {
     
     static let uberButtonBackground: UIColor = UIColor(
         named: "UberButtonBackground",
-        in: .module,
+        in: .resource(for: UberButton.self),
         compatibleWith: nil
     ) ?? UIColor.darkText
     
     static let uberButtonHighlightedBackground: UIColor = UIColor(
         named: "UberButtonHighlightedBackground",
-        in: .module,
+        in: .resource(for: UberButton.self),
         compatibleWith: nil
     ) ?? UIColor.darkText
     
     static let uberButtonForeground: UIColor = UIColor(
         named: "UberButtonForeground",
-        in: .module,
+        in: .resource(for: UberButton.self),
         compatibleWith: nil
     ) ?? UIColor.lightText
 }

--- a/Sources/UberCore/Utilities/Bundle.swift
+++ b/Sources/UberCore/Utilities/Bundle.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+import Foundation
+
+extension Bundle {
+    
+    static func resource(for targetClass: AnyClass?) -> Bundle {
+#if SWIFT_PACKAGE
+        return .module
+#endif
+        if let targetClass {
+            return Bundle(for: targetClass)
+        }
+        return .main
+    }
+}

--- a/Sources/UberRides/RideRequestButton.swift
+++ b/Sources/UberRides/RideRequestButton.swift
@@ -466,7 +466,7 @@ public class RideRequestButton: UberButton_DEPRECATED {
     
     // get image from media directory
     private func getImage(name: String) -> UIImage {
-        let image = UIImage(named: name, in: Bundle.module, compatibleWith: nil)
+        let image = UIImage(named: name, in: .resource(for: RideRequestButton.self), compatibleWith: nil)
         return image!
     }
 }

--- a/Sources/UberRides/RidesCore/Utilities/Bundle.swift
+++ b/Sources/UberRides/RidesCore/Utilities/Bundle.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+import Foundation
+
+extension Bundle {
+    
+    static func resource(for targetClass: AnyClass?) -> Bundle {
+#if SWIFT_PACKAGE
+        return .module
+#endif
+        if let targetClass {
+            return Bundle(for: targetClass)
+        }
+        return .main
+    }
+}


### PR DESCRIPTION
With the introduction of Swift PM support, we started referencing bundles using Bundle.main. This breaks integration for anyone building manually or wrapping in a Cocoapods Podspec.
This change adds Bundle utilities to each framework that will select the correct bundle to load resources from. It will check the runtime argument SWIFT_PACKAGE to determine if we are in a Swift Package and use Bundle.module if so. Otherwise, it will target the bundle by class.