### PR TITLE
Limit code_challenge to shouldExchangeAuthCode only

### DIFF
--- a/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
+++ b/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
@@ -194,7 +194,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         let request = AuthorizeRequest(
             app: nil,
             clientID: clientID,
-            codeChallenge: pkce.codeChallenge,
+            codeChallenge: shouldExchangeAuthCode ? pkce.codeChallenge : nil,
             redirectURI: redirectURI,
             requestURI: requestURI,
             scopes: scopes
@@ -297,7 +297,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         let request = AuthorizeRequest(
             app: app,
             clientID: clientID,
-            codeChallenge: pkce.codeChallenge,
+            codeChallenge: shouldExchangeAuthCode ? pkce.codeChallenge : nil,
             redirectURI: redirectURI,
             requestURI: requestURI,
             scopes: scopes

--- a/Sources/UberAuth/Authorize/AuthorizeRequest.swift
+++ b/Sources/UberAuth/Authorize/AuthorizeRequest.swift
@@ -15,7 +15,7 @@ struct AuthorizeRequest: NetworkRequest {
     // MARK: Private Properties
     
     private let app: UberApp?
-    private let codeChallenge: String
+    private let codeChallenge: String?
     private let clientID: String
     private let redirectURI: String
     private let requestURI: String?
@@ -25,7 +25,7 @@ struct AuthorizeRequest: NetworkRequest {
     
     init(app: UberApp?,
          clientID: String,
-         codeChallenge: String,
+         codeChallenge: String?,
          redirectURI: String,
          requestURI: String?,
          scopes: [String] = []) {
@@ -46,7 +46,7 @@ struct AuthorizeRequest: NetworkRequest {
             "response_type": "code",
             "client_id": clientID,
             "code_challenge": codeChallenge,
-            "code_challenge_method": "S256",
+            "code_challenge_method": codeChallenge != nil ? "S256" : nil,
             "redirect_uri": redirectURI,
             "request_uri": requestURI,
             "scope": scopes.joined(separator: " ")


### PR DESCRIPTION
## Description
This PR fixes a bug where we send code_challenge in the authorize request when we shouldn't be. We should only be sending a codeChallenge to the authorize endpoint in cases where we want to exchange auth code for auth token on device.

## Changes
* Made AuthorizeRequest's `codeChallenge` property optional
* Changed AuthorizeRequest's payload to only set `code_challenge_method` if `codeChallenge` is non-nil
* From AuthorizationCodeAuthProvider, only send pace.codeChallenge if `shouldExchangeAuthCode` is true

## Testing
* Added unit tests to verify `code_challenge` and `code_challenge_method` are not being sent for both inApp and native login destinations