### PR TITLE
Implement prompt for re-login/consent

### DIFF
--- a/Sources/UberAuth/AuthProviding.swift
+++ b/Sources/UberAuth/AuthProviding.swift
@@ -20,11 +20,13 @@ extension AuthProviding where Self == AuthorizationCodeAuthProvider {
     
     public static func authorizationCode(presentationAnchor: ASPresentationAnchor = .init(),
                                          scopes: [String] = AuthorizationCodeAuthProvider.defaultScopes,
-                                         shouldExchangeAuthCode: Bool = true) -> Self {
+                                         shouldExchangeAuthCode: Bool = true,
+                                         prompt: Prompt? = nil) -> Self {
         AuthorizationCodeAuthProvider(
             presentationAnchor: presentationAnchor,
             scopes: scopes,
-            shouldExchangeAuthCode: shouldExchangeAuthCode
+            shouldExchangeAuthCode: shouldExchangeAuthCode,
+            prompt: prompt
         )
     }
 }

--- a/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
+++ b/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
@@ -48,11 +48,14 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
     
     private let scopes: [String]
     
+    private let prompt: Prompt?
+    
     // MARK: Initializers
     
     public init(presentationAnchor: ASPresentationAnchor = .init(),
                 scopes: [String] = AuthorizationCodeAuthProvider.defaultScopes,
-                shouldExchangeAuthCode: Bool = false) {
+                shouldExchangeAuthCode: Bool = false,
+                prompt: Prompt? = nil) {
         self.configurationProvider = DefaultConfigurationProvider()
         
         guard let clientID: String = configurationProvider.clientID else {
@@ -73,11 +76,13 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         self.networkProvider = NetworkProvider(baseUrl: Constants.baseUrl)
         self.tokenManager = TokenManager()
         self.scopes = scopes
+        self.prompt = prompt
     }
     
     init(presentationAnchor: ASPresentationAnchor = .init(),
          authenticationSessionBuilder: AuthenticationSessionBuilder? = nil,
          scopes: [String] = AuthorizationCodeAuthProvider.defaultScopes,
+         prompt: Prompt? = nil,
          shouldExchangeAuthCode: Bool = false,
          configurationProvider: ConfigurationProviding = DefaultConfigurationProvider(),
          applicationLauncher: ApplicationLaunching = UIApplication.shared,
@@ -104,6 +109,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         self.networkProvider = networkProvider
         self.tokenManager = tokenManager
         self.scopes = scopes
+        self.prompt = prompt
     }
     
     // MARK: AuthProviding
@@ -195,6 +201,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
             app: nil,
             clientID: clientID,
             codeChallenge: shouldExchangeAuthCode ? pkce.codeChallenge : nil,
+            prompt: prompt,
             redirectURI: redirectURI,
             requestURI: requestURI,
             scopes: scopes

--- a/Sources/UberAuth/Authorize/AuthorizeRequest.swift
+++ b/Sources/UberAuth/Authorize/AuthorizeRequest.swift
@@ -17,6 +17,7 @@ struct AuthorizeRequest: NetworkRequest {
     private let app: UberApp?
     private let codeChallenge: String?
     private let clientID: String
+    private let prompt: Prompt?
     private let redirectURI: String
     private let requestURI: String?
     private let scopes: [String]
@@ -26,12 +27,14 @@ struct AuthorizeRequest: NetworkRequest {
     init(app: UberApp?,
          clientID: String,
          codeChallenge: String?,
+         prompt: Prompt? = nil,
          redirectURI: String,
          requestURI: String?,
          scopes: [String] = []) {
         self.app = app
         self.clientID = clientID
         self.codeChallenge = codeChallenge
+        self.prompt = prompt
         self.redirectURI = redirectURI
         self.requestURI = requestURI
         self.scopes = scopes
@@ -47,6 +50,7 @@ struct AuthorizeRequest: NetworkRequest {
             "client_id": clientID,
             "code_challenge": codeChallenge,
             "code_challenge_method": codeChallenge != nil ? "S256" : nil,
+            "prompt": prompt?.stringValue,
             "redirect_uri": redirectURI,
             "request_uri": requestURI,
             "scope": scopes.joined(separator: " ")

--- a/Sources/UberAuth/Authorize/Prompt.swift
+++ b/Sources/UberAuth/Authorize/Prompt.swift
@@ -1,0 +1,38 @@
+//
+//  Copyright © Uber Technologies, Inc. All rights reserved.
+//
+
+
+import Foundation
+
+///
+/// A type defining values that specify whether the Authorization Server prompts the End-User for reauthentication and consent.
+/// Current supported values are `login` and `consent`
+
+/// See OpedID standards for more information.
+/// https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+///
+public struct Prompt: OptionSet {
+    
+    public let rawValue: Int
+    
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+    
+    /// The Authorization Server SHOULD prompt the End-User for reauthentication.
+    /// If it cannot reauthenticate the End-User, it MUST return an error, typically `login_required`.
+    public static let login = Prompt(rawValue: 1 << 0)
+    
+    /// The Authorization Server SHOULD prompt the End-User for consent before returning information to the Client. 
+    /// If it cannot obtain consent, it MUST return an error, typically `consent_required`.
+    public static let consent = Prompt(rawValue: 1 << 1)
+    
+    /// Creates a space seperated string containing the values in the option set
+    var stringValue: String {
+        var values: [String] = []
+        if contains(.login) { values.append("login") }
+        if contains(.consent) { values.append("consent") }
+        return values.joined(separator: " ")
+    }
+}

--- a/examples/UberSDK/UberSDKTests/UberAuth/AuthorizeRequestTests.swift
+++ b/examples/UberSDK/UberSDKTests/UberAuth/AuthorizeRequestTests.swift
@@ -10,10 +10,14 @@ final class AuthorizeRequestTests: XCTestCase {
 
     func test_generatedUrl() {
         
+        let prompt: Prompt = [.consent, .login]
+        let promptString = prompt.stringValue.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
+        
         let request = AuthorizeRequest(
             app: nil,
             clientID: "test_client_id",
             codeChallenge: "code_challenge",
+            prompt: prompt,
             redirectURI: "redirect_uri",
             requestURI: "request_url"
         )
@@ -30,6 +34,7 @@ final class AuthorizeRequestTests: XCTestCase {
         XCTAssertTrue(url.query()!.contains("request_uri=request_url"))
         XCTAssertTrue(url.query()!.contains("code_challenge_method=S256"))
         XCTAssertTrue(url.query()!.contains("redirect_uri=redirect_uri"))
+        XCTAssertTrue(url.query()!.contains("prompt=\(promptString)"))
     }
     
     func test_appSpecific_generatedUrls() {


### PR DESCRIPTION
## Description
Implements the OpenID prompt query parameter to allow the integrating client to force either re-login or re-consent when issuing the authorize request. Details on the API [here](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
**Note:** Backend currently only supports `login` and `consent` parameters for inApp auth only. In the future we may add support for other parameters.

## Changes
### Prompt
A new OptionSet that defines which prompt parameters to send to the authorize request. Multiple values are supported, they will be sent space delimited and will be url encoded in the requests query parameters.

### AuthorizeRequest
Updated the AuthorizeRequest to accept prompt as a parameter. If supplied it will send it as an additional query parameter.

### AuthorizationCodeAuthProvider
Also added prompt as a parameter here, which will get injected into AuthorizeRequest **for inApp auth only**.

## Testing
* Added unit tests to ensure parameters were being sent correctly
* Added support for setting prompt values to the sample app
* Manually tested using sample app: 

https://github.com/uber/rides-ios-sdk/assets/5241321/83eb2314-54c2-41d5-98df-1fb01fe08e2a

