### PR TITLE
Prompt parameter for native auth

### DIFF
--- a/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
+++ b/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
@@ -284,10 +284,15 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
             return
         }
         
+        // .login not supported for native auth
+        var prompt = prompt
+        prompt?.remove(.login)
+        
         let request = AuthorizeRequest(
             app: app,
             clientID: clientID,
             codeChallenge: shouldExchangeAuthCode ? pkce.codeChallenge : nil,
+            prompt: prompt,
             redirectURI: redirectURI,
             requestURI: requestURI,
             scopes: scopes

--- a/examples/UberSDK/UberSDKTests/UberAuth/AuthorizationCodeAuthProviderTests.swift
+++ b/examples/UberSDK/UberSDKTests/UberAuth/AuthorizationCodeAuthProviderTests.swift
@@ -123,6 +123,74 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
         
         XCTAssertTrue(hasCalledAuthenticationSessionBuilder)
     }
+    
+    func test_executeNativeLogin_prompt_includedInAuthorizeRequest() {
+
+        configurationProvider.isInstalledHandler = { _, _ in
+            true
+        }
+        
+        let expectation = XCTestExpectation()
+        
+        let prompt: Prompt = [.consent]
+        let promptString = prompt.stringValue.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+        
+        let applicationLauncher = ApplicationLaunchingMock()
+        applicationLauncher.openHandler = { url, _, completion in
+            XCTAssertTrue(url.query()!.contains("prompt=\(promptString)"))
+            expectation.fulfill()
+            completion?(true)
+        }
+        
+        let provider = AuthorizationCodeAuthProvider(
+            prompt: [.consent],
+            shouldExchangeAuthCode: false,
+            configurationProvider: configurationProvider,
+            applicationLauncher: applicationLauncher
+        )
+        
+                      
+        provider.execute(
+            authDestination: .native(),
+            completion: { _ in }
+        )
+        
+        wait(for: [expectation], timeout: 0.2)
+    }
+    
+    func test_executeNativeLogin_prompt_doesNotIncluideLogin() {
+
+        configurationProvider.isInstalledHandler = { _, _ in
+            true
+        }
+        
+        let expectation = XCTestExpectation()
+        
+        let prompt: Prompt = [.consent]
+        let promptString = prompt.stringValue.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+        
+        let applicationLauncher = ApplicationLaunchingMock()
+        applicationLauncher.openHandler = { url, _, completion in
+            XCTAssertTrue(url.query()!.contains("prompt=\(promptString)"))
+            expectation.fulfill()
+            completion?(true)
+        }
+        
+        let provider = AuthorizationCodeAuthProvider(
+            prompt: [.consent, .login],
+            shouldExchangeAuthCode: false,
+            configurationProvider: configurationProvider,
+            applicationLauncher: applicationLauncher
+        )
+        
+                      
+        provider.execute(
+            authDestination: .native(),
+            completion: { _ in }
+        )
+        
+        wait(for: [expectation], timeout: 0.2)
+    }
 
     func test_execute_existingSession_returnsExistingAuthSessionError() {
         let provider = AuthorizationCodeAuthProvider(


### PR DESCRIPTION
## Description
Adding support for the prompt OAuth parameter when executing native auth. We do not want to support the login option when launching the native 1P app, so this is removed before launching. Only the consent option should work for native auth.

## Testing
### Unit Tests
Added unit tests to ensure the login prompt value is not sent for native requests

### Manual Testing
1. Run the sample app
2. Set `Destination` to Native
3. Toggle `Always ask for Login` and `Always ask for Consent` to on
4.  Verify the native app was launched and only consent was required, not login
