### PR TITLE
Logout API

### DIFF
--- a/Sources/UberAuth/AuthProviding.swift
+++ b/Sources/UberAuth/AuthProviding.swift
@@ -33,7 +33,11 @@ public protocol AuthProviding {
                  prefill: Prefill?,
                  completion: @escaping (Result<Client, UberAuthError>) -> ())
     
+    func logout() -> Bool
+    
     func handle(response url: URL) -> Bool
+    
+    var isLoggedIn: Bool { get }
 }
 
 extension AuthProviding where Self == AuthorizationCodeAuthProvider {

--- a/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
+++ b/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
@@ -157,6 +157,10 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         self.completion = authCompletion
     }
     
+    public func logout() -> Bool {
+        tokenManager.deleteToken(identifier: TokenManager.defaultAccessTokenIdentifier)
+    }
+    
     public func handle(response url: URL) -> Bool {
         guard responseParser.isValidResponse(url: url, matching: redirectURI) else {
             return false
@@ -166,6 +170,10 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         completion?(result)
         
         return true
+    }
+    
+    public var isLoggedIn: Bool {
+        tokenManager.getToken(identifier: TokenManager.defaultAccessTokenIdentifier) != nil
     }
     
     // MARK: - Private

--- a/examples/UberSDK/UberSDK/ContentView.swift
+++ b/examples/UberSDK/UberSDK/ContentView.swift
@@ -54,16 +54,19 @@ final class Content {
     var isPrefillExpanded: Bool = false
     var response: AuthReponse?
     var prefillBuilder = PrefillBuilder()
+    var isLoggedIn: Bool {
+        UberAuth.isLoggedIn
+    }
     
     func login() {
         
-        var promt: Prompt = []
-        if shouldForceLogin { promt.insert(.login) }
-        if shouldForceConsent { promt.insert(.consent) }
+        var prompt: Prompt = []
+        if shouldForceLogin { prompt.insert(.login) }
+        if shouldForceConsent { prompt.insert(.consent) }
         
         let authProvider: AuthProviding = .authorizationCode(
             shouldExchangeAuthCode: isTokenExchangeEnabled,
-            prompt: promt
+            prompt: prompt
         )
         
         let authDestination: AuthDestination = {
@@ -92,6 +95,11 @@ final class Content {
                 }
             }
         )
+    }
+    
+    func logout() {
+        UberAuth.logout()
+        response = nil
     }
     
     func openUrl(_ url: URL) {
@@ -219,9 +227,11 @@ struct ContentView: View {
         }
         
         Button(
-            action: { content.login() },
+            action: {
+                content.isLoggedIn ? content.logout() : content.login()
+            },
             label: {
-                Text("Login")
+                Text(content.isLoggedIn ? "Logout" : "Login")
                     .frame(maxWidth: .infinity, alignment: .center)
             }
         )

--- a/examples/UberSDK/UberSDKTests/UberAuth/AuthManagerTests.swift
+++ b/examples/UberSDK/UberSDKTests/UberAuth/AuthManagerTests.swift
@@ -243,4 +243,65 @@ final class UberAuthTests: XCTestCase {
         
         XCTAssertEqual(authProvider.handleCallCount, 1)
     }
+    
+    func test_isLoggedIn_noCurrentContext_returnsFalseIfNoToken() {
+        UberAuth.logout()
+        XCTAssertFalse(UberAuth.isLoggedIn)
+    }
+    
+    func test_isLoggedIn_callsCurrentContextIsLoggedIn() {
+        let authProvider = AuthProvidingMock()
+        
+        let context = AuthContext(
+            authDestination: .inApp,
+            authProvider: authProvider,
+            prefill: nil
+        )
+        
+        UberAuth.login(
+            context: context,
+            completion: { _ in }
+        )
+        
+        XCTAssertFalse(UberAuth.isLoggedIn)
+        
+        authProvider.isLoggedIn = true
+        
+        XCTAssertTrue(UberAuth.isLoggedIn)
+    }
+    
+    func test_logout_triggersAuthProviderLogout() {
+        let tokenManager = TokenManagingMock()
+        let auth = UberAuth(tokenManager: tokenManager)
+        let authProvider = AuthProvidingMock()
+        
+        let context = AuthContext(
+            authDestination: .inApp,
+            authProvider: authProvider,
+            prefill: nil
+        )
+        
+        auth.login(
+            context: context,
+            completion: { _ in }
+        )
+        
+        XCTAssertNotNil(auth.currentContext)
+        XCTAssertEqual(authProvider.logoutCallCount, 0)
+        
+        auth.logout()
+        
+        XCTAssertEqual(authProvider.logoutCallCount, 1)
+    }
+    
+    func test_logout_noCurrentContext_deletesToken() {
+        let tokenManager = TokenManagingMock()
+        let auth = UberAuth(tokenManager: tokenManager)
+        
+        XCTAssertEqual(tokenManager.deleteTokenCallCount, 0)
+        
+        auth.logout()
+        
+        XCTAssertEqual(tokenManager.deleteTokenCallCount, 1)
+    }
 }


### PR DESCRIPTION
## Description
Adding a new top-level API to UberAuth to "logout" the current user. This function deletes the stored auth token by:
1. If UberAuth has a stored currentContext, calls the logout API on the currentContext
2. If UberAuth does not have a stored currentContext, uses an internal TokenManager instance and deletes the token saved under the default identifier.

The equivalent API has been added to AuthorizationCodeAuthProvider to delete the token as described in (2).

After token deletion, UberAuth will release the stored currentContext.

Another computed property `isLoggedIn` was added for convenience to determine if a token exists in the keychain.

## Changes

### UberAuth API
Added new static and instance methods to UberAuth for logout as described above. Added computed isLoggedIn property to determine auth state.

### AuthorizationCodeAuthProvider API
Added methods to AuthorizationCodeAuthProvider to delete the token for logout. Added computed isLoggedIn property to determine auth state.

## Testing
### Unit Tests
Added unit tests to ensure tokens are deleted and currentContext released properly

### Manual Testing
Updated the UberSDK sample app to use the new APIs for manual testing.

https://github.com/user-attachments/assets/1aa82148-b370-4ba6-b3f7-bf64d9b8499c

