### PR TITLE
Xcode 16 Support

### DIFF
--- a/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
+++ b/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
@@ -332,10 +332,9 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         }
         
         DispatchQueue.main.async {
-            self.applicationLauncher.open(
+            self.applicationLauncher.launch(
                 url,
-                options: [:],
-                completionHandler: { opened in
+                completion: { opened in
                     completion?(opened)
                 }
             )

--- a/Sources/UberCore/ApplicationLauncher.swift
+++ b/Sources/UberCore/ApplicationLauncher.swift
@@ -29,7 +29,14 @@ import UIKit
 /// @mockable
 public protocol ApplicationLaunching {
     
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler: ((Bool) -> Void)?)
+    func launch(_ url: URL, completion: ((Bool) -> ())?)
 }
 
-extension UIApplication: ApplicationLaunching {}
+extension UIApplication: ApplicationLaunching {
+    
+    public func launch(_ url: URL, completion: ((Bool) -> ())?) {
+        open(url, options: [:]) {
+            completion?($0)
+        }
+    }
+}

--- a/examples/UberSDK/UberSDKTests/Mocks/Mocks.swift
+++ b/examples/UberSDK/UberSDKTests/Mocks/Mocks.swift
@@ -125,12 +125,12 @@ public class ApplicationLaunchingMock: ApplicationLaunching {
     public init() { }
 
 
-    public private(set) var openCallCount = 0
-    public var openHandler: ((URL, [UIApplication.OpenExternalURLOptionsKey: Any], ((Bool) -> Void)?) -> ())?
-    public func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler: ((Bool) -> Void)?)  {
-        openCallCount += 1
-        if let openHandler = openHandler {
-            openHandler(url, options, completionHandler)
+    public private(set) var launchCallCount = 0
+    public var launchHandler: ((URL, ((Bool) -> ())?) -> ())?
+    public func launch(_ url: URL, completion: ((Bool) -> ())?)  {
+        launchCallCount += 1
+        if let launchHandler = launchHandler {
+            launchHandler(url, completion)
         }
         
     }

--- a/examples/UberSDK/UberSDKTests/UberAuth/AuthorizationCodeAuthProviderTests.swift
+++ b/examples/UberSDK/UberSDKTests/UberAuth/AuthorizationCodeAuthProviderTests.swift
@@ -76,7 +76,7 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
         }
         
         let applicationLauncher = ApplicationLaunchingMock()
-        applicationLauncher.openHandler = { _, _, completion in
+        applicationLauncher.launchHandler = { _, completion in
             completion?(true)
         }
 
@@ -114,7 +114,7 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
         }
         
         let applicationLauncher = ApplicationLaunchingMock()
-        applicationLauncher.openHandler = { _, _, completion in
+        applicationLauncher.launchHandler = { _, completion in
             completion?(true)
         }
 
@@ -156,7 +156,7 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
         let promptString = prompt.stringValue.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
         
         let applicationLauncher = ApplicationLaunchingMock()
-        applicationLauncher.openHandler = { url, _, completion in
+        applicationLauncher.launchHandler = { url, completion in
             XCTAssertTrue(url.query()!.contains("prompt=\(promptString)"))
             expectation.fulfill()
             completion?(true)
@@ -190,7 +190,7 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
         let promptString = prompt.stringValue.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
         
         let applicationLauncher = ApplicationLaunchingMock()
-        applicationLauncher.openHandler = { url, _, completion in
+        applicationLauncher.launchHandler = { url, completion in
             XCTAssertTrue(url.query()!.contains("prompt=\(promptString)"))
             expectation.fulfill()
             completion?(true)
@@ -334,7 +334,7 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
         let expectation = XCTestExpectation()
         
         let applicationLauncher = ApplicationLaunchingMock()
-        applicationLauncher.openHandler = { _, _, completion in
+        applicationLauncher.launchHandler = { _, completion in
             expectation.fulfill()
             completion?(true)
         }
@@ -360,7 +360,7 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
     func test_executeNativeLogin_noDestinations_triggersInAppLogin() {
                 
         let applicationLauncher = ApplicationLaunchingMock()
-        applicationLauncher.openHandler = { _, _, _ in }
+        applicationLauncher.launchHandler = { _, _ in }
         
         configurationProvider.isInstalledHandler = { _, _ in
             false
@@ -385,7 +385,7 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
     func test_executeNativeLogin_noOpens_triggersInAppLogin() {
                 
         let applicationLauncher = ApplicationLaunchingMock()
-        applicationLauncher.openHandler = { _, _, completion in
+        applicationLauncher.launchHandler = { _, completion in
             completion?(false)
         }
         
@@ -423,7 +423,7 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
     func test_executeNativeLogin_noTokenExchange_doesNotIncludeCodeChallenge() {
 
         let applicationLauncher = ApplicationLaunchingMock()
-        applicationLauncher.openHandler = { url, _, completion in
+        applicationLauncher.launchHandler = { url, completion in
             XCTAssertFalse(url.absoluteString.contains("code_challenge"))
             XCTAssertFalse(url.absoluteString.contains("code_challenge_method"))
             completion?(false)
@@ -448,7 +448,7 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
             applicationLauncher: applicationLauncher
         )
                 
-        XCTAssertEqual(applicationLauncher.openCallCount, 0)
+        XCTAssertEqual(applicationLauncher.launchCallCount, 0)
         
         provider.execute(
             authDestination: .native(appPriority: [.eats]),
@@ -458,7 +458,7 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
         
         wait(for: [expectation], timeout: 0.2)
         
-        XCTAssertEqual(applicationLauncher.openCallCount, 1)
+        XCTAssertEqual(applicationLauncher.launchCallCount, 1)
     }
     
     func test_handleResponse_true_callsResponseParser() {
@@ -588,7 +588,7 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
         }
         
         let applicationLauncher = ApplicationLaunchingMock()
-        applicationLauncher.openHandler = { _, _, completion in
+        applicationLauncher.launchHandler = { _, completion in
             completion?(true)
         }
         
@@ -626,7 +626,7 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
         }
         
         let applicationLauncher = ApplicationLaunchingMock()
-        applicationLauncher.openHandler = { _, _, completion in
+        applicationLauncher.launchHandler = { _, completion in
             completion?(true)
         }
         
@@ -671,7 +671,7 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
         }
         
         let applicationLauncher = ApplicationLaunchingMock()
-        applicationLauncher.openHandler = { _, _, completion in
+        applicationLauncher.launchHandler = { _, completion in
             completion?(true)
         }
         


### PR DESCRIPTION
## Description
Made minor updates required to build/run on Xcode 16. Only one change was required to handle UIApplication.openUrl

## Changes
### ApplicationLaunching
UIApplication's open(url...) method signature changed. Since the ApplicationLaunching protocol redefined this method and we had a UIApplication extension conforming to ApplicationLaunching, this broke.
To fix this, open(url) was changed to launch(url) and the method is not called internally in the extension.

## Testing
### Manual Testing
Manually tested both inApp and native auth on simulator and physical devices

### Unit tests
Mocks + unit tests were updated