### PR TITLE
Bump minimum iOS version from 14.0 to 15.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "rides-ios-sdk",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v14)
+        .iOS(.v15)
     ],
     products: [
         .library(


### PR DESCRIPTION
## Description

Bumps the minimum iOS deployment target from 14.0 to 15.0 in preparation for async/await support.

## Testing

- Built and tested the SDK successfully with iOS 15.0 as minimum target
- All existing tests pass