### PR TITLE
[WIP] Refactor/swift concurrency

### DIFF
--- a/Sources/UberAuth/AuthProviding.swift
+++ b/Sources/UberAuth/AuthProviding.swift
@@ -33,6 +33,9 @@ public protocol AuthProviding {
                  prefill: Prefill?,
                  completion: @escaping (Result<Client, UberAuthError>) -> ())
     
+    func execute(authDestination: AuthDestination,
+                 prefill: Prefill?) async throws -> Client
+    
     func logout() -> Bool
     
     func handle(response url: URL) -> Bool

--- a/Sources/UberAuth/AuthProviding.swift
+++ b/Sources/UberAuth/AuthProviding.swift
@@ -29,6 +29,7 @@ import UberCore
 /// @mockable
 public protocol AuthProviding {
 
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     func execute(authDestination: AuthDestination,
                  prefill: Prefill?,
                  completion: @escaping (Result<Client, UberAuthError>) -> ())

--- a/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
+++ b/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
@@ -340,7 +340,8 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
             )
         }
     }
-
+    
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     private func executePar(prefill: Prefill?,
                             completion: @escaping (_ requestURI: String?) -> Void) {
       guard let prefill else {
@@ -366,11 +367,22 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
        )
     }
     
+    private func executePar(prefill: Prefill?) async -> String? {
+        guard let prefill else { return nil }
+        
+        let request = ParRequest(clientID: clientID, prefill: prefill.dictValue)
+        
+        let result = try? await networkProvider.execute(request: request)
+        
+        return result?.requestURI
+    }
+    
     // MARK: Token Exchange
     
     /// Makes a request to the /token endpoing to exchange the authorization code
     /// for an access token.
     /// - Parameter code: The authorization code to exchange
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     private func exchange(code: String, completion: @escaping Completion) {
         let request = TokenRequest(
             clientID: clientID,
@@ -386,7 +398,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
                 case .success(let response):
                     let client = Client(tokenResponse: response)
                     if let accessToken = client.accessToken {
-                        self?.tokenManager.saveToken(
+                        _ = self?.tokenManager.saveToken(
                             accessToken,
                             identifier: TokenManager.defaultAccessTokenIdentifier
                         )
@@ -397,6 +409,28 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
                 }
             }
         )
+    }
+    
+    private func exchange(code: String) async throws -> Client {
+        let request = TokenRequest(
+            clientID: clientID,
+            authorizationCode: code,
+            redirectURI: redirectURI,
+            codeVerifier: pkce.codeVerifier
+        )
+        
+        let response = try await networkProvider.execute(request: request)
+        
+        let client = Client(tokenResponse: response)
+        if let accessToken = client.accessToken {
+            _ = tokenManager
+                .saveToken(
+                    accessToken,
+                    identifier: TokenManager.defaultAccessTokenIdentifier
+                )
+        }
+        
+        return client
     }
     
     // MARK: Constants

--- a/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
+++ b/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
@@ -117,6 +117,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
     
     // MARK: AuthProviding
     
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     public func execute(authDestination: AuthDestination,
                         prefill: Prefill? = nil,
                         completion: @escaping Completion) {
@@ -192,6 +193,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
     
     // MARK: - Private
     
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     private func executeLogin(authDestination: AuthDestination,
                               requestURI: String?,
                               completion: @escaping Completion) {
@@ -337,6 +339,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
     /// - Parameters:
     ///   - appPriority: An ordered list of Uber applications to use to perform login
     ///   - completion: A closure to handle the login result
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     private func executeNativeLogin(appPriority: [UberApp],
                                     requestURI: String?,
                                     completion: @escaping Completion) {
@@ -390,6 +393,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
     /// - Parameters:
     ///   - context: A tuple of the destination app and an optional requestURI
     ///   - completion: An optional closure indicating whether or not the app was launched
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     private func launch(context: (app: UberApp, requestURI: String?),
                         completion: ((Bool) -> Void)?) {
         let (app, requestURI) = context

--- a/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
+++ b/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
@@ -157,6 +157,20 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         self.completion = authCompletion
     }
     
+    public func execute(authDestination: AuthDestination,
+                        prefill: Prefill? = nil) async throws -> Client {
+        
+        let requestURI = await executePar(prefill: prefill)
+        
+        let client = try await executeLogin(authDestination: authDestination, requestURI: requestURI)
+        
+        if shouldExchangeAuthCode, let code = client.authorizationCode {
+            return try await exchange(code: code)
+        }
+        
+        return client
+    }
+    
     public func logout() -> Bool {
         tokenManager.deleteToken(identifier: TokenManager.defaultAccessTokenIdentifier)
     }
@@ -196,9 +210,21 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         }
     }
     
+    func executeLogin(authDestination: AuthDestination,
+                      requestURI: String?) async throws -> Client {
+        switch authDestination {
+        case .inApp:
+            try await executeInAppLogin(requestURI: requestURI)
+        case.native(let appPriority):
+            try await executeNativeLogin(appPriority: appPriority, requestURI: requestURI)
+        }
+        
+    }
+    
     /// Performs login using an embedded browser within the third party client.
     /// - Parameters:
     ///   - completion: A closure to handle the login result
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     private func executeInAppLogin(requestURI: String?,
                                    completion: @escaping Completion) {
         
@@ -242,6 +268,52 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
             )
         
         currentSession?.start()
+    }
+    
+    private func executeInAppLogin(requestURI: String?) async throws -> Client {
+        // Only execute one authentication session at a time
+        guard currentSession == nil else { throw UberAuthError.existingAuthSession }
+        
+        let request = AuthorizeRequest(
+            app: nil,
+            clientID: clientID,
+            codeChallenge: shouldExchangeAuthCode ? pkce.codeChallenge : nil,
+            prompt: prompt,
+            redirectURI: redirectURI,
+            requestURI: requestURI,
+            scopes: scopes
+        )
+        
+        guard let url = request.url(baseUrl: Constants.baseUrl) else {
+            throw UberAuthError.invalidRequest("Invalid base URL")
+        }
+        
+        guard let callbackURL = URL(string: redirectURI),
+              let callbackURLScheme = callbackURL.scheme else {
+            throw UberAuthError.invalidRequest("Invalid redirect URI")
+        }
+#warning("Why we were passing a new instance of ASPresentationAnchor at 274?")
+        return try await withCheckedThrowingContinuation { continuation in
+            if let sessionBuilder = authenticationSessionBuilder {
+                currentSession = sessionBuilder(
+                    presentationAnchor,
+                    callbackURLScheme,
+                    url,
+                    { [weak self] result in
+                        continuation.resume(with: result)
+                        self?.currentSession = nil
+                    })
+            } else {
+                currentSession = AuthenticationSession(anchor: presentationAnchor, callbackURLScheme: callbackURLScheme, url: url) { [weak self] result in
+                    continuation.resume(with: result)
+                    self?.currentSession = nil
+                    
+                }
+            }
+            
+            currentSession?.start()
+            
+        }
     }
         
     /// Performs login using one of the native Uber applications if available.
@@ -295,6 +367,23 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         )
     }
     
+    private func executeNativeLogin(appPriority: [UberApp], requestURI: String?) async throws -> Client {
+        for app in appPriority {
+            let launched = await launch(context: (app, requestURI))
+            
+            if launched {
+                return try await withCheckedThrowingContinuation { continuation in
+                    self.completion = { result in
+                        continuation.resume(with: result)
+                        self.completion = nil
+                    }
+                }
+            }
+        }
+        
+        return try await executeInAppLogin(requestURI: requestURI)
+    }
+    
     /// Attempts to launch a native app with an SSO universal link.
     /// Calls a closure with a boolean indicating if the application was successfully opened.
     ///
@@ -341,6 +430,30 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         }
     }
     
+    func launch(context: (app: UberApp, requestURI: String?)) async -> Bool {
+        let (app, requestURI) = context
+        guard configurationProvider.isInstalled(app: app, defaultIfUnregistered: true) else { return false }
+        
+        // .login not supported for native auth
+        var prompt = prompt
+        prompt?.remove(.login)
+        
+        let request = AuthorizeRequest(
+            app: app,
+            clientID: clientID,
+            codeChallenge: shouldExchangeAuthCode ? pkce.codeChallenge : nil,
+            prompt: prompt,
+            redirectURI: redirectURI,
+            requestURI: requestURI,
+            scopes: scopes
+        )
+        
+        guard let url = request.url(baseUrl: Constants.baseUrl) else { return false }
+        
+        return await applicationLauncher.launch(url)
+    }
+    
+    
     @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     private func executePar(prefill: Prefill?,
                             completion: @escaping (_ requestURI: String?) -> Void) {
@@ -367,7 +480,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
        )
     }
     
-    private func executePar(prefill: Prefill?) async -> String? {
+    func executePar(prefill: Prefill?) async -> String? {
         guard let prefill else { return nil }
         
         let request = ParRequest(clientID: clientID, prefill: prefill.dictValue)
@@ -411,7 +524,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         )
     }
     
-    private func exchange(code: String) async throws -> Client {
+    func exchange(code: String) async throws -> Client {
         let request = TokenRequest(
             clientID: clientID,
             authorizationCode: code,

--- a/Sources/UberAuth/Networking/NetworkProvider.swift
+++ b/Sources/UberAuth/Networking/NetworkProvider.swift
@@ -27,7 +27,9 @@ import Foundation
 
 /// @mockable
 protocol NetworkProviding {
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     func execute<R: NetworkRequest>(request: R, completion: @escaping (Result<R.Response, UberAuthError>) -> ())
+    func execute<R: NetworkRequest>(request: R) async throws -> R.Response
 }
 
 final class NetworkProvider: NetworkProviding {
@@ -40,7 +42,7 @@ final class NetworkProvider: NetworkProviding {
         self.baseUrl = baseUrl
         self.session = URLSession(configuration: .default)
     }
-    
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     func execute<R: NetworkRequest>(request: R, completion: @escaping (Result<R.Response, UberAuthError>) -> ()) {
         guard let urlRequest = request.urlRequest(baseUrl: baseUrl) else {
             completion(.failure(UberAuthError.invalidRequest("")))
@@ -78,4 +80,33 @@ final class NetworkProvider: NetworkProviding {
         
         dataTask.resume()
     }
+    
+    func execute<R: NetworkRequest>(request: R) async throws -> R.Response {
+        guard let urlRequest = request.urlRequest(baseUrl: baseUrl) else {
+            throw UberAuthError.invalidRequest("")
+        }
+        
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: urlRequest)
+        } catch {
+            throw UberAuthError.other(error)
+        }
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw UberAuthError.oAuth(.unsupportedResponseType)
+        }
+        
+        if let error = UberAuthError(httpResponse) {
+            throw error
+        }
+        
+        do {
+            let decodedResponse = try decoder.decode(R.Response.self, from: data)
+            return decodedResponse
+        } catch {
+            throw UberAuthError.serviceError
+        }
+    }
 }
+

--- a/Sources/UberAuth/README.md
+++ b/Sources/UberAuth/README.md
@@ -8,12 +8,13 @@
     3. [Auth Destinations](#auth-destinations)
     4. [Auth Providers](#auth-providers)
         * [AuthorizationCodeAuthProvider](#authorizationcoreauthprovider)
-    5. [Responding to Redirects](#responding-to-redirects)
+    5. [Forcing Login or Consent](#forcing-login-or-consent)
+    6. [Responding to Redirects](#responding-to-redirects)
         * [Using UIKit](#using-uikit)
         * [Using SwiftUI](#using-swiftui)
-    6. [Exchanging Authorization Code](#exchanging-authorization-code)
-    7. [Prefilling User Information](#prefilling-user-information)
-    8. [Login Button](#login-button)
+    7. [Exchanging Authorization Code](#exchanging-authorization-code)
+    8. [Prefilling User Information](#prefilling-user-information)
+    9. [Login Button](#login-button)
 
 # Prerequisites
 If you haven't already, follow the [Getting Started](../../README.md#getting-started) steps in the main README.
@@ -144,6 +145,19 @@ An Auth Provider supplies logic for a specific authentication grant flow. Curren
 
 AuthorizationCoreAuthProvider performs the Authorization Code Grant Flow as specified in the [OAuth 2.0 Framework](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1). AuthorizationCoreAuthProvider is currently the only supported auth provider.
 
+## Forcing Login or Consent
+The auth provider accepts an optional `prompt` parameter that can be used to force the login screen or the consent screen to be presented.
+
+**Note:** Login is only available for .inApp auth destinations.
+
+```
+// Will request login then show the consent screen, even if previously completed by the user
+let prompt: [Prompt] = [.login, .consent]
+
+let authProvider: AuthProviding = .authorizationCode(
+    prompt: prompt
+)
+```
 
 ## Responding to Redirects
 

--- a/Sources/UberAuth/UberAuth.swift
+++ b/Sources/UberAuth/UberAuth.swift
@@ -28,6 +28,34 @@ import Foundation
 public typealias AuthCompletion = (Result<Client, UberAuthError>) -> ()
 
 /// @mockable
+public protocol UberAuthInterface {
+    
+    /// Executes a single login session using the provided context
+    ///
+    /// - Parameters:
+    ///   - context: An `AuthContext` instance providing all information needed to execute authentication
+    ///   - completion: A closure to be called upon completion
+    static func login(context: AuthContext, completion: @escaping AuthCompletion)
+    
+    
+    /// Clears any saved auth information from the keychain
+    /// If `currentAuthContext` exists, logs out using the stored auth context
+    /// Otherwise, attempts to delete the saved auth token directly using the internal TokenManager
+    static func logout()
+    
+    /// Attempts to extract auth information from the provided URL.
+    /// This method should be called from the implemeting application's openURL function.
+    ///
+    /// - Parameter url: The URL that was passed into the implementing app
+    /// - Returns: A boolean indicating if the URL was handled or not
+    static func handle(_ url: URL) -> Bool
+}
+
+
+///
+/// An internal protocol that translates the class -> instance methods for UberAuth
+///
+/// @mockable
 protocol AuthManaging {
     
     func login(context: AuthContext, completion: @escaping AuthCompletion)
@@ -40,7 +68,7 @@ protocol AuthManaging {
 }
 
 /// Public interface for the uber-auth-ios library
-public final class UberAuth: AuthManaging {
+public final class UberAuth: UberAuthInterface, AuthManaging {
     
     // MARK: Public
     

--- a/Sources/UberAuth/UberAuth.swift
+++ b/Sources/UberAuth/UberAuth.swift
@@ -35,8 +35,10 @@ public protocol UberAuthInterface {
     /// - Parameters:
     ///   - context: An `AuthContext` instance providing all information needed to execute authentication
     ///   - completion: A closure to be called upon completion
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     static func login(context: AuthContext, completion: @escaping AuthCompletion)
     
+    static func login(context: AuthContext) async throws -> Client
     
     /// Clears any saved auth information from the keychain
     /// If `currentAuthContext` exists, logs out using the stored auth context
@@ -58,7 +60,10 @@ public protocol UberAuthInterface {
 /// @mockable
 protocol AuthManaging {
     
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     func login(context: AuthContext, completion: @escaping AuthCompletion)
+    
+    func login(context: AuthContext) async throws -> Client
     
     func logout()
     
@@ -77,12 +82,17 @@ public final class UberAuth: UberAuthInterface, AuthManaging {
     /// - Parameters:
     ///   - context: An `AuthContext` instance providing all information needed to execute authentication
     ///   - completion: A closure to be called upon completion
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     public static func login(context: AuthContext = .init(),
                              completion: @escaping AuthCompletion) {
         auth.login(
             context: context,
             completion: completion
         )
+    }
+    
+    public static func login(context: AuthContext = .init()) async throws -> Client {
+        try await auth.login(context: context)
     }
     
     /// Clears any saved auth information from the keychain
@@ -126,6 +136,15 @@ public final class UberAuth: UberAuthInterface, AuthManaging {
             completion: completion
         )
         currentContext = context
+    }
+    
+    func login(context: AuthContext = .init()) async throws -> Client {
+        let client = try await context.authProvider.execute(
+            authDestination: context.authDestination,
+            prefill: context.prefill
+        )
+        currentContext = context
+        return client
     }
     
     func logout() {

--- a/Sources/UberCore/ApplicationLauncher.swift
+++ b/Sources/UberCore/ApplicationLauncher.swift
@@ -30,6 +30,8 @@ import UIKit
 public protocol ApplicationLaunching {
     
     func launch(_ url: URL, completion: ((Bool) -> ())?)
+    
+    func launch(_ url: URL) async -> Bool
 }
 
 extension UIApplication: ApplicationLaunching {
@@ -38,5 +40,9 @@ extension UIApplication: ApplicationLaunching {
         open(url, options: [:]) {
             completion?($0)
         }
+    }
+    
+    public func launch(_ url: URL) async -> Bool {
+        await open(url, options: [:])
     }
 }

--- a/Sources/UberCore/ApplicationLauncher.swift
+++ b/Sources/UberCore/ApplicationLauncher.swift
@@ -29,6 +29,7 @@ import UIKit
 /// @mockable
 public protocol ApplicationLaunching {
     
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     func launch(_ url: URL, completion: ((Bool) -> ())?)
     
     func launch(_ url: URL) async -> Bool
@@ -36,6 +37,7 @@ public protocol ApplicationLaunching {
 
 extension UIApplication: ApplicationLaunching {
     
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
     public func launch(_ url: URL, completion: ((Bool) -> ())?) {
         open(url, options: [:]) {
             completion?($0)

--- a/examples/UberSDK/UberSDKTests/Mocks/Mocks.swift
+++ b/examples/UberSDK/UberSDKTests/Mocks/Mocks.swift
@@ -242,6 +242,41 @@ public class AuthProvidingMock: AuthProviding {
     public var isLoggedIn: Bool = false { didSet { isLoggedInSetCallCount += 1 } }
 }
 
+public class UberAuthInterfaceMock: UberAuthInterface {
+    public init() { }
+
+
+    public static private(set) var loginCallCount = 0
+    public static var loginHandler: ((AuthContext, @escaping AuthCompletion) -> ())?
+    public static func login(context: AuthContext, completion: @escaping AuthCompletion)  {
+        loginCallCount += 1
+        if let loginHandler = loginHandler {
+            loginHandler(context, completion)
+        }
+        
+    }
+
+    public static private(set) var logoutCallCount = 0
+    public static var logoutHandler: (() -> ())?
+    public static func logout()  {
+        logoutCallCount += 1
+        if let logoutHandler = logoutHandler {
+            logoutHandler()
+        }
+        
+    }
+
+    public static private(set) var handleCallCount = 0
+    public static var handleHandler: ((URL) -> (Bool))?
+    public static func handle(_ url: URL) -> Bool {
+        handleCallCount += 1
+        if let handleHandler = handleHandler {
+            return handleHandler(url)
+        }
+        return false
+    }
+}
+
 class AuthManagingMock: AuthManaging {
     init() { }
     init(isLoggedIn: Bool = false) {

--- a/examples/UberSDK/UberSDKTests/Mocks/Mocks.swift
+++ b/examples/UberSDK/UberSDKTests/Mocks/Mocks.swift
@@ -11,12 +11,12 @@ import UIKit
 @testable import UberCore
 
 
-public class TokenManagingMock: TokenManaging {
+public final class TokenManagingMock: TokenManaging {
     public init() { }
 
 
     public private(set) var saveTokenCallCount = 0
-    public var saveTokenHandler: ((AccessToken, String, String?) -> (Bool))?
+    public var saveTokenHandler: ((AccessToken, String, String?) -> Bool)?
     public func saveToken(_ token: AccessToken, identifier: String, accessGroup: String?) -> Bool {
         saveTokenCallCount += 1
         if let saveTokenHandler = saveTokenHandler {
@@ -26,7 +26,7 @@ public class TokenManagingMock: TokenManaging {
     }
 
     public private(set) var getTokenCallCount = 0
-    public var getTokenHandler: ((String, String?) -> (AccessToken?))?
+    public var getTokenHandler: ((String, String?) -> AccessToken?)?
     public func getToken(identifier: String, accessGroup: String?) -> AccessToken? {
         getTokenCallCount += 1
         if let getTokenHandler = getTokenHandler {
@@ -36,7 +36,7 @@ public class TokenManagingMock: TokenManaging {
     }
 
     public private(set) var deleteTokenCallCount = 0
-    public var deleteTokenHandler: ((String, String?) -> (Bool))?
+    public var deleteTokenHandler: ((String, String?) -> Bool)?
     public func deleteToken(identifier: String, accessGroup: String?) -> Bool {
         deleteTokenCallCount += 1
         if let deleteTokenHandler = deleteTokenHandler {
@@ -46,27 +46,12 @@ public class TokenManagingMock: TokenManaging {
     }
 }
 
-class NetworkProvidingMock: NetworkProviding {
-    init() { }
-
-
-    private(set) var executeCallCount = 0
-    var executeHandler: ((Any, Any) -> ())?
-    func execute<R: NetworkRequest>(request: R, completion: @escaping (Result<R.Response, UberAuthError>) -> ())  {
-        executeCallCount += 1
-        if let executeHandler = executeHandler {
-            executeHandler(request, completion)
-        }
-        
-    }
-}
-
-public class KeychainUtilityProtocolMock: KeychainUtilityProtocol {
+public final class KeychainUtilityProtocolMock: KeychainUtilityProtocol {
     public init() { }
 
 
     public private(set) var saveCallCount = 0
-    public var saveHandler: ((Any, String, String?) -> (Bool))?
+    public var saveHandler: ((Any, String, String?) -> Bool)?
     public func save<V: Encodable>(_ value: V, for key: String, accessGroup: String?) -> Bool {
         saveCallCount += 1
         if let saveHandler = saveHandler {
@@ -76,7 +61,7 @@ public class KeychainUtilityProtocolMock: KeychainUtilityProtocol {
     }
 
     public private(set) var getCallCount = 0
-    public var getHandler: ((String, String?) -> (Any?))?
+    public var getHandler: ((String, String?) -> Any?)?
     public func get<V: Decodable>(key: String, accessGroup: String?) -> V? {
         getCallCount += 1
         if let getHandler = getHandler {
@@ -86,7 +71,7 @@ public class KeychainUtilityProtocolMock: KeychainUtilityProtocol {
     }
 
     public private(set) var deleteCallCount = 0
-    public var deleteHandler: ((String, String?) -> (Bool))?
+    public var deleteHandler: ((String, String?) -> Bool)?
     public func delete(key: String, accessGroup: String?) -> Bool {
         deleteCallCount += 1
         if let deleteHandler = deleteHandler {
@@ -96,12 +81,42 @@ public class KeychainUtilityProtocolMock: KeychainUtilityProtocol {
     }
 }
 
-class AuthorizationCodeResponseParsingMock: AuthorizationCodeResponseParsing {
+final class NetworkProvidingMock: NetworkProviding {
+    init() { }
+
+    private(set) var executeCallCount = 0
+    var executeHandler: ((Any, Any) -> ())?
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
+    func execute<R: NetworkRequest>(request: R, completion: @escaping (Result<R.Response, UberAuthError>) -> ()) {
+        executeCallCount += 1
+        if let executeHandler = executeHandler {
+            executeHandler(request, completion)
+        }
+        
+    }
+    
+    var executeAsyncResult: Result<Any, Error>?
+    func execute<R: NetworkRequest>(request: R) async throws -> R.Response {
+        executeCallCount += 1
+        
+        guard let result = executeAsyncResult else { throw UberAuthError.serviceError }
+        
+        switch result {
+        case .success(let response):
+            guard let typedResponse = response as? R.Response else { throw UberAuthError.serviceError }
+            return typedResponse
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
+final class AuthorizationCodeResponseParsingMock: AuthorizationCodeResponseParsing {
     init() { }
 
 
     private(set) var isValidResponseCallCount = 0
-    var isValidResponseHandler: ((URL, String) -> (Bool))?
+    var isValidResponseHandler: ((URL, String) -> Bool)?
     func isValidResponse(url: URL, matching redirectURI: String) -> Bool {
         isValidResponseCallCount += 1
         if let isValidResponseHandler = isValidResponseHandler {
@@ -111,7 +126,7 @@ class AuthorizationCodeResponseParsingMock: AuthorizationCodeResponseParsing {
     }
 
     private(set) var callAsFunctionCallCount = 0
-    var callAsFunctionHandler: ((URL) -> (Result<Client, UberAuthError>))?
+    var callAsFunctionHandler: ((URL) -> Result<Client, UberAuthError>)?
     func callAsFunction(url: URL) -> Result<Client, UberAuthError> {
         callAsFunctionCallCount += 1
         if let callAsFunctionHandler = callAsFunctionHandler {
@@ -121,22 +136,29 @@ class AuthorizationCodeResponseParsingMock: AuthorizationCodeResponseParsing {
     }
 }
 
-public class ApplicationLaunchingMock: ApplicationLaunching {
+public final class ApplicationLaunchingMock: ApplicationLaunching {
     public init() { }
 
 
     public private(set) var launchCallCount = 0
     public var launchHandler: ((URL, ((Bool) -> ())?) -> ())?
-    public func launch(_ url: URL, completion: ((Bool) -> ())?)  {
+    public func launch(_ url: URL, completion: ((Bool) -> ())?) {
         launchCallCount += 1
         if let launchHandler = launchHandler {
             launchHandler(url, completion)
         }
         
     }
+
+    public private(set) var launchUrlCallCount = 0
+    public var launchResult: Bool = false
+    public func launch(_ url: URL) async -> Bool {
+        launchUrlCallCount += 1
+        return launchResult
+    }
 }
 
-public class ConfigurationProvidingMock: ConfigurationProviding {
+public final class ConfigurationProvidingMock: ConfigurationProviding {
     public init() { }
     public init(clientID: String = "", redirectURI: String = "", sdkVersion: String = "", serverToken: String? = nil) {
         self.clientID = clientID
@@ -146,27 +168,23 @@ public class ConfigurationProvidingMock: ConfigurationProviding {
     }
 
 
-    public private(set) var clientIDSetCallCount = 0
-    public var clientID: String = "" { didSet { clientIDSetCallCount += 1 } }
 
-    public private(set) var redirectURISetCallCount = 0
-    public var redirectURI: String = "" { didSet { redirectURISetCallCount += 1 } }
+    public var clientID: String = ""
 
-    public private(set) var sdkVersionSetCallCount = 0
-    public var sdkVersion: String = "" { didSet { sdkVersionSetCallCount += 1 } }
 
-    public private(set) var serverTokenSetCallCount = 0
-    public var serverToken: String? = nil { didSet { serverTokenSetCallCount += 1 } }
+    public var redirectURI: String = ""
 
-    public static private(set) var isSandboxSetCallCount = 0
-    static private var _isSandbox: Bool = false { didSet { isSandboxSetCallCount += 1 } }
-    public static var isSandbox: Bool {
-        get { return _isSandbox }
-        set { _isSandbox = newValue }
-    }
+
+    public var sdkVersion: String = ""
+
+
+    public var serverToken: String? = nil
+
+
+    public static var isSandbox: Bool = false
 
     public private(set) var isInstalledCallCount = 0
-    public var isInstalledHandler: ((UberApp, Bool) -> (Bool))?
+    public var isInstalledHandler: ((UberApp, Bool) -> Bool)?
     public func isInstalled(app: UberApp, defaultIfUnregistered: Bool) -> Bool {
         isInstalledCallCount += 1
         if let isInstalledHandler = isInstalledHandler {
@@ -176,8 +194,8 @@ public class ConfigurationProvidingMock: ConfigurationProviding {
     }
 }
 
-class AuthenticationSessioningMock: AuthenticationSessioning {
-        private var _anchor: ASPresentationAnchor!
+final class AuthenticationSessioningMock: AuthenticationSessioning {
+    private var _anchor: ASPresentationAnchor!
     private var _callbackURLScheme: String!
     private var _completion: AuthCompletion!
     private var _url: URL!
@@ -192,7 +210,7 @@ class AuthenticationSessioningMock: AuthenticationSessioning {
 
     private(set) var startCallCount = 0
     var startHandler: (() -> ())?
-    func start()  {
+    func start() {
         startCallCount += 1
         if let startHandler = startHandler {
             startHandler()
@@ -201,7 +219,7 @@ class AuthenticationSessioningMock: AuthenticationSessioning {
     }
 }
 
-public class AuthProvidingMock: AuthProviding {
+public final class AuthProvidingMock: AuthProviding {
     public init() { }
     public init(isLoggedIn: Bool = false) {
         self.isLoggedIn = isLoggedIn
@@ -210,16 +228,30 @@ public class AuthProvidingMock: AuthProviding {
 
     public private(set) var executeCallCount = 0
     public var executeHandler: ((AuthDestination, Prefill?, @escaping (Result<Client, UberAuthError>) -> ()) -> ())?
-    public func execute(authDestination: AuthDestination, prefill: Prefill?, completion: @escaping (Result<Client, UberAuthError>) -> ())  {
+    public func execute(authDestination: AuthDestination, prefill: Prefill?, completion: @escaping (Result<Client, UberAuthError>) -> ()) {
         executeCallCount += 1
         if let executeHandler = executeHandler {
             executeHandler(authDestination, prefill, completion)
         }
         
     }
+    
+    public var executeAsyncResult: Result<Client, Error>?
+    public func execute(authDestination: AuthDestination, prefill: Prefill?) async throws -> Client {
+        executeCallCount += 1
+        
+        guard let result = executeAsyncResult else { throw UberAuthError.serviceError }
+        
+        switch result {
+        case .success(let client):
+            return client
+        case .failure(let error):
+            throw error
+        }
+    }
 
     public private(set) var logoutCallCount = 0
-    public var logoutHandler: (() -> (Bool))?
+    public var logoutHandler: (() -> Bool)?
     public func logout() -> Bool {
         logoutCallCount += 1
         if let logoutHandler = logoutHandler {
@@ -229,7 +261,7 @@ public class AuthProvidingMock: AuthProviding {
     }
 
     public private(set) var handleCallCount = 0
-    public var handleHandler: ((URL) -> (Bool))?
+    public var handleHandler: ((URL) -> Bool)?
     public func handle(response url: URL) -> Bool {
         handleCallCount += 1
         if let handleHandler = handleHandler {
@@ -238,27 +270,40 @@ public class AuthProvidingMock: AuthProviding {
         return false
     }
 
-    public private(set) var isLoggedInSetCallCount = 0
-    public var isLoggedIn: Bool = false { didSet { isLoggedInSetCallCount += 1 } }
+    public var isLoggedIn: Bool = false
 }
 
-public class UberAuthInterfaceMock: UberAuthInterface {
+public final class UberAuthInterfaceMock: UberAuthInterface {
     public init() { }
-
 
     public static private(set) var loginCallCount = 0
     public static var loginHandler: ((AuthContext, @escaping AuthCompletion) -> ())?
-    public static func login(context: AuthContext, completion: @escaping AuthCompletion)  {
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
+    public static func login(context: AuthContext, completion: @escaping AuthCompletion) {
         loginCallCount += 1
         if let loginHandler = loginHandler {
             loginHandler(context, completion)
         }
         
     }
+    
+    public static var loginAsyncResult: Result<Client, Error>?
+    public static func login(context: AuthContext) async throws -> Client {
+        loginCallCount += 1
+        
+        guard let result = loginAsyncResult else { throw UberAuthError.serviceError }
+        
+        switch result {
+        case .success(let client):
+            return client
+        case .failure(let error):
+            throw error
+        }
+    }
 
     public static private(set) var logoutCallCount = 0
     public static var logoutHandler: (() -> ())?
-    public static func logout()  {
+    public static func logout() {
         logoutCallCount += 1
         if let logoutHandler = logoutHandler {
             logoutHandler()
@@ -267,7 +312,7 @@ public class UberAuthInterfaceMock: UberAuthInterface {
     }
 
     public static private(set) var handleCallCount = 0
-    public static var handleHandler: ((URL) -> (Bool))?
+    public static var handleHandler: ((URL) -> Bool)?
     public static func handle(_ url: URL) -> Bool {
         handleCallCount += 1
         if let handleHandler = handleHandler {
@@ -277,26 +322,40 @@ public class UberAuthInterfaceMock: UberAuthInterface {
     }
 }
 
-class AuthManagingMock: AuthManaging {
+final class AuthManagingMock: AuthManaging {
     init() { }
     init(isLoggedIn: Bool = false) {
         self.isLoggedIn = isLoggedIn
     }
 
-
     private(set) var loginCallCount = 0
     var loginHandler: ((AuthContext, @escaping AuthCompletion) -> ())?
-    func login(context: AuthContext, completion: @escaping AuthCompletion)  {
+    @available(*, deprecated, message: "This method is deprecated. Use the async method instead.")
+    func login(context: AuthContext, completion: @escaping AuthCompletion) {
         loginCallCount += 1
         if let loginHandler = loginHandler {
             loginHandler(context, completion)
         }
         
     }
+    
+    var loginAsyncResult: Result<Client, Error>?
+    func login(context: AuthContext) async throws -> Client {
+        loginCallCount += 1
+        
+        guard let result = loginAsyncResult else { throw UberAuthError.serviceError }
+        
+        switch result {
+        case .success(let client):
+            return client
+        case .failure(let error):
+            throw error
+        }
+    }
 
     private(set) var logoutCallCount = 0
     var logoutHandler: (() -> ())?
-    func logout()  {
+    func logout() {
         logoutCallCount += 1
         if let logoutHandler = logoutHandler {
             logoutHandler()
@@ -305,7 +364,7 @@ class AuthManagingMock: AuthManaging {
     }
 
     private(set) var handleCallCount = 0
-    var handleHandler: ((URL) -> (Bool))?
+    var handleHandler: ((URL) -> Bool)?
     func handle(_ url: URL) -> Bool {
         handleCallCount += 1
         if let handleHandler = handleHandler {
@@ -314,7 +373,5 @@ class AuthManagingMock: AuthManaging {
         return false
     }
 
-    private(set) var isLoggedInSetCallCount = 0
-    var isLoggedIn: Bool = false { didSet { isLoggedInSetCallCount += 1 } }
+    var isLoggedIn: Bool = false
 }
-

--- a/examples/UberSDK/UberSDKTests/UberAuth/AuthManagerTests.swift
+++ b/examples/UberSDK/UberSDKTests/UberAuth/AuthManagerTests.swift
@@ -305,3 +305,33 @@ final class UberAuthTests: XCTestCase {
         XCTAssertEqual(tokenManager.deleteTokenCallCount, 1)
     }
 }
+
+@MainActor
+extension UberAuthTests {
+    
+    func test_login_async_success() async throws {
+        let authProvider = AuthProvidingMock()
+        authProvider.executeAsyncResult = .success(Client(authorizationCode: "code"))
+        
+        let context = AuthContext(authDestination: .inApp, authProvider: authProvider, prefill: nil)
+        
+        let client = try await uberAuth.login(context: context)
+        
+        XCTAssertNotNil(client.authorizationCode)
+        XCTAssertEqual(authProvider.executeCallCount, 1)
+    }
+    
+    func test_login_async_error() async {
+        let authProvider = AuthProvidingMock()
+        authProvider.executeAsyncResult = .failure(UberAuthError.serviceError)
+        
+        let context = AuthContext(authDestination: .inApp, authProvider: authProvider, prefill: nil)
+        
+        do {
+            _ = try await uberAuth.login(context: context)
+            XCTFail("Should have thrown error")
+        } catch {
+            XCTAssertNotNil(error as? UberAuthError)
+        }
+    }
+}

--- a/examples/UberSDK/UberSDKTests/UberAuth/AuthorizationCodeAuthProviderTests.swift
+++ b/examples/UberSDK/UberSDKTests/UberAuth/AuthorizationCodeAuthProviderTests.swift
@@ -712,3 +712,332 @@ final class AuthorizationCodeAuthProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 0.1)
     }
 }
+
+@MainActor
+extension AuthorizationCodeAuthProviderTests {
+    
+    func test_executePar_async_withNoPrefill_returnsNil() async {
+        let provider = AuthorizationCodeAuthProvider(configurationProvider: configurationProvider)
+        
+        let result = await provider.executePar(prefill: nil)
+        
+        XCTAssertNil(result)
+    }
+    
+    func test_executePar_async_withPrefill_success_returnsRequestURI() async {
+        let mockNetwork = NetworkProvidingMock()
+        let expectedRequestURI = "urn:test:request:uri:12345"
+        mockNetwork.executeAsyncResult = .success(
+            Par(
+                requestURI: expectedRequestURI,
+                expiresIn: Date(timeIntervalSinceNow: 3600)
+            )
+        )
+        
+        let provider = AuthorizationCodeAuthProvider(
+            configurationProvider: configurationProvider,
+            networkProvider: mockNetwork
+        )
+        
+        let prefill = Prefill(email: "test@example.com")
+        
+        let result = await provider.executePar(prefill: prefill)
+        
+        XCTAssertEqual(result, expectedRequestURI)
+        XCTAssertEqual(mockNetwork.executeCallCount, 1)
+    }
+    
+    func test_executePar_async_withPrefill_failure_returnsNil() async {
+        let mockNetwork = NetworkProvidingMock()
+        mockNetwork.executeAsyncResult = .failure(UberAuthError.serviceError)
+        
+        let provider = AuthorizationCodeAuthProvider(
+            configurationProvider: configurationProvider,
+            networkProvider: mockNetwork
+        )
+        
+        let prefill = Prefill(email: "test@example.com")
+        
+        let result = await provider.executePar(prefill: prefill)
+        
+        XCTAssertNil(result, "executePar should return nil on failure (PAR is optional)")
+        XCTAssertEqual(mockNetwork.executeCallCount, 1)
+    }
+    
+    func test_exchange_async_success_returnsClientAndSavesToken() async throws {
+        let mockNetwork = NetworkProvidingMock()
+        let mockTokenManager = TokenManagingMock()
+        
+        let expectedToken = AccessToken(
+            tokenString: "access_token_abc123",
+            refreshToken: "refresh_token_xyz789",
+            tokenType: "Bearer",
+            expiresIn: 3600,
+            scope: ["profile", "history"]
+        )
+        
+        mockNetwork.executeAsyncResult = .success(expectedToken)
+        mockTokenManager.saveTokenHandler = { _, _, _ in true }
+        
+        let provider = AuthorizationCodeAuthProvider(
+            configurationProvider: configurationProvider,
+            networkProvider: mockNetwork,
+            tokenManager: mockTokenManager
+        )
+        
+        let client = try await provider.exchange(code: "auth_code_test_123")
+        
+        XCTAssertEqual(client.accessToken, expectedToken)
+        XCTAssertEqual(mockTokenManager.saveTokenCallCount, 1)
+        XCTAssertEqual(mockNetwork.executeCallCount, 1)
+    }
+    
+    func test_exchange_async_error_throwsAndDoesNotSaveToken() async {
+        let mockNetwork = NetworkProvidingMock()
+        mockNetwork.executeAsyncResult = .failure(UberAuthError.serviceError)
+        
+        let mockTokenManager = TokenManagingMock()
+        
+        let provider = AuthorizationCodeAuthProvider(
+            configurationProvider: configurationProvider,
+            networkProvider: mockNetwork,
+            tokenManager: mockTokenManager
+        )
+        
+        do {
+            _ = try await provider.exchange(code: "invalid_code")
+            XCTFail("Should have thrown error")
+        } catch {
+            XCTAssertNotNil(error as? UberAuthError)
+            XCTAssertEqual(mockTokenManager.saveTokenCallCount, 0)
+        }
+    }
+    
+    func test_launch_async_appNotInstalled_returnsFalse() async {
+        configurationProvider.isInstalledHandler = { _, _ in false }
+        
+        let provider = AuthorizationCodeAuthProvider(
+            configurationProvider: configurationProvider
+        )
+        
+        let launched = await provider.launch(context: (.eats, nil))
+        
+        XCTAssertFalse(launched)
+    }
+    
+    func test_launch_async_appInstalled_success_returnsTrue() async {
+        configurationProvider.isInstalledHandler = { _, _ in true }
+        
+        let mockLauncher = ApplicationLaunchingMock()
+        mockLauncher.launchResult = true
+        
+        let provider = AuthorizationCodeAuthProvider(
+            configurationProvider: configurationProvider,
+            applicationLauncher: mockLauncher
+        )
+        
+        let launched = await provider.launch(context: (.eats, nil))
+        
+        XCTAssertTrue(launched)
+        XCTAssertEqual(mockLauncher.launchUrlCallCount, 1)
+    }
+    
+    func test_launch_async_appInstalled_launchFails_returnsFalse() async {
+        configurationProvider.isInstalledHandler = { _, _ in true }
+        
+        let mockLauncher = ApplicationLaunchingMock()
+        mockLauncher.launchResult = false
+        
+        let provider = AuthorizationCodeAuthProvider(
+            configurationProvider: configurationProvider,
+            applicationLauncher: mockLauncher
+        )
+        
+        let launched = await provider.launch(context: (.eats, nil))
+        
+        XCTAssertFalse(launched)
+        XCTAssertEqual(mockLauncher.launchUrlCallCount, 1)
+    }
+    
+    func test_executeLogin_async_inApp_usesAuthenticationSession() async throws {
+        let authSessionBuilder: AuthorizationCodeAuthProvider.AuthenticationSessionBuilder = { _, _, _, completion in
+            let client = Client(authorizationCode: "in_app_code")
+            completion(.success(client))
+            return AuthenticationSessioningMock()
+        }
+        
+        let provider = AuthorizationCodeAuthProvider(
+            authenticationSessionBuilder: authSessionBuilder,
+            shouldExchangeAuthCode: false,
+            configurationProvider: configurationProvider
+        )
+        
+        let client = try await provider.executeLogin(
+            authDestination: .inApp,
+            requestURI: nil
+        )
+        
+        XCTAssertEqual(client.authorizationCode, "in_app_code")
+    }
+    
+    func test_executeLogin_async_native_fallsBackToInApp() async throws {
+        configurationProvider.isInstalledHandler = { _, _ in true }
+        
+        let mockLauncher = ApplicationLaunchingMock()
+        mockLauncher.launchResult = false
+        
+        let authSessionBuilder: AuthorizationCodeAuthProvider.AuthenticationSessionBuilder = { _, _, _, completion in
+            let client = Client(authorizationCode: "fallback_code")
+            completion(.success(client))
+            return AuthenticationSessioningMock()
+        }
+        
+        let provider = AuthorizationCodeAuthProvider(
+            authenticationSessionBuilder: authSessionBuilder,
+            shouldExchangeAuthCode: false,
+            configurationProvider: configurationProvider,
+            applicationLauncher: mockLauncher
+        )
+        
+        let client = try await provider.executeLogin(
+            authDestination: .native(appPriority: [.eats, .driver]),
+            requestURI: nil
+        )
+        
+        XCTAssertEqual(client.authorizationCode, "fallback_code")
+        XCTAssertEqual(mockLauncher.launchUrlCallCount, 2, "Should try both apps")
+    }
+    
+    func test_execute_async_withoutExchange_returnsAuthCode() async throws {
+        let authSessionBuilder: AuthorizationCodeAuthProvider.AuthenticationSessionBuilder = { _, _, _, completion in
+            completion(.success(Client(authorizationCode: "code")))
+            return AuthenticationSessioningMock()
+        }
+        
+        let provider = AuthorizationCodeAuthProvider(
+            authenticationSessionBuilder: authSessionBuilder,
+            shouldExchangeAuthCode: false,
+            configurationProvider: configurationProvider
+        )
+        
+        let client = try await provider.execute(authDestination: .inApp, prefill: nil)
+        
+        XCTAssertNotNil(client.authorizationCode)
+        XCTAssertNil(client.accessToken)
+    }
+    
+    func test_execute_async_withExchange_returnsToken() async throws {
+        let mockNetwork = NetworkProvidingMock()
+        mockNetwork.executeAsyncResult = .success(AccessToken(
+            tokenString: "token",
+            refreshToken: "refresh",
+            tokenType: "Bearer",
+            expiresIn: 3600,
+            scope: []
+        ))
+        
+        let mockTokenManager = TokenManagingMock()
+        mockTokenManager.saveTokenHandler = { _, _, _ in true }
+        
+        let authSessionBuilder: AuthorizationCodeAuthProvider.AuthenticationSessionBuilder = { _, _, _, completion in
+            completion(.success(Client(authorizationCode: "code")))
+            return AuthenticationSessioningMock()
+        }
+        
+        let provider = AuthorizationCodeAuthProvider(
+            authenticationSessionBuilder: authSessionBuilder,
+            shouldExchangeAuthCode: true,
+            configurationProvider: configurationProvider,
+            networkProvider: mockNetwork,
+            tokenManager: mockTokenManager
+        )
+        
+        let client = try await provider.execute(authDestination: .inApp, prefill: nil)
+        
+        XCTAssertNotNil(client.accessToken)
+        XCTAssertEqual(mockNetwork.executeCallCount, 1)
+    }
+    
+    func test_execute_async_withPrefill_executesPAR() async throws {
+        let mockNetwork = NetworkProvidingMock()
+        mockNetwork.executeAsyncResult = .success(Par(
+            requestURI: "urn:par",
+            expiresIn: Date(timeIntervalSinceNow: 3600)
+        ))
+        
+        let authSessionBuilder: AuthorizationCodeAuthProvider.AuthenticationSessionBuilder = { _, _, _, completion in
+            completion(.success(Client(authorizationCode: "code")))
+            return AuthenticationSessioningMock()
+        }
+        
+        let provider = AuthorizationCodeAuthProvider(
+            authenticationSessionBuilder: authSessionBuilder,
+            shouldExchangeAuthCode: false,
+            configurationProvider: configurationProvider,
+            networkProvider: mockNetwork
+        )
+        
+        _ = try await provider.execute(authDestination: .inApp, prefill: Prefill(email: "test@test.com"))
+        
+        XCTAssertEqual(mockNetwork.executeCallCount, 1)
+    }
+    
+    func test_execute_async_authenticationError_throwsError() async {
+        let authSessionBuilder: AuthorizationCodeAuthProvider.AuthenticationSessionBuilder = { _, _, _, completion in
+            completion(.failure(UberAuthError.cancelled))
+            return AuthenticationSessioningMock()
+        }
+        
+        let provider = AuthorizationCodeAuthProvider(
+            authenticationSessionBuilder: authSessionBuilder,
+            shouldExchangeAuthCode: false,
+            configurationProvider: configurationProvider
+        )
+        
+        do {
+            _ = try await provider.execute(authDestination: .inApp, prefill: nil)
+            XCTFail("Should have thrown error")
+        } catch {
+            XCTAssertNotNil(error as? UberAuthError)
+        }
+    }
+    
+    func test_execute_async_exchangeError_throwsError() async {
+        let mockNetwork = NetworkProvidingMock()
+        mockNetwork.executeAsyncResult = .failure(UberAuthError.serviceError)
+        
+        let authSessionBuilder: AuthorizationCodeAuthProvider.AuthenticationSessionBuilder = { _, _, _, completion in
+            completion(.success(Client(authorizationCode: "code")))
+            return AuthenticationSessioningMock()
+        }
+        
+        let provider = AuthorizationCodeAuthProvider(
+            authenticationSessionBuilder: authSessionBuilder,
+            shouldExchangeAuthCode: true,
+            configurationProvider: configurationProvider,
+            networkProvider: mockNetwork
+        )
+        
+        do {
+            _ = try await provider.execute(authDestination: .inApp, prefill: nil)
+            XCTFail("Should have thrown error")
+        } catch {
+            XCTAssertNotNil(error as? UberAuthError)
+        }
+    }
+    
+    func test_execute_async_existingSession_throwsError() async {
+        let provider = AuthorizationCodeAuthProvider(
+            shouldExchangeAuthCode: false,
+            configurationProvider: configurationProvider
+        )
+        provider.currentSession = AuthenticationSessioningMock()
+        
+        do {
+            _ = try await provider.execute(authDestination: .inApp, prefill: nil)
+            XCTFail("Should have thrown error")
+        } catch {
+            XCTAssertNotNil(error as? UberAuthError)
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR adds async/await versions of all authentication methods while maintaining full backward compatibility with existing completion-based APIs.

**New public API:**
```swift
let client = try await UberAuth.login(context: context)
```

**Key changes:**
- Added async/await methods to `UberAuth`, `AuthProviding`, and `NetworkProvider`
- Old completion-based APIs remain functional and are marked as deprecated

## Testing

- Added 18 new async/await unit tests covering full authentication flow
- Updated all mocks to support async/await
- Verified backward compatibility - existing completion-based code still works