### PR TITLE
Allow client to choose the request environment

### DIFF
--- a/Sources/UberAuth/AuthProviding.swift
+++ b/Sources/UberAuth/AuthProviding.swift
@@ -49,12 +49,14 @@ extension AuthProviding where Self == AuthorizationCodeAuthProvider {
     public static func authorizationCode(presentationAnchor: ASPresentationAnchor = .init(),
                                          scopes: [String] = AuthorizationCodeAuthProvider.defaultScopes,
                                          shouldExchangeAuthCode: Bool = true,
-                                         prompt: Prompt? = nil) -> Self {
+                                         prompt: Prompt? = nil,
+                                         environment: UberEnvironment = .production) -> Self {
         AuthorizationCodeAuthProvider(
             presentationAnchor: presentationAnchor,
             scopes: scopes,
             shouldExchangeAuthCode: shouldExchangeAuthCode,
-            prompt: prompt
+            prompt: prompt,
+            environment: environment
         )
     }
 }

--- a/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
+++ b/Sources/UberAuth/Authorize/AuthorizationCodeAuthProvider.swift
@@ -67,15 +67,18 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
     private let tokenManager: TokenManaging
     
     private let scopes: [String]
-    
+
     private let prompt: Prompt?
-    
+
+    private let baseUrl: String
+
     // MARK: Initializers
-    
+
     public init(presentationAnchor: ASPresentationAnchor = .init(),
                 scopes: [String] = AuthorizationCodeAuthProvider.defaultScopes,
                 shouldExchangeAuthCode: Bool = false,
-                prompt: Prompt? = nil) {
+                prompt: Prompt? = nil,
+                environment: UberEnvironment = .production) {
         self.configurationProvider = ConfigurationProvider()
         self.applicationLauncher = UIApplication.shared
         self.authenticationSessionBuilder = nil
@@ -84,12 +87,13 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         self.redirectURI = configurationProvider.redirectURI
         self.responseParser = AuthorizationCodeResponseParser()
         self.shouldExchangeAuthCode = shouldExchangeAuthCode
-        self.networkProvider = NetworkProvider(baseUrl: Constants.baseUrl)
-        self.tokenManager = TokenManager()
+        self.baseUrl = environment.baseUrl + "/v2"
+        self.networkProvider = NetworkProvider(baseUrl: self.baseUrl)
+        self.tokenManager = TokenManager(environment: environment)
         self.scopes = scopes
         self.prompt = prompt
     }
-    
+
     init(presentationAnchor: ASPresentationAnchor = .init(),
          authenticationSessionBuilder: AuthenticationSessionBuilder? = nil,
          scopes: [String] = AuthorizationCodeAuthProvider.defaultScopes,
@@ -98,9 +102,10 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
          configurationProvider: ConfigurationProviding = ConfigurationProvider(),
          applicationLauncher: ApplicationLaunching = UIApplication.shared,
          responseParser: AuthorizationCodeResponseParsing = AuthorizationCodeResponseParser(),
-         networkProvider: NetworkProviding = NetworkProvider(baseUrl: Constants.baseUrl),
-         tokenManager: TokenManaging = TokenManager()) {
-        
+         networkProvider: NetworkProviding = NetworkProvider(baseUrl: UberEnvironment.production.baseUrl + "/v2"),
+         tokenManager: TokenManaging = TokenManager(),
+         environment: UberEnvironment = .production) {
+
         self.applicationLauncher = applicationLauncher
         self.authenticationSessionBuilder = authenticationSessionBuilder
         self.clientID = configurationProvider.clientID
@@ -109,6 +114,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         self.redirectURI = configurationProvider.redirectURI
         self.responseParser = responseParser
         self.shouldExchangeAuthCode = shouldExchangeAuthCode
+        self.baseUrl = environment.baseUrl + "/v2"
         self.networkProvider = networkProvider
         self.tokenManager = tokenManager
         self.scopes = scopes
@@ -244,11 +250,11 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
             scopes: scopes
         )
         
-        guard let url = request.url(baseUrl: Constants.baseUrl) else {
+        guard let url = request.url(baseUrl: baseUrl) else {
             completion(.failure(.invalidRequest("Invalid base URL")))
             return
         }
-        
+
         guard let callbackURL = URL(string: redirectURI),
               let callbackURLScheme = callbackURL.scheme else {
             completion(.failure(.invalidRequest("Invalid redirect URI")))
@@ -284,7 +290,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
             scopes: scopes
         )
         
-        guard let url = request.url(baseUrl: Constants.baseUrl) else {
+        guard let url = request.url(baseUrl: baseUrl) else {
             throw UberAuthError.invalidRequest("Invalid base URL")
         }
         
@@ -415,11 +421,11 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
             scopes: scopes
         )
         
-        guard let url = request.url(baseUrl: Constants.baseUrl) else {
+        guard let url = request.url(baseUrl: baseUrl) else {
             completion?(false)
             return
         }
-        
+
         DispatchQueue.main.async {
             self.applicationLauncher.launch(
                 url,
@@ -448,7 +454,7 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
             scopes: scopes
         )
         
-        guard let url = request.url(baseUrl: Constants.baseUrl) else { return false }
+        guard let url = request.url(baseUrl: baseUrl) else { return false }
         
         return await applicationLauncher.launch(url)
     }
@@ -545,13 +551,6 @@ public final class AuthorizationCodeAuthProvider: AuthProviding {
         return client
     }
     
-    // MARK: Constants
-    
-    private enum Constants {
-        static let clientIDKey = "ClientID"
-        static let redirectURI = "RedirectURI"
-        static let baseUrl = "https://auth.uber.com/v2"
-    }
 }
 
 

--- a/Sources/UberAuth/Token/TokenManager.swift
+++ b/Sources/UberAuth/Token/TokenManager.swift
@@ -24,6 +24,7 @@
 
 
 import Foundation
+import UberCore
 
 /// @mockable
 public protocol TokenManaging {
@@ -66,15 +67,19 @@ public extension TokenManaging {
 }
 
 public final class TokenManager: TokenManaging {
-    
+
     public static let defaultAccessTokenIdentifier: String = "UberAccessTokenKey"
-    
+
     public static let defaultKeychainAccessGroup: String = ""
-    
+
     private let keychainUtility: KeychainUtilityProtocol
-    
-    public init(keychainUtility: KeychainUtilityProtocol = KeychainUtility()) {
+
+    private let regionHost: String
+
+    public init(keychainUtility: KeychainUtilityProtocol = KeychainUtility(),
+                environment: UberEnvironment = .production) {
         self.keychainUtility = keychainUtility
+        self.regionHost = environment.baseUrl
     }
     
     // MARK: Save
@@ -128,9 +133,9 @@ public final class TokenManager: TokenManaging {
     
     // MARK: Private Interface
     
-    /// Removes all cookies in the shared cookie store corresponding with the auth.uber.com domain
+    /// Removes all cookies in the shared cookie store corresponding with the auth domain
     private func deleteCookies() {
-        guard let loginUrl = URL(string: Constants.regionHost) else {
+        guard let loginUrl = URL(string: regionHost) else {
             return
         }
         
@@ -141,11 +146,5 @@ public final class TokenManager: TokenManaging {
                 sharedCookieStorage.deleteCookie(cookie)
             }
         }
-    }
-    
-    // MARK: Constants
-    
-    private enum Constants {
-        static let regionHost = "https://auth.uber.com"
     }
 }

--- a/Sources/UberCore/UberEnvironment.swift
+++ b/Sources/UberCore/UberEnvironment.swift
@@ -1,6 +1,6 @@
 //
-//  SelectionOptions.swift
-//  UberSDK
+//  UberEnvironment.swift
+//  UberCore
 //
 //  Copyright © 2024 Uber Technologies, Inc. All rights reserved.
 //
@@ -22,29 +22,16 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-
 import Foundation
-import UberAuth
 
-enum LoginType: String, CaseIterable, SelectionOption {
-    case authorizationCode = "Authorization Code"
+public enum UberEnvironment {
+    case production
+    case sandbox
 
-    var description: String { rawValue }
-    var id: String { rawValue }
-}
-
-enum LoginDestination: String, CaseIterable, SelectionOption {
-    case inApp = "In App"
-    case native = "Native"
-
-    var description: String { rawValue }
-    var id: String { rawValue }
-}
-
-enum LoginEnvironment: String, CaseIterable, SelectionOption {
-    case production = "Production"
-    case sandbox = "Sandbox"
-
-    var description: String { rawValue }
-    var id: String { rawValue }
+    public var baseUrl: String {
+        switch self {
+        case .production: return "https://auth.uber.com"
+        case .sandbox: return "https://sandbox-login.uber.com"
+        }
+    }
 }

--- a/examples/UberSDK/UberSDK/ContentView.swift
+++ b/examples/UberSDK/UberSDK/ContentView.swift
@@ -48,6 +48,7 @@ final class Content {
     var selection: Item?
     var type: LoginType? = .authorizationCode
     var destination: LoginDestination? = .inApp
+    var environment: LoginEnvironment? = .production
     var isTokenExchangeEnabled: Bool = true
     var shouldForceLogin: Bool = false
     var shouldForceConsent: Bool = false
@@ -76,9 +77,12 @@ final class Content {
         if shouldForceLogin { prompt.insert(.login) }
         if shouldForceConsent { prompt.insert(.consent) }
         
+        let uberEnvironment: UberEnvironment = environment == .sandbox ? .sandbox : .production
+
         let authProvider: AuthProviding = .authorizationCode(
             shouldExchangeAuthCode: isTokenExchangeEnabled,
-            prompt: prompt
+            prompt: prompt,
+            environment: uberEnvironment
         )
         
         let authDestination: AuthDestination = {
@@ -116,6 +120,7 @@ final class Content {
     enum Item: String, Hashable, Identifiable {
         case type = "Auth Type"
         case destination = "Destination"
+        case environment = "Environment"
         case tokenExchange = "Exchange Auth Code for Token"
         case forceLogin = "Always ask for Login"
         case forceConsent = "Always ask for Consent"
@@ -166,6 +171,12 @@ struct ContentView: View {
                     options: LoginDestination.allCases
                 )
                 .presentationDetents([.height(200)])
+            case .environment:
+                SelectionView(
+                    selection: $content.environment,
+                    options: LoginEnvironment.allCases
+                )
+                .presentationDetents([.height(200)])
             default:
                 EmptyView()
             }
@@ -201,6 +212,7 @@ struct ContentView: View {
         
         textRow(.type, value: content.type?.description)
         textRow(.destination, value: content.destination?.description)
+        textRow(.environment, value: content.environment?.description)
         toggleRow(.tokenExchange, value: $content.isTokenExchangeEnabled)
         toggleRow(.forceLogin, value: $content.shouldForceLogin)
         toggleRow(.forceConsent, value: $content.shouldForceConsent)

--- a/examples/UberSDK/UberSDK/ContentView.swift
+++ b/examples/UberSDK/UberSDK/ContentView.swift
@@ -76,13 +76,11 @@ final class Content {
         var prompt: Prompt = []
         if shouldForceLogin { prompt.insert(.login) }
         if shouldForceConsent { prompt.insert(.consent) }
-        
-        let uberEnvironment: UberEnvironment = environment == .sandbox ? .sandbox : .production
 
         let authProvider: AuthProviding = .authorizationCode(
             shouldExchangeAuthCode: isTokenExchangeEnabled,
             prompt: prompt,
-            environment: uberEnvironment
+            environment: environment == .sandbox ? .sandbox : .production
         )
         
         let authDestination: AuthDestination = {

--- a/examples/UberSDK/UberSDK/Info.plist
+++ b/examples/UberSDK/UberSDK/Info.plist
@@ -24,9 +24,9 @@
 	<key>Uber</key>
 	<dict>
 		<key>ClientID</key>
-		<string>[Client ID]</string>
+		<string>u6fWe9U2aQv1hE-dPXhzPXmnmOD45n6N</string>
 		<key>RedirectURI</key>
-		<string>com.uber.UberSDK://oauth/consumer</string>
+		<string>https://www.uber.com/</string>
 		<key>DisplayName</key>
 		<string>[App Name]</string>
 	</dict>

--- a/examples/UberSDK/UberSDKTests/UberAuth/AuthorizationCodeAuthProviderTests.swift
+++ b/examples/UberSDK/UberSDKTests/UberAuth/AuthorizationCodeAuthProviderTests.swift
@@ -1025,19 +1025,81 @@ extension AuthorizationCodeAuthProviderTests {
             XCTAssertNotNil(error as? UberAuthError)
         }
     }
-    
+
     func test_execute_async_existingSession_throwsError() async {
         let provider = AuthorizationCodeAuthProvider(
             shouldExchangeAuthCode: false,
             configurationProvider: configurationProvider
         )
         provider.currentSession = AuthenticationSessioningMock()
-        
+
         do {
             _ = try await provider.execute(authDestination: .inApp, prefill: nil)
             XCTFail("Should have thrown error")
         } catch {
             XCTAssertNotNil(error as? UberAuthError)
         }
+    }
+
+    // MARK: Environment
+
+    func test_environment_production_usesProductionBaseUrl() {
+        var capturedUrl: URL?
+        let authenticationSessionBuilder: AuthorizationCodeAuthProvider.AuthenticationSessionBuilder = { _, _, url, _ in
+            capturedUrl = url
+            return AuthenticationSessioningMock()
+        }
+
+        let provider = AuthorizationCodeAuthProvider(
+            authenticationSessionBuilder: authenticationSessionBuilder,
+            configurationProvider: configurationProvider,
+            environment: .production
+        )
+
+        provider.execute(authDestination: .inApp, completion: { _ in })
+
+        XCTAssertTrue(capturedUrl?.absoluteString.contains("auth.uber.com") == true)
+        XCTAssertFalse(capturedUrl?.absoluteString.contains("sandbox-login.uber.com") == true)
+    }
+
+    func test_environment_sandbox_usesSandboxBaseUrl() {
+        var capturedUrl: URL?
+        let authenticationSessionBuilder: AuthorizationCodeAuthProvider.AuthenticationSessionBuilder = { _, _, url, _ in
+            capturedUrl = url
+            return AuthenticationSessioningMock()
+        }
+
+        let provider = AuthorizationCodeAuthProvider(
+            authenticationSessionBuilder: authenticationSessionBuilder,
+            configurationProvider: configurationProvider,
+            environment: .sandbox
+        )
+
+        provider.execute(authDestination: .inApp, completion: { _ in })
+
+        XCTAssertTrue(capturedUrl?.absoluteString.contains("sandbox-login.uber.com") == true)
+        XCTAssertFalse(capturedUrl?.absoluteString.contains("auth.uber.com") == true)
+    }
+
+    func test_environment_sandbox_nativeLogin_usesSandboxBaseUrl() {
+        configurationProvider.isInstalledHandler = { _, _ in true }
+
+        let expectation = XCTestExpectation()
+        let applicationLauncher = ApplicationLaunchingMock()
+        applicationLauncher.launchHandler = { url, completion in
+            XCTAssertTrue(url.absoluteString.contains("sandbox-login.uber.com"))
+            expectation.fulfill()
+            completion?(true)
+        }
+
+        let provider = AuthorizationCodeAuthProvider(
+            configurationProvider: configurationProvider,
+            applicationLauncher: applicationLauncher,
+            environment: .sandbox
+        )
+
+        provider.execute(authDestination: .native(appPriority: [.rides]), completion: { _ in })
+
+        wait(for: [expectation], timeout: 0.2)
     }
 }


### PR DESCRIPTION
**Add support for customizable auth environments (production / sandbox)**

## Summary

A 3P developer requested the ability to target different Uber auth environments from the iOS SDK.

Previously the SDK hardcoded `https://auth.uber.com` across all auth flows with no way for 3Ps to redirect to sandbox.

- Adds a new `UberEnvironment` enum to `UberCore` with `.production` and `.sandbox` cases, each mapping to its base URL (`auth.uber.com` / `sandbox-login.uber.com`)
- Threads `environment` through `AuthorizationCodeAuthProvider`'s public initializer (defaults to `.production` — fully backwards-compatible)
- Example app updated with an Environment picker so the flow can be tested end-to-end against sandbox

## Usage

```swift
// Production (default — no change for existing integrations)
let provider = AuthorizationCodeAuthProvider()

// Sandbox
let provider = AuthorizationCodeAuthProvider(environment: .sandbox)
```

## Test plan
- [x] New unit tests verify production URLs contain `auth.uber.com` and sandbox URLs contain `sandbox-login.uber.com` for both in-app and native login flows
- [x] All existing tests pass
- [x] Manually tested in the example app using the new Environment picker



https://github.com/user-attachments/assets/f291311a-8029-4bf1-9bc6-a5f0ab1faed9


https://github.com/user-attachments/assets/d79100d9-e476-47d5-b9df-0d8c4e29ff84

